### PR TITLE
get apiUrl from environment files

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -1,0 +1,27 @@
+import { environment } from "src/environments/environment";
+
+export class Configuration {
+    public production = environment.production;
+    public endpoint = environment.apiUrl;
+}
+
+export const ConfigurationFactory = () => {
+    const env = new Configuration();
+
+    const browserWindow = window || {};
+    const browserWindowEnv = browserWindow['__env'] || {};
+
+    for (const key in browserWindowEnv) {
+        if (browserWindowEnv.hasOwnProperty(key)) {
+            env[key] = window['__env'][key];
+        }
+    }
+    return env;
+};
+
+// Export const to use in modules
+export const ConfigurationProvider = {
+    provide: Configuration,
+    useFactory: ConfigurationFactory,
+    deps: [],
+};

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { UserService } from './services/user.service';
 import { CookieService } from 'ngx-cookie-service';
 import { SessionInterceptor } from './services/interceptor.service';
 import { LoginGuard } from './login.guard';
+import { ConfigurationProvider } from './app.constants';
 
 @NgModule({
   imports: [
@@ -47,6 +48,7 @@ import { LoginGuard } from './login.guard';
       useClass: SessionInterceptor,
       multi: true
     },
+    ConfigurationProvider
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/services/datasets.service.ts
+++ b/src/app/services/datasets.service.ts
@@ -1,16 +1,22 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Configuration } from '../app.constants';
 
 @Injectable({
   providedIn: 'root'
 })
 export class DatasetsService {
 
-  endpoint = 'http://localhost:3000/'
+  baseUrl: string;
 
-  constructor(private http: HttpClient) { }
+  constructor(
+    private http: HttpClient,
+    private config: Configuration
+  ) {
+    this.baseUrl = this.config.endpoint;
+  }
 
   getInvestment() {
-    return this.http.get(`${this.endpoint}investment`);
+    return this.http.get(`${this.baseUrl}/investment`);
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -4,11 +4,12 @@ import { Router } from '@angular/router';
 import { Subject, throwError } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Md5 } from 'ts-md5';
+import { Configuration } from '../app.constants';
 import { User } from '../models/user';
 
 @Injectable()
 export class UserService {
-  private baseUrl: string = 'http://localhost:3000';
+  private baseUrl: string;
 
   private _user: User = new User();
   private userSource = new Subject<User>();
@@ -35,7 +36,8 @@ export class UserService {
 
   constructor(
     private http: HttpClient,
-    private router: Router
+    private router: Router,
+    private config: Configuration
   ) {
     this._loggedIn = !!window.localStorage.getItem("auth_token");
     this.user.email = !!window.localStorage.getItem("usermail")
@@ -44,6 +46,8 @@ export class UserService {
     this.user.username = !!window.localStorage.getItem("username")
       ? window.localStorage.getItem("username")
       : "";
+
+    this.baseUrl = this.config.endpoint;
   }
 
   singup(email: string, psw: string) {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+  production: true,
+  apiUrl: 'http://localhost:3000/api/v1',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,7 +3,8 @@
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl: 'http://localhost:3000/api/v1',
 };
 
 /*


### PR DESCRIPTION
# Problem Description
- Even though doesn't defined apiUrl for staging and production yet is necessary get the apiUrl from environment files in order to to make changes to services more easily

# Features
- Add apiUrl as a environment property in environment files
- Use app.constanatns.ts to get apiUrl and use it in all services endpoints requests

# Where this change will be used
- In app services to get endpoint url

# More details
- The apiUrl values in staging and production will be updated after
