### PR TITLE
add template to invite-user components

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -36,6 +36,10 @@ export class NavbarComponent implements OnInit {
       if (this.listTitles[item].path === titlee) {
         return this.listTitles[item].title;
       }
+
+      if (titlee.includes(this.listTitles[item].path)) {
+        return this.listTitles[item].title
+      }
     }
     return 'Dashboard';
   }

--- a/src/app/modules/users-mngmt/components/users-list/users-list.component.html
+++ b/src/app/modules/users-mngmt/components/users-list/users-list.component.html
@@ -2,14 +2,12 @@
 
     <div class="row">
         <div class="col-12 col-sm-12 col-md-6 offset-md-6 col-lg-4 offset-lg-8">
-            <div class="form-group mb-3">
-                <div class="input-group input-group-alternative">
-                    <div class="input-group-prepend">
-                        <span class="input-group-text"><i class="fas fa-search"></i></span>
-                    </div>
-                    <input matInput class="form-control" placeholder="Buscar" type="text" #input
-                        (keyup)="applyFilter($event)">
+            <div class="input-group input-group-alternative">
+                <div class="input-group-prepend">
+                    <span class="input-group-text"><i class="fas fa-search"></i></span>
                 </div>
+                <input matInput class="form-control" placeholder="Buscar" type="text" #input
+                    (keyup)="applyFilter($event)">
             </div>
         </div>
     </div>
@@ -17,12 +15,6 @@
 
     <div class="adaptable-container">
         <table mat-table [dataSource]="dataSource">
-
-            <!-- Name Column -->
-            <ng-container matColumnDef="name">
-                <th mat-header-cell *matHeaderCellDef> Nombre </th>
-                <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-            </ng-container>
 
             <!-- Weight Email -->
             <ng-container matColumnDef="email">
@@ -40,11 +32,8 @@
             <ng-container matColumnDef="action">
                 <th mat-header-cell *matHeaderCellDef> </th>
                 <td mat-cell *matCellDef="let element">
-                    <!-- <button type="button" class="btn btn-sm btn-outline-danger"
-                        (click)="selection(element)">Eliminar</button> -->
-
                     <div class="icon-shape bg-danger text-white rounded-circle" (click)="selection(element)">
-                        <i class="ni ni-fat-delete"></i>
+                        <i class="fas fa-minus"></i>
                     </div>
                 </td>
             </ng-container>

