### PR TITLE
adapt auth module behaviour to API requests and responses

### DIFF
--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
@@ -39,7 +39,7 @@
 
               <div *ngIf="reqStatus === 3" class="text-center mb-4">
                 <small class="text-danger">
-                  Request Failed. Please try again.
+                  {{ errorMsg }}
                 </small>
               </div>
 

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
@@ -42,7 +42,6 @@
                   {{ errorMsg }}
                 </small>
               </div>
-
               <div class="text-center">
                 <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid || reqStatus === 1">
                   Send password reset email
@@ -57,6 +56,7 @@
               Check your email for a link to reset your password.
             </small>
 
+            <br>
             <button type="button" class="btn btn-light my-4" routerLink="/login">
               Return to Sign in
             </button>

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.ts
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.ts
@@ -14,6 +14,7 @@ export class ForgotPswComponent implements OnInit {
 
   form: FormGroup;
   reqStatus: number = 0;
+  errorMsg: string;
 
   constructor(
     private fb: FormBuilder,
@@ -35,10 +36,12 @@ export class ForgotPswComponent implements OnInit {
     this.userService.pswRecoveryRequest(email)
       .subscribe(
         () => {
+          delete this.errorMsg;
           this.reqStatus = 2;
         },
         error => {
-          console.error(`[forgot-psw.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+          this.errorMsg = error?.error?.message ? error.error.message : error?.message
+          console.error(`[forgot-psw.component]: ${this.errorMsg}`);
           this.reqStatus = 3;
         }
       )

--- a/src/app/modules/auth/pages/login/login.component.html
+++ b/src/app/modules/auth/pages/login/login.component.html
@@ -56,7 +56,7 @@
             <!-- error message -->
             <div class="text-center mt-4">
               <small class="text-danger" *ngIf="reqStatus === 3">
-                Request Failed. Please try again.
+                {{ errorMsg }}
               </small>
             </div>
 

--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -21,6 +21,7 @@ export class LoginComponent implements OnInit {
   form: FormGroup;
   pwdModeOn: boolean;
   reqStatus: number = 0;
+  errorMsg: string;
 
   redirect: string;
 
@@ -77,6 +78,7 @@ export class LoginComponent implements OnInit {
     if (this.form.valid) {
       this.userService.login(email, password).subscribe(
         () => {
+          delete this.errorMsg;
           if (this.remember_password.value) {
             this.rememberPsw();
           } else {
@@ -86,7 +88,8 @@ export class LoginComponent implements OnInit {
           this.router.navigate([this.redirect]);
         },
         error => {
-          console.error(`[login.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+          this.errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[login.component]: ${this.errorMsg}`);
           this.reqStatus = 3;
         }
       )

--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -79,6 +79,8 @@ export class LoginComponent implements OnInit {
         () => {
           if (this.remember_password.value) {
             this.rememberPsw();
+          } else {
+            this.userService.deleteUserCookieIfExists();
           }
           this.reqStatus = 2;
           this.router.navigate([this.redirect]);

--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -94,7 +94,8 @@ export class LoginComponent implements OnInit {
   rememberPsw() {
     const user = {
       email: this.email.value,
-      anonymous_id: this.userService.hashPsw(this.password.value)
+      // anonymous_id: this.userService.hashPsw(this.password.value)
+      anonymous_id: this.password.value
     }
     this.cookieService.set('coop_user', JSON.stringify(user), 365);
   }

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
@@ -38,8 +38,8 @@ export class ResetPswComponent implements OnInit {
           }, 6000);
         },
         error => {
-          this.errorMsg = 'Request failed. Please try again';
-          console.error(`[reset-psw.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+          this.errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[reset-psw.component]: ${this.errorMsg}`);
           this.reqStatus = 3;
         }
       )

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.ts
@@ -31,8 +31,10 @@ export class ResetPswComponent implements OnInit {
         () => {
           this.reqStatus = 2;
           delete this.errorMsg;
+          this.userService.deleteUserCookieIfExists();
+
           setTimeout(() => {
-            this.router.navigate(['/login']);
+            this.userService.cleanUserData();
           }, 6000);
         },
         error => {

--- a/src/app/services/interceptor.service.ts
+++ b/src/app/services/interceptor.service.ts
@@ -30,10 +30,9 @@ export class SessionInterceptor {
           if (err instanceof HttpErrorResponse) {
             if (err.status === 401) {
               // check if user data is in coop_user cookie
-              const user = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'))
-              console.log(user)
+              const user = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'));
               if (user) {
-                this.generatePersistSession(user.email, user.anonymous_id)
+                this.generatePersistSession(user.email, user.anonymous_id);
               } else {
                 this.userService.logout();
               }
@@ -46,7 +45,7 @@ export class SessionInterceptor {
   generatePersistSession(email: string, password: string) {
     this.userService.login(email, password).subscribe(
       () => {
-        this.router.navigate(['/dashboard']);
+        this.router.navigate(['/dashboard/investment']);
       },
       error => {
         this.userService.logout();

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -135,13 +135,9 @@ export class UserService {
   }
 
   deleteUserCookieIfExists() {
-    console.log('deleteUserCookieIfExists')
     const user = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'));
     if (user) {
-      console.log('existe cookie')
       this.cookieService.delete('coop_user');
     }
-
-    console.log('user', this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user')))
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { CookieService } from 'ngx-cookie-service';
 import { Subject, throwError } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Md5 } from 'ts-md5';
@@ -37,7 +38,8 @@ export class UserService {
   constructor(
     private http: HttpClient,
     private router: Router,
-    private config: Configuration
+    private config: Configuration,
+    private cookieService: CookieService
   ) {
     this._loggedIn = !!window.localStorage.getItem("auth_token");
     this.user.email = !!window.localStorage.getItem("usermail")
@@ -130,5 +132,16 @@ export class UserService {
 
   hashPsw(password: string): string | Int32Array {
     return Md5.hashStr(password);
+  }
+
+  deleteUserCookieIfExists() {
+    console.log('deleteUserCookieIfExists')
+    const user = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'));
+    if (user) {
+      console.log('existe cookie')
+      this.cookieService.delete('coop_user');
+    }
+
+    console.log('user', this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user')))
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -57,7 +57,8 @@ export class UserService {
     if (!psw) {
       return throwError("[user.service]: not psw provided");
     }
-    const password = this.hashPsw(psw);
+    // const password = this.hashPsw(psw);
+    const password = psw;
     return this.http.post(`${this.baseUrl}/users`, { email, password });
   }
 
@@ -74,7 +75,8 @@ export class UserService {
       window.localStorage.clear();
     }
 
-    const password = this.hashPsw(psw);
+    // const password = this.hashPsw(psw);
+    const password = psw;
     return this.http
       .post(`${this.baseUrl}/auth`, { email, password })
       .pipe(
@@ -106,7 +108,8 @@ export class UserService {
       return throwError("[user.service]: not password provided");
     }
 
-    const password = this.hashPsw(psw);
+    // const password = this.hashPsw(psw);
+    const password = psw;
     return this.http.post(`${this.baseUrl}/users/restore_password`, { code, password });
   }
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:3000/api/v1',
+  apiUrl: 'http://99a875cafdf5.ngrok.io/api/v1',
 };
 
 /*

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://99a875cafdf5.ngrok.io/api/v1',
+  apiUrl: 'http://localhost:3000/api/v1',
 };
 
 /*


### PR DESCRIPTION
# Problem Description
- Use COOP API instead data mock and consider some adaptations to requests and responses

# Features
- Disable hash MD5 for passwords in requests
- Show API error menssages intead an error dault copy
- Clear user cookie when an user reset the password or re-login but now without the option of "remember me"

# Bug Fixes
- Update navigation route in interceptor service
- Update forgot-psw template (add a `<br>` between success copy and button)

# Where this change will be used
- In auth module components in the following routes:
  - /create-user
  - /login
  - /forgot-password
  - /reset-password