### PR TITLE
add invitations functionality to users management module

### DIFF
--- a/src/app/modules/users-mngmt/components/invitation/invitation.component.html
+++ b/src/app/modules/users-mngmt/components/invitation/invitation.component.html
@@ -1,0 +1,38 @@
+<div class="card">
+    <div class="card-body">
+        <div class="row">
+            <div class="col-12">
+                <div class="invitation-container">
+                    <p class="invitation-text">
+                        Esperando respuesta del usuario con la cuenta de <strong>{{ invitation.email }}</strong>
+                    </p>
+                    <div class="invitation-buttons text-right">
+                        <button type="button" class="btn btn-light" [disabled]="reqStatus === 1"
+                            (click)="resendInvitation()">
+                            Reenviar
+                        </button>
+                        <button type="button" class="btn btn-danger" [disabled]="reqStatus === 1"
+                            (click)="cancelInvitation()">
+                            Cancelar
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- messages -->
+        <div class="row mt-4" *ngIf="reqStatus > 1">
+            <div class="col-12 text-center">
+                <!-- resend success -->
+                <p class="text-muted mb-0" *ngIf="reqStatus === 2">
+                    Invitación reenviada
+                </p>
+
+                <!-- resend or cancel error -->
+                <p class="text-red mb-0" *ngIf="reqStatus === 3">
+                    {{ errorMsg }}
+                </p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/users-mngmt/components/invitation/invitation.component.scss
+++ b/src/app/modules/users-mngmt/components/invitation/invitation.component.scss
@@ -1,0 +1,42 @@
+.invitation-container {
+    align-items: center;
+    display: grid;
+    grid-gap: 8px;
+    grid-template-columns: 1fr auto;
+    
+    .invitation-buttons {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+    
+    button.btn {
+        align-self: flex-end;
+        height: fit-content;
+        width: fit-content;
+
+        &:not(:last-child) {
+            margin-right: 1rem;
+        }
+    }
+
+    @media screen and (max-width: 560px) {
+        grid-template-columns: 1fr;
+        button.btn {
+            justify-self: flex-end;
+            margin-bottom: 1rem;
+        }
+    }
+
+    @media screen and (max-width: 300px) {
+        button.btn {
+            &:not(:last-child) {
+                margin-right: 0rem;
+            }
+            &:last-child {
+                margin-left: 1rem;
+            }
+        }
+    }
+}

--- a/src/app/modules/users-mngmt/components/invitation/invitation.component.spec.ts
+++ b/src/app/modules/users-mngmt/components/invitation/invitation.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { InvitationComponent } from './invitation.component';
+
+describe('InvitationComponent', () => {
+  let component: InvitationComponent;
+  let fixture: ComponentFixture<InvitationComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ InvitationComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InvitationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/users-mngmt/components/invitation/invitation.component.ts
+++ b/src/app/modules/users-mngmt/components/invitation/invitation.component.ts
@@ -1,0 +1,59 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { UsersMngmtService } from '../../services/users-mngmt.service';
+
+@Component({
+  selector: 'app-invitation',
+  templateUrl: './invitation.component.html',
+  styleUrls: ['./invitation.component.scss']
+})
+export class InvitationComponent implements OnInit {
+  @Input() invitation: any;
+  @Output() invitationDeleted = new EventEmitter<boolean>();
+
+  reqStatus: number = 0;
+  errorMsg: string;
+
+  constructor(private usersMngmtService: UsersMngmtService) { }
+
+  ngOnInit(): void {
+  }
+
+  cancelInvitation() {
+    this.reqStatus = 1;
+    this.usersMngmtService.deleteInvitation(this.invitation.id)
+      .subscribe(
+        () => {
+          this.invitationDeleted.emit(true);
+          this.errorMsg && delete this.errorMsg;
+          this.reqStatus = 2;
+        },
+        error => {
+          const errorDetails = error?.error?.message ? error.error.message : error?.message;
+          this.errorMsg = `Ocurrió un error al cancelar la invitación: ${errorDetails}.`
+          console.error(`[invitation.component]: ${error}`);
+          this.reqStatus = 3;
+        }
+      );
+  }
+
+  resendInvitation() {
+    this.reqStatus = 1;
+    this.usersMngmtService.resendInvitation(this.invitation.id)
+      .subscribe(
+        () => {
+          this.errorMsg && delete this.errorMsg;
+          this.reqStatus = 2;
+
+          setTimeout(() => {
+            this.reqStatus = 0;
+          }, 5000)
+        },
+        error => {
+          const errorDetails = error?.error?.message ? error.error.message : error?.message;
+          this.errorMsg = `Ocurrió un reenviar la invitación: ${errorDetails}.`
+          console.error(`[invitation.component]: ${error}`);
+          this.reqStatus = 3;
+        }
+      );
+  }
+}

--- a/src/app/modules/users-mngmt/pages/users/users.component.html
+++ b/src/app/modules/users-mngmt/pages/users/users.component.html
@@ -1,14 +1,45 @@
-<div class="card">
-    <div class="card-body">
-        <div class="main-container mt-4">
-            <div class="row">
-                <div class="col-12 mb-4 text-right">
-                    <button type="button" class="btn btn-primary" routerLink="/dashboard/users/invite-user">
-                        <i class="fas fa-user-plus text-white mr-1"></i>
-                        Invitar a un nuevo usuario
-                    </button>
+<div class="main-container mt-4">
+    <!-- invitations -->
+    <div *ngIf="getReqSatus > 1" class="mb-4">
+        <div class="row">
+            <div class="col-12" *ngIf="invitations?.length > 0 || getReqSatus === 3">
+                <p class="text-uppercase text-muted mb-4"><b>Invitaciones enviadas</b></p>
+            </div>
+
+            <div class="col-12 mb-4" *ngIf="invitations?.length > 0">
+                <app-invitation *ngFor="let invitation of invitations" [invitation]="invitation"
+                    (invitationDeleted)="getInvitations()"></app-invitation>
+            </div>
+        </div>
+
+        <!-- error message -->
+        <div class="row" *ngIf="getReqSatus === 3">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-body">
+                        <p class="text-danger text-center mb-0">
+                            Se generó un error al consultar las invitaciones enviadas
+                        </p>
+                    </div>
                 </div>
             </div>
+        </div>
+    </div>
+
+    <p class="text-uppercase text-muted my-4"><b>Administar usuarios</b></p>
+    <!-- invite new user button -->
+    <div class="row">
+        <div class="col-12 mb-4 text-right">
+            <button type="button" class="btn btn-primary" routerLink="/dashboard/users/invite-user">
+                <i class="fas fa-user-plus text-white mr-1"></i>
+                Invitar a un nuevo usuario
+            </button>
+        </div>
+    </div>
+
+    <!-- users list -->
+    <div class="card">
+        <div class="card-body">
             <div class="row">
                 <div class="col-12">
                     <app-users-list></app-users-list>

--- a/src/app/modules/users-mngmt/pages/users/users.component.ts
+++ b/src/app/modules/users-mngmt/pages/users/users.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { UsersMngmtService } from '../../services/users-mngmt.service';
 
 @Component({
   selector: 'app-users',
@@ -6,10 +7,29 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./users.component.scss']
 })
 export class UsersComponent implements OnInit {
+  private invitations: any[];
+  getReqSatus: number = 0;
 
-  constructor() { }
+  constructor(
+    private usersMngmtService: UsersMngmtService
+  ) { }
 
   ngOnInit(): void {
+    this.getInvitations();
   }
 
+  getInvitations() {
+    this.getReqSatus = 1;
+    this.usersMngmtService.getInvitations()
+      .subscribe(
+        (resp: any[]) => {
+          this.invitations = resp;
+          this.getReqSatus = 2;
+        },
+        error => {
+          this.getReqSatus = 3;
+          console.error(`[users.component]: ${error?.error?.message ? error.error.message : error?.message}`);
+        }
+      )
+  }
 }

--- a/src/app/modules/users-mngmt/services/users-mngmt.service.ts
+++ b/src/app/modules/users-mngmt/services/users-mngmt.service.ts
@@ -57,10 +57,28 @@ export class UsersMngmtService {
   /**** INVITATIONS
   * Endpoints related to user invitation
   * ****/
+  getInvitations() {
+    return this.http.get(`${this.baseUrl}/users/invitations`);
+  }
+
   sendInvitation(invite: Invite) {
     if (!invite) {
       return throwError('[users-mngmt.service]: not invite provided');
     }
     return this.http.post(`${this.baseUrl}/users/invitations`, invite);
+  }
+
+  resendInvitation(invitationID: number) {
+    if (!invitationID) {
+      return throwError('[users-mngmt.service]: not invitationID provided');
+    }
+    return this.http.post(`${this.baseUrl}/invitations/${invitationID}/resend`, {});
+  }
+
+  deleteInvitation(invitationID: number) {
+    if (!invitationID) {
+      return throwError('[users-mngmt.service]: not invitationID provided');
+    }
+    return this.http.delete(`${this.baseUrl}/invitations/${invitationID}`);
   }
 }

--- a/src/app/modules/users-mngmt/users-mngmt.module.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.module.ts
@@ -12,6 +12,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatSelectModule } from '@angular/material/select';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { UsersMngmtService } from './services/users-mngmt.service';
+import { InvitationComponent } from './components/invitation/invitation.component';
 
 
 
@@ -21,6 +22,7 @@ import { UsersMngmtService } from './services/users-mngmt.service';
     UsersListComponent,
     UsersComponent,
     InviteUserComponent,
+    InvitationComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
# Problem Description
- Manage invitations for users with admin as role:
  - Show sent invitations
  - Cancel a sent invitation
  - Resend an invitation

# Features
- Add GET request to `/users/invitations` endpoint to GET all pending invitations and show them with invitation component
- Add POST request to `/invitations/invitationID/resend` to resend an invitation
- Add DELETE request to `/invitations/invitationID` to cancel an invitation
- Add success and error messages after requests

# Where this change will be used
- In management users module at `/dashboard/users` path

# More details
- Invitations list
![image](https://user-images.githubusercontent.com/38545126/114105262-1632b080-9892-11eb-88ec-8b93039b9d4b.png)