--- a/src/app/modules/users-mngmt/components/users-list/users-list.component.scss
+++ b/src/app/modules/users-mngmt/components/users-list/users-list.component.scss
@@ -9,4 +9,10 @@ table {
 .icon-shape {
     cursor: pointer;
     padding: 0;
+    height: 20px;
+    width: 20px;
+
+    i {
+        font-size: 12px;
+    }
 }

--- a/src/app/modules/users-mngmt/components/users-list/users-list.component.ts
+++ b/src/app/modules/users-mngmt/components/users-list/users-list.component.ts
@@ -8,7 +8,7 @@ import { MatTableDataSource } from '@angular/material/table';
   styleUrls: ['./users-list.component.scss']
 })
 export class UsersListComponent implements OnInit, AfterViewInit {
-  displayedColumns: string[] = ['name', 'email', 'created_at', 'action'];
+  displayedColumns: string[] = ['email', 'created_at', 'action'];
   dataSource = new MatTableDataSource<User>(ELEMENT_DATA);
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -49,14 +49,13 @@ export class UsersListComponent implements OnInit, AfterViewInit {
 }
 
 const ELEMENT_DATA: User[] = [
-  { name: 'Daniela Torres Jimenez', email: 'dtorresj@hp.com', created_at: new Date() },
-  { name: 'José Luis Ramírez Rosas', email: 'jramirezr@hp.com', created_at: new Date() },
-  { name: 'Sandra Reza Hernández', email: 'srezah@hp.com', created_at: new Date() },
-  { name: 'Felipe Sánchez Coronado', email: 'fsanchezc@hp.com', created_at: new Date() },
+  { email: 'dtorresj@hp.com', created_at: new Date() },
+  { email: 'jramirezr@hp.com', created_at: new Date() },
+  { email: 'srezah@hp.com', created_at: new Date() },
+  { email: 'fsanchezc@hp.com', created_at: new Date() },
 ];
 
 export interface User {
-  name: string;
   email: string;
   created_at: Date
 }

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -43,44 +43,115 @@
                             </div>
                         </div>
 
-                        <div class="row mt-4">
+                        <div class="row mt-4"
+                            *ngIf="selectedRole && selectedRole?.name !== 'admin' && selectedRole?.name !== 'hp'">
                             <div class="col-12 col-sm-6">
-                                <!-- COUNTRIES -->
-                                <ng-container *ngIf="selectedRole?.name === 'country'">
-                                    <p class="text-uppercase text-sm text-muted mb-2">Paises</p>
+                                <div class="mb-4">
+                                    <!-- COUNTRIES -->
+                                    <ng-container *ngIf="selectedRole?.name === 'country'">
+                                        <p class="text-uppercase text-sm mb-2">Paises</p>
+                                        <div class="row section-header">
+                                            <div class="col-12 col-lg-6 mb-2">
+                                                <small>Selecciona al menos un país</small>
+                                            </div>
 
-                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
-                                        *ngFor="let country of countries; let i = index" formArrayName="countries">
-                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
-                                            [id]="'country-custom-checkbox-'+i">
-                                        <label class="custom-control-label" [for]="'country-custom-checkbox-'+i">
-                                            <span class="text-muted">{{ country.name }}</span>
-                                        </label>
-                                    </div>
-                                </ng-container>
+                                            <div class="col-12 col-lg-6 mb-2">
+                                                <button type="button" class="btn btn-outline-primary btn-sm"
+                                                    (click)="convertAllOptionsTo('countries')">
+                                                    <div *ngIf="!allOptionsSelected('countries')">
+                                                        <i class="fas fa-check"></i>
+                                                        <span>
+                                                            Seleccionar todo
+                                                        </span>
+                                                    </div>
+                                                    <div *ngIf="allOptionsSelected('countries')">
+                                                        <i class="fas fa-minus"></i>
+                                                        <span>
+                                                            Deseleccionar todo
+                                                        </span>
+                                                    </div>
+                                                </button>
+                                            </div>
+                                        </div>
 
-                                <!-- RETAILERS -->
-                                <ng-container *ngIf="selectedRole?.name === 'retailer'">
-                                    <p class="text-uppercase text-sm text-muted mb-2">Retailers</p>
+                                        <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                            *ngFor="let country of countries; let i = index" formArrayName="countries">
+                                            <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                                [id]="'country-custom-checkbox-'+i">
+                                            <label class="custom-control-label" [for]="'country-custom-checkbox-'+i">
+                                                <span class="text-muted">{{ country.name }}</span>
+                                            </label>
+                                        </div>
+                                    </ng-container>
 
-                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
-                                        *ngFor="let retailer of retailers; let i = index" formArrayName="retailers">
-                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
-                                            [id]="'retailer-custom-checkbox-'+i">
-                                        <label class="custom-control-label" [for]="'retailer-custom-checkbox-'+i">
-                                            <span class="text-muted">{{ retailer.name }}</span>
-                                        </label>
-                                    </div>
-                                </ng-container>
+                                    <!-- RETAILERS -->
+                                    <ng-container *ngIf="selectedRole?.name === 'retailer'">
+                                        <p class="text-uppercase text-sm mb-2">Retailers</p>
+                                        <div class="row section-header">
+                                            <div class="col-12 col-lg-6 mb-2">
+                                                <small>Selecciona al menos un retailer</small>
+                                            </div>
+
+                                            <div class="col-12 col-lg-6 mb-2">
+                                                <button type="button" class="btn btn-outline-primary btn-sm"
+                                                    (click)="convertAllOptionsTo('retailers')">
+                                                    <div *ngIf="!allOptionsSelected('retailers')">
+                                                        <i class="fas fa-check"></i>
+                                                        <span>
+                                                            Seleccionar todo
+                                                        </span>
+                                                    </div>
+                                                    <div *ngIf="allOptionsSelected('retailers')">
+                                                        <i class="fas fa-minus"></i>
+                                                        <span>
+                                                            Deseleccionar todo
+                                                        </span>
+                                                    </div>
+                                                </button>
+                                            </div>
+                                        </div>
+
+                                        <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                            *ngFor="let retailer of retailers; let i = index" formArrayName="retailers">
+                                            <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                                [id]="'retailer-custom-checkbox-'+i">
+                                            <label class="custom-control-label" [for]="'retailer-custom-checkbox-'+i">
+                                                <span class="text-muted">{{ retailer.name }}</span>
+                                            </label>
+                                        </div>
+                                    </ng-container>
+                                </div>
                             </div>
-
 
                             <div class="col-12 col-sm-6"
                                 *ngIf="selectedRole?.name === 'country' || selectedRole?.name === 'retailer'">
 
                                 <!-- SECTORS -->
                                 <div class="mb-4">
-                                    <p class="text-uppercase text-sm text-muted mb-2">Sectors</p>
+                                    <p class="text-uppercase text-sm mb-2">Sectores</p>
+                                    <div class="row section-header">
+                                        <div class="col-12 col-lg-6 mb-2">
+                                            <small>Selecciona al menos un sector</small>
+                                        </div>
+
+                                        <div class="col-12 col-lg-6 mb-2">
+                                            <button type="button" class="btn btn-outline-primary btn-sm"
+                                                (click)="convertAllOptionsTo('sectors')">
+                                                <div *ngIf="!allOptionsSelected('sectors')">
+                                                    <i class="fas fa-check"></i>
+                                                    <span>
+                                                        Seleccionar todo
+                                                    </span>
+                                                </div>
+                                                <div *ngIf="allOptionsSelected('sectors')">
+                                                    <i class="fas fa-minus"></i>
+                                                    <span>
+                                                        Deseleccionar todo
+                                                    </span>
+                                                </div>
+                                            </button>
+                                        </div>
+                                    </div>
 
                                     <div class="custom-control custom-control-alternative custom-checkbox my-1"
                                         *ngFor="let sector of sectors; let i = index" formArrayName="sectors">
@@ -94,7 +165,30 @@
 
                                 <!-- CATEGORIES -->
                                 <div>
-                                    <p class="text-uppercase text-sm text-muted mb-2">Categorías</p>
+                                    <p class="text-uppercase text-sm mb-2">Categorías</p>
+                                    <div class="row section-header">
+                                        <div class="col-12 col-lg-6 mb-2">
+                                            <small>Selecciona al menos una categoría</small>
+                                        </div>
+
+                                        <div class="col-12 col-lg-6 mb-2">
+                                            <button type="button" class="btn btn-outline-primary btn-sm"
+                                                (click)="convertAllOptionsTo('categories')">
+                                                <div *ngIf="!allOptionsSelected('categories')">
+                                                    <i class="fas fa-check"></i>
+                                                    <span>
+                                                        Seleccionar todo
+                                                    </span>
+                                                </div>
+                                                <div *ngIf="allOptionsSelected('categories')">
+                                                    <i class="fas fa-minus"></i>
+                                                    <span>
+                                                        Deseleccionar todo
+                                                    </span>
+                                                </div>
+                                            </button>
+                                        </div>
+                                    </div>
 
                                     <div class="custom-control custom-control-alternative custom-checkbox my-1"
                                         *ngFor="let category of categories; let i = index" formArrayName="categories">
@@ -109,11 +203,11 @@
                         </div>
                         <br>
                         <div class="text-right">
-                            <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
+                            <button type="submit" class="btn btn-primary mt-4" [disabled]="!form.valid">
                                 Enviar invitación
                             </button>
-                            <br>
-                            <span>Status: {{ form.valid }}</span>
+                            <!-- <br> -->
+                            <!-- <span>Status: {{ form.valid }}</span> -->
                         </div>
                     </form>
                 </div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -202,12 +202,22 @@
                             </div>
                         </div>
                         <br>
+                        <div class="row" *ngIf="selectedRole?.name === 'admin' || selectedRole?.name === 'hp'">
+                            <div class="col-12 text-center">
+                                <div class="aditional-info bg-secondary">
+                                    <small>
+                                        Con el rol de
+                                        <b>{{ selectedRole.name === 'admin' ? 'Administrador' : 'HP' }}</b>
+                                        el usuario podrá visualizar información de todos los paises, retailers, sectores
+                                        y categorías
+                                    </small>
+                                </div>
+                            </div>
+                        </div>
                         <div class="text-right">
                             <button type="submit" class="btn btn-primary mt-4" [disabled]="!form.valid">
                                 Enviar invitación
                             </button>
-                            <!-- <br> -->
-                            <!-- <span>Status: {{ form.valid }}</span> -->
                         </div>
                     </form>
                 </div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -31,9 +31,13 @@
                             </div>
 
                             <div class="col-12 col-sm-6">
-                                <mat-select formControlName="role" placeholder="Select a role">
-                                    <mat-option *ngFor="let role of roles" [value]="role">
-                                        {{role}}
+                                <mat-select formControlName="role" placeholder="Select a role" [(value)]="selectedRole"
+                                    (selectionChange)="roleChange()">
+                                    <mat-option *ngFor="let role of roles" [value]="role" [ngSwitch]="role.name">
+                                        <span *ngSwitchCase="'admin'"> {{ 'administrador' | titlecase }}</span>
+                                        <span *ngSwitchCase="'country'"> {{ 'país' | titlecase }}</span>
+                                        <span *ngSwitchCase="'hp'"> {{ 'hp' | uppercase }}</span>
+                                        <span *ngSwitchDefault> {{ role.name | titlecase }}</span>
                                     </mat-option>
                                 </mat-select>
                             </div>
@@ -41,15 +45,65 @@
 
                         <div class="row mt-4">
                             <div class="col-12 col-sm-6">
-                                <p class="text-uppercase text-sm text-muted mb-2">Paises</p>
+                                <!-- COUNTRIES -->
+                                <ng-container *ngIf="selectedRole?.name === 'country'">
+                                    <p class="text-uppercase text-sm text-muted mb-2">Paises</p>
 
-                                <div class="custom-control custom-control-alternative custom-checkbox my-1"
-                                    *ngFor="let country of countries; let i = index" formArrayName="countries">
-                                    <input type="checkbox" class="custom-control-input" [formControlName]="i"
-                                        [id]="'custom-checkbox-'+i">
-                                    <label class="custom-control-label" [for]="'custom-checkbox-'+i">
-                                        <span class="text-muted">{{country}}</span>
-                                    </label>
+                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                        *ngFor="let country of countries; let i = index" formArrayName="countries">
+                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                            [id]="'country-custom-checkbox-'+i">
+                                        <label class="custom-control-label" [for]="'country-custom-checkbox-'+i">
+                                            <span class="text-muted">{{ country.name }}</span>
+                                        </label>
+                                    </div>
+                                </ng-container>
+
+                                <!-- RETAILERS -->
+                                <ng-container *ngIf="selectedRole?.name === 'retailer'">
+                                    <p class="text-uppercase text-sm text-muted mb-2">Retailers</p>
+
+                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                        *ngFor="let retailer of retailers; let i = index" formArrayName="retailers">
+                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                            [id]="'retailer-custom-checkbox-'+i">
+                                        <label class="custom-control-label" [for]="'retailer-custom-checkbox-'+i">
+                                            <span class="text-muted">{{ retailer.name }}</span>
+                                        </label>
+                                    </div>
+                                </ng-container>
+                            </div>
+
+
+                            <div class="col-12 col-sm-6"
+                                *ngIf="selectedRole?.name === 'country' || selectedRole?.name === 'retailer'">
+
+                                <!-- SECTORS -->
+                                <div class="mb-4">
+                                    <p class="text-uppercase text-sm text-muted mb-2">Sectors</p>
+
+                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                        *ngFor="let sector of sectors; let i = index" formArrayName="sectors">
+                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                            [id]="'sector-custom-checkbox-'+i">
+                                        <label class="custom-control-label" [for]="'sector-custom-checkbox-'+i">
+                                            <span class="text-muted">{{ sector.name }}</span>
+                                        </label>
+                                    </div>
+                                </div>
+
+                                <!-- CATEGORIES -->
+                                <div>
+                                    <p class="text-uppercase text-sm text-muted mb-2">Categorías</p>
+
+                                    <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                        *ngFor="let category of categories; let i = index" formArrayName="categories">
+                                        <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                            [id]="'category-custom-checkbox-'+i">
+                                        <label class="custom-control-label" [for]="'category-custom-checkbox-'+i">
+                                            <span class="text-muted">{{ category.name }}</span>
+                                        </label>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -59,7 +113,7 @@
                                 Enviar invitación
                             </button>
                             <br>
-                            <span>Status: {{ form.valid}}</span>
+                            <span>Status: {{ form.valid }}</span>
                         </div>
                     </form>
                 </div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -1,0 +1,69 @@
+<div class="row">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header bg-transparent">
+                <div class="row align-items-center">
+                    <div class="col">
+                        <!-- <h6 class="text-uppercase text-muted ls-1 mb-1">Datos del usuario</h6> -->
+                        <span class="text-uppercase text-muted ls-1 mb-1"><b>Datos del usuario</b></span>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="form-container">
+                    <form role="form" [formGroup]="form" (ngSubmit)="onSubmit()">
+                        <div class="row">
+                            <div class="col-12 col-sm-6">
+                                <div class="form-group mb-3">
+                                    <div class="input-group input-group-alternative"
+                                        [ngClass]="{'is-invalid': !email.valid && email.touched || !email.valid && email.touched}">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text"><i class="ni ni-email-83"></i></span>
+                                        </div>
+                                        <input [formControl]="email" class="form-control"
+                                            placeholder="Correo electrónico" type="email">
+                                    </div>
+                                    <small class="text-danger"
+                                        *ngIf="!email.valid && email.touched || !email.valid && email.touched">
+                                        Ingresa un correo electrónico válido.
+                                    </small>
+                                </div>
+                            </div>
+
+                            <div class="col-12 col-sm-6">
+                                <mat-select formControlName="role" placeholder="Select a role">
+                                    <mat-option *ngFor="let role of roles" [value]="role">
+                                        {{role}}
+                                    </mat-option>
+                                </mat-select>
+                            </div>
+                        </div>
+
+                        <div class="row mt-4">
+                            <div class="col-12 col-sm-6">
+                                <p class="text-uppercase text-sm text-muted mb-2">Paises</p>
+
+                                <div class="custom-control custom-control-alternative custom-checkbox my-1"
+                                    *ngFor="let country of countries; let i = index" formArrayName="countries">
+                                    <input type="checkbox" class="custom-control-input" [formControlName]="i"
+                                        [id]="'custom-checkbox-'+i">
+                                    <label class="custom-control-label" [for]="'custom-checkbox-'+i">
+                                        <span class="text-muted">{{country}}</span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <br>
+                        <div class="text-right">
+                            <button type="submit" class="btn btn-primary my-4" [disabled]="!form.valid">
+                                Enviar invitación
+                            </button>
+                            <br>
+                            <span>Status: {{ form.valid}}</span>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
@@ -1,3 +1,13 @@
 .form-container {
     max-width: 800px;
 }
+
+.section-header {
+    div:last-child {
+        text-align: right;
+
+        @media screen and (min-width: 400px) and (max-width: 990px) {
+            text-align: left;
+        }
+    }
+}

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
@@ -1,0 +1,3 @@
+.form-container {
+    max-width: 800px;
+}

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
@@ -1,5 +1,7 @@
 .form-container {
-    max-width: 800px;
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .section-header {
@@ -10,4 +12,8 @@
             text-align: left;
         }
     }
+}
+
+.aditional-info {
+    padding: 20px;
 }

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.spec.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InviteUserComponent } from './invite-user.component';
+
+describe('InviteUserComponent', () => {
+  let component: InviteUserComponent;
+  let fixture: ComponentFixture<InviteUserComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InviteUserComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InviteUserComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -1,3 +1,4 @@
+import { array } from '@amcharts/amcharts4/core';
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { EmailValidator } from 'src/app/tools/validators/email.validator';
@@ -93,7 +94,6 @@ export class InviteUserComponent implements OnInit {
       name: 'WWS Print'
     }
   ];
-
   categories = [
     {
       id: 1,
@@ -108,6 +108,25 @@ export class InviteUserComponent implements OnInit {
       name: 'Suministros'
     }
   ]
+  formSuboptions = [
+    {
+      name: 'countries',
+      allOptSelected: false
+    },
+    {
+      name: 'retailers',
+      allOptSelected: false
+    },
+    {
+      name: 'sectors',
+      allOptSelected: false
+    },
+    {
+      name: 'categories',
+      allOptSelected: false
+    }
+  ];
+
   selectedRole: any;
 
   constructor(private fb: FormBuilder) { }
@@ -127,20 +146,16 @@ export class InviteUserComponent implements OnInit {
         [Validators.required]
       ],
       countries: this.fb.array(
-        this.countries.map(() => this.fb.control('')),
-        MultipleCheckboxValidator.validate
+        this.countries.map(() => this.fb.control(''))
       ),
       retailers: this.fb.array(
-        this.retailers.map(() => this.fb.control('')),
-        MultipleCheckboxValidator.validate
+        this.retailers.map(() => this.fb.control(''))
       ),
       sectors: this.fb.array(
-        this.sectors.map(() => this.fb.control('')),
-        MultipleCheckboxValidator.validate
+        this.sectors.map(() => this.fb.control(''))
       ),
       categories: this.fb.array(
-        this.categories.map(() => this.fb.control('')),
-        MultipleCheckboxValidator.validate
+        this.categories.map(() => this.fb.control(''))
       ),
     });
 
