### PR TITLE
add session interceptor service in app

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
@@ -17,6 +17,7 @@ import { DatasetsService } from './services/datasets.service';
 import { AmchartsComponent } from './pages/amcharts/amcharts.component';
 import { UserService } from './services/user.service';
 import { CookieService } from 'ngx-cookie-service';
+import { SessionInterceptor } from './services/interceptor.service';
 
 @NgModule({
   imports: [
@@ -38,7 +39,12 @@ import { CookieService } from 'ngx-cookie-service';
   providers: [
     DatasetsService,
     UserService,
-    CookieService
+    CookieService,
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: SessionInterceptor,
+      multi: true
+    },
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -7,11 +7,8 @@ import { AdminLayoutComponent } from './layouts/admin-layout/admin-layout.compon
 import { AuthLayoutComponent } from './layouts/auth-layout/auth-layout.component';
 
 const routes: Routes = [
+  { path: '', redirectTo: 'login', pathMatch: 'full' },
   {
-    path: '',
-    redirectTo: 'dashboard',
-    pathMatch: 'full',
-  }, {
     path: '',
     component: AdminLayoutComponent,
     children: [
@@ -35,9 +32,6 @@ const routes: Routes = [
           )
       }
     ]
-  }, {
-    path: '**',
-    redirectTo: 'dashboard'
   }
 ];
 

--- a/src/app/services/interceptor.service.spec.ts
+++ b/src/app/services/interceptor.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SessionInterceptor } from './interceptor.service';
+
+describe('InterceptorService', () => {
+  let service: SessionInterceptor;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SessionInterceptor);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/interceptor.service.ts
+++ b/src/app/services/interceptor.service.ts
@@ -1,0 +1,57 @@
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { CookieService } from 'ngx-cookie-service';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { UserService } from './user.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SessionInterceptor {
+  constructor(
+    private userService: UserService,
+    private cookieService: CookieService,
+    private router: Router
+  ) { }
+
+  intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const authToken = localStorage.getItem('auth_token');
+    if (authToken) {
+      request = request.clone({
+        headers: request.headers.set('Authorization', 'Bearer ' + authToken)
+      });
+    }
+
+    return next.handle(request).pipe(
+      tap(() => { },
+        err => {
+          if (err instanceof HttpErrorResponse) {
+            if (err.status === 401) {
+              // check if user data is in coop_user cookie
+              const user = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'))
+              console.log(user)
+              if (user) {
+                this.generatePersistSession(user.email, user.anonymous_id)
+              } else {
+                this.userService.logout();
+              }
+            }
+          }
+        })
+    );
+  }
+
+  generatePersistSession(email: string, password: string) {
+    this.userService.login(email, password).subscribe(
+      () => {
+        this.router.navigate(['/dashboard']);
+      },
+      error => {
+        this.userService.logout();
+        console.error(`[interceptor.service]: ${error?.error?.message ? error.error.message : error?.message}`);
+      }
+    )
+  }
+}


### PR DESCRIPTION
# Problem Description
- Is necessary add Authorization Bearer token in requests to CO-OP API
- Is necessary generate a persist user session when an user select "rember me" in `/login`

# Features
- Add interceptor service to logout an user when a request response status code is 401
- Avoid logout an user when there is user info in the coop_user cookie, instead use this info to generate a persist session
- Set `/login` as a root route

# Where this change will be used
- In app requests to CO-OP API