### PR TITLE
add functionality to forgot-psw component

### DIFF
--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
@@ -15,30 +15,52 @@
     <div class="col-lg-5 col-md-7">
       <div class="card bg-secondary shadow border-0">
         <div class="card-body px-lg-5 py-lg-5">
-          <div class="text-center text-muted mb-4">
-            <small>Enter your user account's verified email address and we will send you a password reset link.</small>
-          </div>
-
-          <form role="form" [formGroup]="form" (ngSubmit)="sendPswResetEmail(email.value)">
-            <div class="form-group mb-3">
-              <div class="input-group input-group-alternative is-invalid"
-                [ngClass]="{'is-invalid': !email.valid && email.touched || !email.valid && email.touched}">
-                <div class="input-group-prepend">
-                  <span class="input-group-text"><i class="ni ni-email-83"></i></span>
-                </div>
-                <input [formControl]="email" class="form-control" placeholder="Email" type="email">
-              </div>
-              <small class="text-danger" *ngIf="!email.valid && email.touched || !email.valid && email.touched">
-                Please provide a valid email.
+          <ng-container *ngIf="reqStatus !== 2">
+            <div class="text-center text-muted mb-4">
+              <small>
+                Enter your user account's verified email address and we will send you a password reset link.
               </small>
             </div>
 
-            <div class="text-center">
-              <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
-                Send password reset email
-              </button>
-            </div>
-          </form>
+            <!-- form -->
+            <form role="form" [formGroup]="form" (ngSubmit)="sendPswResetEmail(email.value)">
+              <div class="form-group mb-3">
+                <div class="input-group input-group-alternative is-invalid"
+                  [ngClass]="{'is-invalid': !email.valid && email.touched || !email.valid && email.touched}">
+                  <div class="input-group-prepend">
+                    <span class="input-group-text"><i class="ni ni-email-83"></i></span>
+                  </div>
+                  <input [formControl]="email" class="form-control" placeholder="Email" type="email">
+                </div>
+                <small class="text-danger" *ngIf="!email.valid && email.touched || !email.valid && email.touched">
+                  Please provide a valid email.
+                </small>
+              </div>
+
+              <div *ngIf="reqStatus === 3" class="text-center mb-4">
+                <small class="text-danger">
+                  Request Failed. Please try again.
+                </small>
+              </div>
+
+              <div class="text-center">
+                <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
+                  Send password reset email
+                </button>
+              </div>
+            </form>
+          </ng-container>
+
+          <!-- successful request -->
+          <div *ngIf="reqStatus === 2" class="text-center text-muted">
+            <small>
+              Check your email for a link to reset your password.
+            </small>
+
+            <button type="button" class="btn btn-light my-4" routerLink="/login">
+              Return to Sign in
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
@@ -44,7 +44,7 @@
               </div>
 
               <div class="text-center">
-                <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
+                <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid || reqStatus === 1">
                   Send password reset email
                 </button>
               </div>

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.ts
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { UserService } from 'src/app/services/user.service';
 import { EmailValidator } from 'src/app/tools/validators/email.validator';
 
 @Component({
@@ -14,7 +15,10 @@ export class ForgotPswComponent implements OnInit {
   form: FormGroup;
   reqStatus: number = 0;
 
-  constructor(private fb: FormBuilder) { }
+  constructor(
+    private fb: FormBuilder,
+    private userService: UserService
+  ) { }
 
   ngOnInit(): void {
     this.form = this.fb.group({
@@ -23,10 +27,20 @@ export class ForgotPswComponent implements OnInit {
         Validators.compose([Validators.required, EmailValidator.validate])
       ]
     });
-
     this.email = this.form.controls['email'];
   }
 
   sendPswResetEmail(email) {
+    this.reqStatus = 1;
+    this.userService.pswRecoveryRequest(email)
+      .subscribe(
+        () => {
+          this.reqStatus = 2;
+        },
+        error => {
+          console.error(`[forgot-psw.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+          this.reqStatus = 3;
+        }
+      )
   }
 }


### PR DESCRIPTION
# Problem Description
- In order to make a functional component is necessary add request to CO-OP API

# Features
- Add POST request to /users endpoint after form submittion
- Show a message with a button to redirect to `/login` after successful request

# Where this change will be used
- In `/create-access` path a auth module page

# More details
- Default view
![image](https://user-images.githubusercontent.com/38545126/112370957-a3c3ad00-8ca3-11eb-9dfb-87b736399018.png)

- Successful message
![image](https://user-images.githubusercontent.com/38545126/112371023-bc33c780-8ca3-11eb-9864-9ee0cfa4e902.png)

- Error message
![image](https://user-images.githubusercontent.com/38545126/112371101-d8376900-8ca3-11eb-8a77-36b6ab830f50.png)