@@ -148,19 +163,61 @@ export class InviteUserComponent implements OnInit {
   }
 
   roleChange() {
-    if (this.selectedRole) {
-      console.log('exists selectedRole', this.selectedRole)
-      this.resetCheckboxes();
+    this.resetFormControls();
+    this.addFormValidators();
+  }
+
+  resetFormControls() {
+    this.formSuboptions.forEach(opt => {
+      // reset form controls values
+      this.form.controls[opt.name].reset();
+
+      // reset form controls validators
+      this.form.controls[opt.name].setValidators([]);
+      this.form.controls[opt.name].updateValueAndValidity();
+    });
+  }
+
+  addFormValidators() {
+    switch (this.selectedRole.name) {
+      case 'country':
+        this.form.controls.countries.setValidators([
+          MultipleCheckboxValidator.validate
+        ]);
+        this.form.controls.countries.updateValueAndValidity();
+        break;
+      case 'retailer':
+        this.form.controls.retailers.setValidators([
+          MultipleCheckboxValidator.validate
+        ]);
+        this.form.controls.retailers.updateValueAndValidity();
+        break;
+    }
+
+    if (this.selectedRole.name === 'country' || this.selectedRole.name === 'retailer') {
+      this.form.controls.sectors.setValidators([
+        MultipleCheckboxValidator.validate
+      ]);
+      this.form.controls.categories.setValidators([
+        MultipleCheckboxValidator.validate
+      ]);
+
+      this.form.controls.sectors.updateValueAndValidity();
+      this.form.controls.categories.updateValueAndValidity();
     }
   }
 
-  resetCheckboxes() {
-    this.form.reset({
-      'countries': '',
-      'retailers': '',
-      'sectors': '',
-      'categories': ''
-    });
+  convertAllOptionsTo(formSuboption: string) {
+    const formOption = this.formSuboptions.find(option => option.name === formSuboption);
+
+    const selectAllOptions = !formOption.allOptSelected;
+    if (selectAllOptions) {
+      this.form.controls[formSuboption].setValue(this[formSuboption].map(() => this.fb.control(true)));
+      formOption.allOptSelected = true;
+    } else {
+      this.form.controls[formSuboption].reset();
+      formOption.allOptSelected = false;
+    }
   }
 
   convertToValue(key: string) {
@@ -173,5 +230,9 @@ export class InviteUserComponent implements OnInit {
       countries: this.convertToValue('countries')
     });
     console.log(valueToStore);
+  }
+
+  allOptionsSelected(formSuboption) {
+    return this.formSuboptions.find(opt => opt.name === formSuboption).allOptSelected;
   }
 }

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -13,8 +13,102 @@ export class InviteUserComponent implements OnInit {
 
   form: FormGroup;
   email: AbstractControl;
-  roles: any = ['Administrador', 'País', 'Retail', 'HP'];
-  countries = ['Argentina', 'Chile', 'Colombia', 'México'];
+  roles: any = [
+    {
+      id: 1,
+      name: 'admin'
+    },
+    {
+      id: 2,
+      name: 'country'
+    },
+    {
+      id: 3,
+      name: 'retailer'
+    },
+    {
+      id: 4,
+      name: 'hp'
+    }
+  ];
+  countries = [
+    {
+      id: 1,
+      name: 'México'
+    },
+    {
+      id: 2,
+      name: 'Argentina'
+    },
+    {
+      id: 3,
+      name: 'Chile'
+    },
+    {
+      id: 4,
+      name: 'Colombia'
+    }
+  ];
+  retailers = [
+    {
+      id: 1,
+      name: 'Liverpool'
+    },
+    {
+      id: 2,
+      name: 'Carrefourl'
+    },
+    {
+      id: 3,
+      name: 'Frávega'
+    },
+    {
+      id: 4,
+      name: 'Garbarino'
+    },
+    {
+      id: 5,
+      name: 'Office Depot'
+    },
+    {
+      id: 6,
+      name: 'Office Max'
+    },
+  ];
+  sectors = [
+    {
+      id: 1,
+      name: 'Marketing'
+    },
+    {
+      id: 2,
+      name: 'Retail'
+    },
+    {
+      id: 3,
+      name: 'WWS PS'
+    },
+    {
+      id: 4,
+      name: 'WWS Print'
+    }
+  ];
+
+  categories = [
+    {
+      id: 1,
+      name: 'Cómputo'
+    },
+    {
+      id: 2,
+      name: 'Impresoras'
+    },
+    {
+      id: 3,
+      name: 'Suministros'
+    }
+  ]
+  selectedRole: any;
 
   constructor(private fb: FormBuilder) { }
 
@@ -36,9 +130,37 @@ export class InviteUserComponent implements OnInit {
         this.countries.map(() => this.fb.control('')),
         MultipleCheckboxValidator.validate
       ),
+      retailers: this.fb.array(
+        this.retailers.map(() => this.fb.control('')),
+        MultipleCheckboxValidator.validate
+      ),
+      sectors: this.fb.array(
+        this.sectors.map(() => this.fb.control('')),
+        MultipleCheckboxValidator.validate
+      ),
+      categories: this.fb.array(
+        this.categories.map(() => this.fb.control('')),
+        MultipleCheckboxValidator.validate
+      ),
     });
 
     this.email = this.form.controls['email'];
