### PR TITLE
add send invite functionality to invite-user component

### DIFF
--- a/src/app/models/permission.ts
+++ b/src/app/models/permission.ts
@@ -1,0 +1,10 @@
+export class Permission {
+    role_id: number;
+    entity_type: string;
+    entity_id: number;
+}
+
+export class Invite {
+    user_email: string;
+    permissions: Permission[];
+}

--- a/src/app/models/permission.ts
+++ b/src/app/models/permission.ts
@@ -5,6 +5,6 @@ export class Permission {
 }
 
 export class Invite {
-    user_email: string;
+    email: string;
     permissions: Permission[];
 }

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -5,14 +5,14 @@
                 <div class="row align-items-center">
                     <div class="col">
                         <!-- <h6 class="text-uppercase text-muted ls-1 mb-1">Datos del usuario</h6> -->
-                        <span class="text-uppercase text-muted ls-1 mb-1"><b>Datos del usuario</b></span>
+                        <span class="text-uppercase text-muted ls-1 mb-1"><b>Invitar usuario</b></span>
                     </div>
                 </div>
             </div>
 
             <div class="card-body">
                 <!-- form -->
-                <div class="form-container" *ngIf="form">
+                <div class="form-container" *ngIf="form && inviteReqStatus !== 2">
                     <form role="form" [formGroup]="form" (ngSubmit)="onSubmit()">
 
                         <!-- loader (emal and role) -->
@@ -283,12 +283,13 @@
 
                         <!-- send invitation button -->
                         <div class="text-right" *ngIf="getRoleStatus !== 1">
-                            <button type="submit" class="btn btn-primary mt-4" [disabled]="!form.valid">
+                            <button type="submit" class="btn btn-primary mt-4"
+                                [disabled]="!form.valid || inviteReqStatus === 1">
                                 Enviar invitación
                             </button>
                         </div>
 
-                        <!-- error message -->
+                        <!-- GET error message -->
                         <div class="row my-4" *ngIf="getRoleStatus === 3 || getReqStatus === 3">
                             <div class="col-12 text-center text-danger">
                                 <small>
@@ -298,6 +299,26 @@
                             </div>
                         </div>
                     </form>
+                </div>
+
+                <!-- invite message -->
+                <div class="row my-4" *ngIf="inviteReqStatus > 1">
+                    <div class="col-12 text-center">
+                        <div class="text-muted" *ngIf="inviteReqStatus === 2">
+                            <small>
+                                Invitación enviada
+                            </small>
+                            <br>
+                            <button type="button" class="btn btn-light my-4" routerLink="/dashboard/users">
+                                Regresar a Administrar usuarios
+                            </button>
+                        </div>
+
+                        <small class="text-danger" *ngIf="inviteReqStatus === 3">
+                            Ocurrió un error al enviar la invitación al usuario: <br>
+                            {{ this.inviteErrorMsg }}
+                        </small>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -298,13 +298,12 @@ export class InviteUserComponent implements OnInit {
 
     permissions = [...permissions, ...this.convertToValue('sectors', 'sector')];
     permissions = [...permissions, ...this.convertToValue('categories', 'category')];
-    console.log('permissions', permissions);
 
     const invite: Invite = {
       user_email: this.form.value.email,
       permissions
     }
-    console.log('invite', invite)
+
     this.sendInviteToUser(invite);
   }
 

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -286,13 +286,20 @@ export class InviteUserComponent implements OnInit {
 
   onSubmit() {
     let permissions: Permission[] = [];
-    const role = this.form.value.role.name;
-    switch (role) {
+    const role = this.form.value.role;
+    switch (role.name) {
       case 'country':
         permissions = [...this.convertToValue('countries', 'country')];
         break;
       case 'retailer':
         permissions = [...this.convertToValue('retailers', 'retailer')];
+        break;
+      default:
+        permissions = [{
+          role_id: role.id,
+          entity_type: null,
+          entity_id: null
+        }]
         break;
     }
 
@@ -300,7 +307,7 @@ export class InviteUserComponent implements OnInit {
     permissions = [...permissions, ...this.convertToValue('categories', 'category')];
 
     const invite: Invite = {
-      user_email: this.form.value.email,
+      email: this.form.value.email,
       permissions
     }
 

--- a/src/app/modules/users-mngmt/services/users-mngmt.service.ts
+++ b/src/app/modules/users-mngmt/services/users-mngmt.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { throwError } from 'rxjs';
 import { Configuration } from 'src/app/app.constants';
+import { Invite } from 'src/app/models/permission';
 
 @Injectable({
   providedIn: 'root'
@@ -16,6 +17,9 @@ export class UsersMngmtService {
     this.baseUrl = this.config.endpoint;
   }
 
+  /**** USERS MANAGMENT
+  * Endpoints related to list and remove created users
+  * ****/
   getUsers() {
     return this.http.get(`${this.baseUrl}/users`);
   }
@@ -27,6 +31,9 @@ export class UsersMngmtService {
     return this.http.delete(`${this.baseUrl}/users/${userID}`);
   }
 
+  /**** ROLE AND ENTITIES
+  * Endpoints related to role and entities to invite a new user
+  * ****/
   getRoles() {
     return this.http.get(`${this.baseUrl}/roles`);
   }
@@ -45,5 +52,15 @@ export class UsersMngmtService {
 
   getCategories() {
     return this.http.get(`${this.baseUrl}/categories`);
+  }
+
+  /**** INVITATIONS
+  * Endpoints related to user invitation
+  * ****/
+  sendInvitation(invite: Invite) {
+    if (!invite) {
+      return throwError('[users-mngmt.service]: not invite provided');
+    }
+    return this.http.post(`${this.baseUrl}/users/invitations`, invite);
   }
 }


### PR DESCRIPTION
# Problem Description
- In order to make a functional component is necessary add request to CO-OP API

# Features
- Add a Pemission and and Invite models
- Create an Invite object after form submition to send it in POST request
- Add POST request to `/users/invitations` endpoint
- Show error or successful message after POST request

# Where this change will be used
- When a new user is invited at `/dashboard/users/invite-user` path

# More details
- Example:
![image](https://user-images.githubusercontent.com/38545126/113942430-62182380-97c6-11eb-8d1d-a6e4f6bf88a1.png)

- Body payload in request: 
![image](https://user-images.githubusercontent.com/38545126/113942538-8ffd6800-97c6-11eb-833b-aa374e62652c.png)

- Success message after request
![image](https://user-images.githubusercontent.com/38545126/113942577-a3a8ce80-97c6-11eb-8a6d-1c5ab4f8681c.png)

- Error message after request
![image](https://user-images.githubusercontent.com/38545126/113942686-d357d680-97c6-11eb-84b7-023136cc2b2e.png)


