### PR TITLE
add functionality to login component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8611,6 +8611,14 @@
         "ngx-window-token": ">=3.0.0"
       }
     },
+    "ngx-cookie-service": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-11.0.2.tgz",
+      "integrity": "sha512-nsjzdcjK+gNAweE/DDdnOyHo04jlxTeMXOL/oJNp8MHtOTvCXnOtIFYgq4Sb2JU6UXTovO9tHEMIf9TxjlsdgQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "ngx-toastr": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-13.0.0.tgz",
@@ -13147,6 +13155,11 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
+    },
+    "ts-md5": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.7.tgz",
+      "integrity": "sha512-emODogvKGWi1KO1l9c6YxLMBn6CEH3VrH5mVPIyOtxBG52BvV4jP3GWz6bOZCz61nLgBc3ffQYE4+EHfCD+V7w=="
     },
     "ts-node": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,11 @@
     "core-js": "3.6.5",
     "moment": "^2.29.1",
     "ngx-clipboard": "13.0.1",
+    "ngx-cookie-service": "^11.0.2",
     "ngx-toastr": "13.0.0",
     "nouislider": "14.6.2",
     "rxjs": "6.6.3",
+    "ts-md5": "^1.2.7",
     "zone.js": "0.11.1"
   },
   "devDependencies": {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { ChartJsComponent } from './pages/chart-js/chart-js.component';
 import { DatasetsService } from './services/datasets.service';
 import { AmchartsComponent } from './pages/amcharts/amcharts.component';
 import { UserService } from './services/user.service';
+import { CookieService } from 'ngx-cookie-service';
 
 @NgModule({
   imports: [
@@ -36,7 +37,8 @@ import { UserService } from './services/user.service';
   ],
   providers: [
     DatasetsService,
-    UserService
+    UserService,
+    CookieService
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/modules/auth/pages/login/login.component.html
+++ b/src/app/modules/auth/pages/login/login.component.html
@@ -52,8 +52,16 @@
                 <span class="text-muted">Remember me</span>
               </label>
             </div>
+
+            <!-- error message -->
+            <div class="text-center mt-4">
+              <small class="text-danger" *ngIf="reqStatus === 3">
+                Request Failed. Please try again.
+              </small>
+            </div>
+
             <div class="text-center">
-              <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
+              <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid || reqStatus === 1">
                 Sign in
               </button>
             </div>

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,36 +1,91 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { throwError } from 'rxjs';
+import { Router } from '@angular/router';
+import { Subject, throwError } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Md5 } from 'ts-md5';
+import { User } from '../models/user';
 
 @Injectable()
 export class UserService {
   private baseUrl: string = 'http://localhost:3000';
 
-  constructor(private http: HttpClient) { }
+  private _user: User = new User();
+  private userSource = new Subject<User>();
+  user$ = this.userSource.asObservable();
 
-  login(email, password) {
-    if (!email) {
-      return throwError("[user.service]: not email provided");
-    }
-    if (!password) {
-      return throwError("[user.service]: not password provided");
-    }
+  private _loggedIn = false;
 
-    return this.http.post(`${this.baseUrl}/auth`, { email, password });
+  get user(): User {
+    return this._user;
   }
 
-  singup(email, password) {
+  set user(user: User) {
+    if (!user) {
+      return;
+    }
+    this._user = user;
+    this.userSource.next(this._user);
+  }
+
+  get loggedIn() {
+    return !!window.localStorage.getItem("auth_token")
+  }
+
+  constructor(
+    private http: HttpClient,
+    private router: Router
+  ) {
+    this._loggedIn = !!window.localStorage.getItem("auth_token");
+    this.user.email = !!window.localStorage.getItem("usermail")
+      ? window.localStorage.getItem("usermail")
+      : "";
+    this.user.username = !!window.localStorage.getItem("username")
+      ? window.localStorage.getItem("username")
+      : "";
+  }
+
+  singup(email: string, psw: string) {
     if (!email) {
       return throwError("[user.service]: not email provided");
     }
-    if (!password) {
-      return throwError("[user.service]: not password provided");
+    if (!psw) {
+      return throwError("[user.service]: not psw provided");
     }
-
+    const password = this.hashPsw(psw);
     return this.http.post(`${this.baseUrl}/users`, { email, password });
   }
 
-  pswRecoveryRequest(email) {
+  login(email: string, psw: string) {
+    if (!email) {
+      return throwError("[user.service]: not email provided");
+    }
+    if (!psw) {
+      return throwError("[user.service]: not psw provided");
+    }
+
+    // Delete last session info if token expired and user doesn't logout.
+    if (window.localStorage.getItem("usermail") !== email) {
+      window.localStorage.clear();
+    }
+
+    const password = this.hashPsw(psw);
+    return this.http
+      .post(`${this.baseUrl}/auth`, { email, password })
+      .pipe(
+        tap((resp: any) => {
+          if (resp && resp.token) {
+            this.user.email = email;
+            window.localStorage.setItem("usermail", email);
+            window.localStorage.setItem("auth_token", resp.token);
+
+            this._loggedIn = true;
+          }
+        })
+      )
+  }
+
+  pswRecoveryRequest(email: string) {
     if (!email) {
       return throwError("[user.service]: not email provided");
     }
@@ -38,14 +93,34 @@ export class UserService {
     return this.http.post(`${this.baseUrl}/users/forgot_password`, { email });
   }
 
-  pswUpdateRequest(code, password) {
+  pswUpdateRequest(code: string, psw: string) {
     if (!code) {
       return throwError("[user.service]: not code provided");
     }
-    if (!password) {
+    if (!psw) {
       return throwError("[user.service]: not password provided");
     }
 
+    const password = this.hashPsw(psw);
     return this.http.post(`${this.baseUrl}/users/forgot_password`, { code, password });
+  }
+
+  isLoggedIn(): boolean {
+    return this.loggedIn;
+  }
+
+  logout() {
+    this.cleanUserData();
+  }
+
+  cleanUserData() {
+    this._loggedIn = false;
+    this._user = new User();
+    this.router.navigate(["/"]);
+    window.localStorage.clear();
+  }
+
+  hashPsw(password: string): string | Int32Array {
+    return Md5.hashStr(password);
   }
 }


### PR DESCRIPTION
# Problem Description
- In order to make a functional component is necessary add request to CO-OP API

# Features
- Add Md5 to hash passwords in user service
- Add POST request to `/auth` endpoint after form submittion
- Save in local storage when user logs in to redirect to `/dashboard` if access to `/login`
- Save in a cookie the user info when is selected "remember me" in the form 

# Where this change will be used
- In `/login` path a auth module page

# More details
- View when "Remember me" is selected
![image](https://user-images.githubusercontent.com/38545126/112360307-c780f600-8c97-11eb-9bc7-cefb48fa7b1f.png)
![image](https://user-images.githubusercontent.com/38545126/112359656-1b3f0f80-8c97-11eb-832e-b8815d0f8330.png)

- Error message
![image](https://user-images.githubusercontent.com/38545126/112360154-9dc7cf00-8c97-11eb-9e3e-adbb5b63df2b.png)