+  }
+
+  roleChange() {
+    if (this.selectedRole) {
+      console.log('exists selectedRole', this.selectedRole)
+      this.resetCheckboxes();
+    }
+  }
+
+  resetCheckboxes() {
+    this.form.reset({
+      'countries': '',
+      'retailers': '',
+      'sectors': '',
+      'categories': ''
+    });
   }
 
   convertToValue(key: string) {

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { EmailValidator } from 'src/app/tools/validators/email.validator';
+import { MultipleCheckboxValidator } from 'src/app/tools/validators/multiple-checkbox.validator';
+
+
+@Component({
+  selector: 'app-invite-user',
+  templateUrl: './invite-user.component.html',
+  styleUrls: ['./invite-user.component.scss']
+})
+export class InviteUserComponent implements OnInit {
+
+  form: FormGroup;
+  email: AbstractControl;
+  roles: any = ['Administrador', 'País', 'Retail', 'HP'];
+  countries = ['Argentina', 'Chile', 'Colombia', 'México'];
+
+  constructor(private fb: FormBuilder) { }
+
+  ngOnInit(): void {
+    this.loadForm();
+  }
+
+  loadForm() {
+    this.form = this.fb.group({
+      email: [
+        '',
+        Validators.compose([Validators.required, EmailValidator.validate])
+      ],
+      role: [
+        '',
+        [Validators.required]
+      ],
+      countries: this.fb.array(
+        this.countries.map(() => this.fb.control('')),
+        MultipleCheckboxValidator.validate
+      ),
+    });
+
+    this.email = this.form.controls['email'];
+  }
+
+  convertToValue(key: string) {
+    return this.form.value[key].map((x, i) => x && this[key][i]).filter(x => !!x);
+  }
+
+  onSubmit() {
+    console.log('this.form.value', this.form.value)
+    const valueToStore = Object.assign({}, this.form.value, {
+      countries: this.convertToValue('countries')
+    });
+    console.log(valueToStore);
+  }
+}

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -1,4 +1,3 @@
-import { array } from '@amcharts/amcharts4/core';
 import { Component, OnInit } from '@angular/core';
 import { AbstractControl, FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { EmailValidator } from 'src/app/tools/validators/email.validator';
@@ -225,9 +224,11 @@ export class InviteUserComponent implements OnInit {
   }
 
   onSubmit() {
-    console.log('this.form.value', this.form.value)
     const valueToStore = Object.assign({}, this.form.value, {
-      countries: this.convertToValue('countries')
+      countries: this.convertToValue('countries'),
+      retailers: this.convertToValue('retailers'),
+      sectors: this.convertToValue('sectors'),
+      categories: this.convertToValue('categories'),
     });
     console.log(valueToStore);
   }

--- a/src/app/modules/users-mngmt/pages/users/users.component.html
+++ b/src/app/modules/users-mngmt/pages/users/users.component.html
@@ -1,5 +1,14 @@
 <div class="row">
+    <div class="col-12 mb-5 text-right">
+        <button type="button" class="btn btn-primary" routerLink="/dashboard/users/invite-user">
+            <i class="fas fa-user-plus text-white mr-1"></i>
+            Invitar a un nuevo usuario
+        </button>
+    </div>
+</div>
+<div class="row">
     <div class="col-12">
+
         <app-users-list></app-users-list>
     </div>
 </div>

--- a/src/app/modules/users-mngmt/pages/users/users.component.html
+++ b/src/app/modules/users-mngmt/pages/users/users.component.html
@@ -1,14 +1,19 @@
-<div class="row">
-    <div class="col-12 mb-5 text-right">
-        <button type="button" class="btn btn-primary" routerLink="/dashboard/users/invite-user">
-            <i class="fas fa-user-plus text-white mr-1"></i>
-            Invitar a un nuevo usuario
-        </button>
-    </div>
-</div>
-<div class="row">
-    <div class="col-12">
-
-        <app-users-list></app-users-list>
+<div class="card">
+    <div class="card-body">
+        <div class="main-container mt-4">
+            <div class="row">
+                <div class="col-12 mb-4 text-right">
+                    <button type="button" class="btn btn-primary" routerLink="/dashboard/users/invite-user">
+                        <i class="fas fa-user-plus text-white mr-1"></i>
+                        Invitar a un nuevo usuario
+                    </button>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    <app-users-list></app-users-list>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/app/modules/users-mngmt/pages/users/users.component.scss
+++ b/src/app/modules/users-mngmt/pages/users/users.component.scss
@@ -1,0 +1,5 @@
+.main-container {
+    max-width: 900px;
+    margin-right: auto;
+    margin-left: auto;
+}

--- a/src/app/modules/users-mngmt/users-mngmt.module.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.module.ts
@@ -7,6 +7,10 @@ import { RouterModule } from '@angular/router';
 import { UsersMngmtRoutes } from './users-mngmt.routing';
 import { MatTableModule } from '@angular/material/table';
 import { MatPaginatorModule } from '@angular/material/paginator';
+import { InviteUserComponent } from './pages/invite-user/invite-user.component';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatSelectModule } from '@angular/material/select';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 
 
@@ -15,12 +19,16 @@ import { MatPaginatorModule } from '@angular/material/paginator';
     UsersMngmtComponent,
     UsersListComponent,
     UsersComponent,
+    InviteUserComponent,
   ],
   imports: [
     CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
     RouterModule.forChild(UsersMngmtRoutes),
     MatTableModule,
-    MatPaginatorModule
+    MatPaginatorModule,
+    MatSelectModule
   ]
 })
 export class UsersMngmtModule { }

