### PR TITLE
add view options for user with admin role

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -69,12 +69,14 @@
       </form>
       <!-- Navigation -->
       <ul class="navbar-nav">
-        <li *ngFor="let menuItem of menuItems" class="{{menuItem.class}} nav-item">
-          <a routerLinkActive="active" [routerLink]="[menuItem.path]" class="nav-link">
-            <i class="ni {{menuItem.icon}}"></i>
-            {{menuItem.title}}
-          </a>
-        </li>
+        <ng-container *ngFor="let menuItem of menuItems">
+          <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
+            <a routerLinkActive="active" [routerLink]="[menuItem.path]" class="nav-link">
+              <i class="ni {{menuItem.icon}}"></i>
+              {{menuItem.title}}
+            </a>
+          </li>
+        </ng-container>
       </ul>
 
       <!-- <hr class="my-3">

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -7,13 +7,14 @@ declare interface RouteInfo {
   title: string;
   icon: string;
   class: string;
+  isForAdmin: boolean;
 }
 export const ROUTES: RouteInfo[] = [
-  { path: '/dashboard/investment', title: 'Inversión', icon: 'text-primary', class: '' },
-  { path: '/dashboard/argentina', title: 'Argentina', icon: 'text-primary', class: '' },
-  { path: '/dashboard/colombia', title: 'Colombia', icon: 'text-primary', class: '' },
-  { path: '/dashboard/mexico', title: 'México', icon: 'text-primary', class: '' },
-  { path: '/dashboard/users', title: 'Administrar usuarios', icon: 'text-primary', class: '' },
+  { path: '/dashboard/investment', title: 'Inversión', icon: 'text-primary', class: '', isForAdmin: false },
+  { path: '/dashboard/argentina', title: 'Argentina', icon: 'text-primary', class: '', isForAdmin: false },
+  { path: '/dashboard/colombia', title: 'Colombia', icon: 'text-primary', class: '', isForAdmin: false },
+  { path: '/dashboard/mexico', title: 'México', icon: 'text-primary', class: '', isForAdmin: false },
+  { path: '/dashboard/users', title: 'Administrar usuarios', icon: 'text-primary', class: '', isForAdmin: true },
   // { path: '/chart-js', title: 'chart.js', icon: 'ni-chart-bar-32 text-primary', class: '' },
   // { path: '/amcharts', title: 'amcharts', icon: 'ni-chart-pie-35 text-primary', class: '' },
   // { path: '/icons', title: 'Icons', icon: 'ni-planet text-blue', class: '' },
@@ -33,6 +34,7 @@ export class SidebarComponent implements OnInit {
 
   public menuItems: any[];
   public isCollapsed = true;
+  public userIsAdmin: boolean;
 
   constructor(
     private router: Router,
@@ -40,6 +42,8 @@ export class SidebarComponent implements OnInit {
   ) { }
 
   ngOnInit() {
+    this.userIsAdmin = this.userService.isAdmin();
+
     this.menuItems = ROUTES.filter(menuItem => menuItem);
     this.router.events.subscribe((event) => {
       this.isCollapsed = true;

--- a/src/app/layouts/admin-layout/admin-layout.module.ts
+++ b/src/app/layouts/admin-layout/admin-layout.module.ts
@@ -11,6 +11,7 @@ import { IconsComponent } from '../../pages/icons/icons.component';
 import { MapsComponent } from '../../pages/maps/maps.component';
 import { UserProfileComponent } from '../../pages/user-profile/user-profile.component';
 import { TablesComponent } from '../../pages/tables/tables.component';
+import { UsersMngmtGuard } from 'src/app/modules/users-mngmt/users-mngmt.guard';
 
 // import { ToastrModule } from 'ngx-toastr';
 
@@ -28,6 +29,9 @@ import { TablesComponent } from '../../pages/tables/tables.component';
     TablesComponent,
     IconsComponent,
     MapsComponent
+  ],
+  providers: [
+    UsersMngmtGuard
   ]
 })
 

--- a/src/app/layouts/admin-layout/admin-layout.routing.ts
+++ b/src/app/layouts/admin-layout/admin-layout.routing.ts
@@ -8,6 +8,7 @@ import { TablesComponent } from '../../pages/tables/tables.component';
 import { ChartJsComponent } from 'src/app/pages/chart-js/chart-js.component';
 import { AmchartsComponent } from 'src/app/pages/amcharts/amcharts.component';
 import { UsersMngmtComponent } from 'src/app/modules/users-mngmt/users-mngmt.component';
+import { UsersMngmtGuard } from 'src/app/modules/users-mngmt/users-mngmt.guard';
 
 export const AdminLayoutRoutes: Routes = [
     { path: 'investment', component: DashboardComponent },
@@ -24,8 +25,9 @@ export const AdminLayoutRoutes: Routes = [
         path: 'users',
         component: UsersMngmtComponent,
         loadChildren: () =>
-            import("src/app/modules/users-mngmt/users-mngmt.module").then(
+            import('src/app/modules/users-mngmt/users-mngmt.module').then(
                 m => m.UsersMngmtModule
-            )
+            ),
+        canActivate: [UsersMngmtGuard]
     }
 ];

--- a/src/app/models/user.ts
+++ b/src/app/models/user.ts
@@ -6,4 +6,5 @@ export class User {
     created_at: string;
     updated_at: string;
     deleted_at?: string;
+    role_name?: string;
 }

--- a/src/app/modules/users-mngmt/users-mngmt.guard.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { Router, CanActivate } from '@angular/router';
+import { UserService } from 'src/app/services/user.service';
+
+@Injectable()
+export class UsersMngmtGuard implements CanActivate {
+    constructor(
+        private userService: UserService,
+        private router: Router
+    ) { }
+
+    canActivate() {
+        if (this.userService.isAdmin()) {
+            return true;
+        } else {
+            this.router.navigate(['/dashboard/investment']);
+            return false;
+        }
+    }
+}

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -32,7 +32,7 @@ export class UserService {
   }
 
   get loggedIn() {
-    return !!window.localStorage.getItem("auth_token")
+    return !!window.localStorage.getItem('auth_token')
   }
 
   constructor(
@@ -41,13 +41,16 @@ export class UserService {
     private config: Configuration,
     private cookieService: CookieService
   ) {
-    this._loggedIn = !!window.localStorage.getItem("auth_token");
-    this.user.email = !!window.localStorage.getItem("usermail")
-      ? window.localStorage.getItem("usermail")
-      : "";
-    this.user.username = !!window.localStorage.getItem("username")
-      ? window.localStorage.getItem("username")
-      : "";
+    this._loggedIn = !!window.localStorage.getItem('auth_token');
+    this.user.email = !!window.localStorage.getItem('usermail')
+      ? window.localStorage.getItem('usermail')
+      : '';
+    this.user.username = !!window.localStorage.getItem('username')
+      ? window.localStorage.getItem('username')
+      : '';
+    this.user.role_name = !!window.localStorage.getItem('role_name')
+      ? window.localStorage.getItem('role_name')
+      : '';
 
     this.baseUrl = this.config.endpoint;
   }
@@ -83,10 +86,14 @@ export class UserService {
       .post(`${this.baseUrl}/auth`, { email, password })
       .pipe(
         tap((resp: any) => {
-          if (resp && resp.token) {
-            this.user.email = email;
-            window.localStorage.setItem("usermail", email);
-            window.localStorage.setItem("auth_token", resp.token);
+          if (resp.user && resp.token && resp.role) {
+            // this.user.email = email;
+            window.localStorage.setItem('usermail', resp.user.email);
+            window.localStorage.setItem('auth_token', resp.token);
+            window.localStorage.setItem('role_name', resp.role.name);
+
+            this.user = resp.user;
+            this.user.role_name = resp.role.name;
 
             this._loggedIn = true;
           }
@@ -117,6 +124,14 @@ export class UserService {
 
   isLoggedIn(): boolean {
     return this.loggedIn;
+  }
+
+  isAdmin(): boolean {
+    let role_name = this.user.role_name
+      ? this.user.role_name
+      : window.localStorage.getItem('role_name');
+
+    return role_name === 'admin' ? true : false;
   }
 
   logout() {


### PR DESCRIPTION
# Problem Description
- Show user management module (access) only to users with "admin" role

# Features
- Get and save user role after `/auth` request (login)
- Add isAdmin function in the main service to use this function from differents components
- In sidebar component show user managment module option only if the user has admin role
- Add a guard to protect the route `/dashboard/users` where is alocated users management module

# Where this change will be used
- In users management module at `/dashboard/users` path