### PR TITLE
add functionality to reset-psw

### DIFF
--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.html
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.html
@@ -1,14 +1,14 @@
 <div class="header bg-gradient-info pb-7 pt-8 pb-md-7 pt-md-9">
-    <div class="container">
-      <div class="header-body text-center mb-6">
-        <div class="row justify-content-center">
-          <div class="col-lg-5 col-md-6">
-            <h1 class="text-white">Change password</h1>
-          </div>
+  <div class="container">
+    <div class="header-body text-center mb-6">
+      <div class="row justify-content-center">
+        <div class="col-lg-5 col-md-6">
+          <h1 class="text-white">Change password</h1>
         </div>
       </div>
     </div>
   </div>
+</div>
 <!-- Page content -->
 <div class="container mt--8 pb-5">
   <div class="row justify-content-center">
@@ -16,10 +16,17 @@
       <div class="card bg-secondary shadow border-0">
         <div class="card-body px-lg-5 py-lg-5">
           <!-- Change password -->
-          <app-set-psw></app-set-psw>
+          <app-set-psw submitBtnLegend="Change password" (passwordChange)="resetPsw($event)"
+            [submitting]="reqStatus === 1 || reqStatus === 2 ? true : false" [submitErrorLegend]="errorMsg">
+          </app-set-psw>
+
+          <div class="text-center">
+            <small class="text-success" *ngIf="reqStatus === 2">
+              Your <b>password</b> has been updated successfully. Redirecting to <b>Login page.</b>
+            </small>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
-  

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-reset-psw',
@@ -6,10 +8,37 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./reset-psw.component.scss']
 })
 export class ResetPswComponent implements OnInit {
+  code: string;
+  reqStatus: number = 0;
+  errorMsg: string;
 
-  constructor() { }
+  constructor(
+    private userService: UserService,
+    private route: ActivatedRoute,
+    private router: Router
+  ) { }
 
   ngOnInit(): void {
+    this.code = this.route.snapshot.queryParamMap.get('code')
+      ? this.route.snapshot.queryParamMap.get('code')
+      : 'ac337071eed387a1';
   }
 
+  resetPsw(newPassword) {
+    this.reqStatus = 1;
+    this.userService.pswUpdateRequest(this.code, newPassword)
+      .subscribe(
+        () => {
+          this.reqStatus = 2;
+          setTimeout(() => {
+            this.router.navigate(['/login']);
+          }, 6000);
+        },
+        error => {
+          this.errorMsg = 'Request failed. Please try again';
+          console.error(`[reset-psw.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+          this.reqStatus = 3;
+        }
+      )
+  }
 }

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
@@ -30,6 +30,7 @@ export class ResetPswComponent implements OnInit {
       .subscribe(
         () => {
           this.reqStatus = 2;
+          delete this.errorMsg;
           setTimeout(() => {
             this.router.navigate(['/login']);
           }, 6000);

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -102,7 +102,7 @@ export class UserService {
     }
 
     const password = this.hashPsw(psw);
-    return this.http.post(`${this.baseUrl}/users/forgot_password`, { code, password });
+    return this.http.post(`${this.baseUrl}/users/restore_password`, { code, password });
   }
 
   isLoggedIn(): boolean {


### PR DESCRIPTION
# Problem Description
- In order to make a functional component is necessary add request to CO-OP API

# Features
- Get code through a query param in the route
- Add POST request to `/users/restore_password` endpoint after form submittion
- Show a success or error message depending of the API response
- Redirection to `/login` after successful response

# Where this change will be used
- In `/reset-password` path a auth module page

# More details
- Get user code through a query param in the route
![image](https://user-images.githubusercontent.com/38545126/112374562-de2f4900-8ca7-11eb-9a70-61177d714a0d.png)
![image](https://user-images.githubusercontent.com/38545126/112374460-bf30b700-8ca7-11eb-971f-9c16f82b4035.png)

- Successful message
![image](https://user-images.githubusercontent.com/38545126/112374639-f7d09080-8ca7-11eb-8d9b-8bd3104196ea.png)

- Error message
![image](https://user-images.githubusercontent.com/38545126/112374728-120a6e80-8ca8-11eb-897a-b05fd77a9fd5.png)
