### PR TITLE
add login guard to access to dashboard

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { AmchartsComponent } from './pages/amcharts/amcharts.component';
 import { UserService } from './services/user.service';
 import { CookieService } from 'ngx-cookie-service';
 import { SessionInterceptor } from './services/interceptor.service';
+import { LoginGuard } from './login.guard';
 
 @NgModule({
   imports: [
@@ -40,6 +41,7 @@ import { SessionInterceptor } from './services/interceptor.service';
     DatasetsService,
     UserService,
     CookieService,
+    LoginGuard,
     {
       provide: HTTP_INTERCEPTORS,
       useClass: SessionInterceptor,

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -5,6 +5,7 @@ import { Routes, RouterModule } from '@angular/router';
 
 import { AdminLayoutComponent } from './layouts/admin-layout/admin-layout.component';
 import { AuthLayoutComponent } from './layouts/auth-layout/auth-layout.component';
+import { LoginGuard } from './login.guard';
 
 const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
@@ -17,7 +18,8 @@ const routes: Routes = [
         loadChildren: () =>
           import("./layouts/admin-layout/admin-layout.module").then(
             m => m.AdminLayoutModule
-          )
+          ),
+        canActivate: [LoginGuard]
       }
     ]
   }, {

--- a/src/app/login.guard.ts
+++ b/src/app/login.guard.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { Router, CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { UserService } from './services/user.service';
+
+@Injectable()
+export class LoginGuard implements CanActivate {
+    token: string;
+    constructor(
+        private userService: UserService,
+        private router: Router
+    ) { }
+
+    canActivate(route: ActivatedRouteSnapshot, rss: RouterStateSnapshot) {
+        this.token = route.queryParams['token']
+        if (this.token) {
+            localStorage.setItem('auth_token', this.token)
+            this.router.navigate([rss.url.split('?')[0]], { queryParams: {}, replaceUrl: true, state: {} });
+        }
+        if (this.userService.isLoggedIn()) {
+            return true;
+        } else {
+            // Store the attempted URL for redirecting
+            this.userService.redirectUrl = rss.url;
+            this.router.navigate(['/login']);
+        }
+        return false;
+    }
+}

--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -22,6 +22,8 @@ export class LoginComponent implements OnInit {
   pwdModeOn: boolean;
   reqStatus: number = 0;
 
+  redirect: string;
+
   constructor(
     private fb: FormBuilder,
     private userService: UserService,
@@ -29,8 +31,9 @@ export class LoginComponent implements OnInit {
     private cookieService: CookieService
   ) {
     const islogged = this.userService.isLoggedIn();
+    this.redirect = this.userService.redirectUrl ?? '/dashboard/investment'
     if (islogged) {
-      this.router.navigate(['/dashboard']);
+      this.router.navigate(['/dashboard/investment']);
     }
   }
 
@@ -78,7 +81,7 @@ export class LoginComponent implements OnInit {
             this.rememberPsw();
           }
           this.reqStatus = 2;
-          this.router.navigate(['/dashboard/investment']);
+          this.router.navigate([this.redirect]);
         },
         error => {
           console.error(`[login.component]: ${error?.error?.message ? error.error.message : error?.message}`);

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -15,6 +15,7 @@ export class UserService {
   user$ = this.userSource.asObservable();
 
   private _loggedIn = false;
+  redirectUrl: string;
 
   get user(): User {
     return this._user;


### PR DESCRIPTION
# Problem Description
- Don't allow access to` /dashboard` path when an user isn't login
- Redirect an user to `/login` page when isn't login

# Features
- Add login.guard in app module
- Use login.guard in `/dashboard` module
- Remember the user's last page to redirect there

# Where this change will be used
- In `/dashboard` path (module level)