--- a/src/app/modules/users-mngmt/users-mngmt.routing.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.routing.ts
@@ -1,6 +1,8 @@
 import { Routes } from '@angular/router';
+import { InviteUserComponent } from './pages/invite-user/invite-user.component';
 import { UsersComponent } from './pages/users/users.component';
 
 export const UsersMngmtRoutes: Routes = [
     { path: '', component: UsersComponent },
+    { path: 'invite-user', component: InviteUserComponent },
 ];

--- a/src/app/tools/validators/multiple-checkbox.validator.ts
+++ b/src/app/tools/validators/multiple-checkbox.validator.ts
@@ -1,0 +1,18 @@
+import { FormArray } from '@angular/forms';
+
+// Multiple checkbox required one validator
+export class MultipleCheckboxValidator {
+    public static validate(fa: FormArray) {
+        let valid = false;
+
+        for (let x = 0; x < fa.length; ++x) {
+            if (fa.at(x).value) {
+                valid = true;
+                break;
+            }
+        }
+        return valid ? null : {
+            validate: true
+        };
+    }
+}

--- a/src/assets/scss/core/buttons/_button.scss
+++ b/src/assets/scss/core/buttons/_button.scss
@@ -89,3 +89,8 @@
 .btn-neutral {
    color: theme-color("primary");
 }
+
+
+.btn.disabled, .btn:disabled {
+   opacity: 0.3;
+}

--- a/src/assets/scss/core/custom-forms/_custom-checkbox.scss
+++ b/src/assets/scss/core/custom-forms/_custom-checkbox.scss
@@ -14,9 +14,6 @@
                 &::before {
                     border-color: $custom-control-indicator-checked-border-color;
                 }
-                &::after {
-                    background-image: $custom-checkbox-indicator-icon-checked;
-                }
             }
         }
 

--- a/src/assets/scss/core/custom-forms/_custom-form.scss
+++ b/src/assets/scss/core/custom-forms/_custom-form.scss
@@ -14,9 +14,6 @@
                 &::before {
                     border-color: $custom-control-indicator-checked-border-color;
                 }
-                &::after {
-                    background-image: $custom-checkbox-indicator-icon-checked;
-                }
             }
         }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -44,3 +44,34 @@ $coop-dashboard-theme: mat-light-theme((
 th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
   padding: 0 8px !important;
 }
+
+.mat-select-trigger {
+  border-radius: 0.375rem;
+  box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
+  border: 0;
+  transition: box-shadow 0.15s ease;
+  padding: 0.625rem 0.75rem;
+  white-space: nowrap;
+
+    .mat-select-value {
+      color: #767676;
+      font-size: 0.875rem;
+      font-weight: 400;
+      line-height: 1.5;
+    }
+
+    .mat-select-arrow {
+      color: #adb5bd;
+    }
+}
+
+.mat-select-panel:not([class*=mat-elevation-z]){
+  box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
+  border-radius: 0.375rem;
+}
+
+.mat-select-panel .mat-optgroup-label, .mat-select-panel .mat-option {
+  height: 2.5em !important;
+  color: #767676;
+  font-size: 0.875rem !important;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,6 +27,14 @@ $coop-dashboard-theme: mat-light-theme((
   )
 ));
 
+// Define a custom typography config that overrides the font-family as well as the
+// `headlines` and `body-1` levels.
+$custom-typography: mat-typography-config(
+  $font-family: 'HPSimplifiedLight, Arial, sans-serif',
+  $headline: mat-typography-level(32px, 48px, 700),
+  $body-1: mat-typography-level(16px, 24px, 500)
+);
+@include mat-core($custom-typography);
 // Include theme styles for core and each component used in your app.
 // Alternatively, you can import and @include the theme mixins for each component
 // that you are using.
@@ -37,12 +45,16 @@ $coop-dashboard-theme: mat-light-theme((
 // CUSTOM ANGULAR MATERIAL
 
 // table
-.mat-table {
-  font-family: inherit;
-}
-
 th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
   padding: 0 8px !important;
+}
+
+.mat-header-cell  {
+  font-size: 14.5px;
+}
+
+.mat-cell, .mat-footer-cell {
+  font-size: 14px;
 }
 
 .mat-select-trigger {


### PR DESCRIPTION
# Problem Description
- Is necessary to integrate a template view with front-end behaviour as conditionals and form validators to invite-user component

# Features
- Add form with email, role and conditionals entities (countries, retailers, sectors and categories)
- Add dinamical validators based on role value
- Homologate styles

# Where this change will be used
- In `/dashboard/users/invite-user` path

# More details
- `/dashboard/users` view
![image](https://user-images.githubusercontent.com/38545126/113635850-feabbb80-9636-11eb-8c50-1988c58433d7.png)

- `/dashboard/users/invite-user` view
![image](https://user-images.githubusercontent.com/38545126/113635939-2ac73c80-9637-11eb-82a9-1ffaf84c9390.png)
