### PR TITLE
show available countries based on user permissions in sidebar component

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -68,7 +68,7 @@
         </div>
       </form>
       <!-- Navigation -->
-      <ul class="navbar-nav">
+      <ul class="navbar-nav" *ngIf="menuReqStatus >= 2">
         <ng-container *ngFor="let menuItem of menuItems">
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
             <a routerLinkActive="active" [routerLink]="[menuItem.path]" class="nav-link">
@@ -78,6 +78,12 @@
           </li>
         </ng-container>
       </ul>
+
+      <div class="text-danger mt-5 pl-3 pr-3" *ngIf="menuReqStatus === 3">
+        <small>
+          Ocurrió un error al consultar los países o retailers a los que tienes acceso. Intenta más tarde.
+        </small>
+      </div>
 
       <!-- <hr class="my-3">
       <h6 class="navbar-heading text-muted">Settings</h6>

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -1,0 +1,3 @@
+.text-danger {
+    line-height: 1rem; 
+}

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -44,7 +44,7 @@ export class SidebarComponent implements OnInit, AfterViewInit {
   async ngAfterViewInit() {
     this.userIsAdmin = this.userService.isAdmin();
 
-    this.menuItems = ROUTES;
+    this.menuItems = ROUTES.filter(menuItem => menuItem);
     this.router.events.subscribe((event) => {
       this.isCollapsed = true;
     });

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { AfterViewInit, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { UsersMngmtService } from 'src/app/modules/users-mngmt/services/users-mngmt.service';
 import { UserService } from 'src/app/services/user.service';
 
 declare interface RouteInfo {
@@ -11,10 +12,6 @@ declare interface RouteInfo {
 }
 export const ROUTES: RouteInfo[] = [
   { path: '/dashboard/investment', title: 'Inversión', icon: 'text-primary', class: '', isForAdmin: false },
-  { path: '/dashboard/argentina', title: 'Argentina', icon: 'text-primary', class: '', isForAdmin: false },
-  { path: '/dashboard/colombia', title: 'Colombia', icon: 'text-primary', class: '', isForAdmin: false },
-  { path: '/dashboard/mexico', title: 'México', icon: 'text-primary', class: '', isForAdmin: false },
-  { path: '/dashboard/users', title: 'Administrar usuarios', icon: 'text-primary', class: '', isForAdmin: true },
   // { path: '/chart-js', title: 'chart.js', icon: 'ni-chart-bar-32 text-primary', class: '' },
   // { path: '/amcharts', title: 'amcharts', icon: 'ni-chart-pie-35 text-primary', class: '' },
   // { path: '/icons', title: 'Icons', icon: 'ni-planet text-blue', class: '' },
@@ -30,24 +27,69 @@ export const ROUTES: RouteInfo[] = [
   templateUrl: './sidebar.component.html',
   styleUrls: ['./sidebar.component.scss']
 })
-export class SidebarComponent implements OnInit {
+export class SidebarComponent implements OnInit, AfterViewInit {
 
   public menuItems: any[];
   public isCollapsed = true;
   public userIsAdmin: boolean;
+  public menuReqStatus: number = 0;
+  public errorMsg: string;
 
   constructor(
     private router: Router,
-    private userService: UserService
+    private userService: UserService,
+    private usersMngmtService: UsersMngmtService
   ) { }
 
-  ngOnInit() {
+  async ngAfterViewInit() {
     this.userIsAdmin = this.userService.isAdmin();
 
-    this.menuItems = ROUTES.filter(menuItem => menuItem);
+    this.menuItems = ROUTES;
     this.router.events.subscribe((event) => {
       this.isCollapsed = true;
     });
+
+    await this.getAvailableRoutes();
+
+    // Admin routes
+    const menuItem = {
+      path: '/dashboard/users',
+      title: 'Administrar usuarios',
+      icon: 'text-primary',
+      class: '',
+      isForAdmin: true
+    }
+    this.menuItems.push(menuItem);
+  }
+
+  ngOnInit() { }
+
+  getAvailableRoutes() {
+    this.menuReqStatus = 1;
+
+    return this.usersMngmtService.getCountries()
+      .toPromise()
+      .then((resp: any[]) => {
+        for (let country of resp) {
+          const menuItem = {
+            path: `/dashboard/${country.name.toLowerCase()}`,
+            title: country.name,
+            icon: 'text-primary',
+            class: '',
+            isForAdmin: false
+          }
+
+          this.menuItems.push(menuItem);
+          this.errorMsg && delete this.errorMsg;
+          this.menuReqStatus = 2;
+        }
+      })
+      .catch(error => {
+        this.errorMsg = error?.error?.message ? error.error.message : error?.message
+        console.error(this.errorMsg);
+        this.menuReqStatus = 3;
+        this.router.navigate(['dashboard/investment']);
+      });
   }
 
   logout() {

--- a/src/app/layouts/admin-layout/admin-layout.routing.ts
+++ b/src/app/layouts/admin-layout/admin-layout.routing.ts
@@ -18,9 +18,11 @@ export const AdminLayoutRoutes: Routes = [
     { path: 'tables', component: TablesComponent },
     { path: 'icons', component: IconsComponent },
     { path: 'maps', component: MapsComponent },
-    { path: 'argentina', component: ChartJsComponent },
-    { path: 'colombia', component: AmchartsComponent },
+    { path: 'argentina', component: AmchartsComponent },
+    { path: 'brasil', component: ChartJsComponent },
+    { path: 'colombia', component: ChartJsComponent },
     { path: 'mexico', component: ChartJsComponent },
+    { path: 'panama', component: ChartJsComponent },
     {
         path: 'users',
         component: UsersMngmtComponent,


### PR DESCRIPTION
# Problem Description
- Adapt sidebar in order to show only available countries based on user permissions.

# Features
- Add request GET to `/countries` in sidebar component to show only the countries which the user has access
- Show sidebar items only after request is response
- Show error message after an error in request

# Where this change will be used
- In dashboard sidebar at `/dashboard` path

# More details
- View of sidebar for an user with admin role (with access to all countries)
![image](https://user-images.githubusercontent.com/38545126/114207229-c4d20200-9921-11eb-9721-d6adc1df704e.png)

- View of sidebar for an user with country role (with specific countries)
![image](https://user-images.githubusercontent.com/38545126/114207443-ff3b9f00-9921-11eb-8a70-003c9c0bf751.png)

- View when there's an error in GET `/countries` request (with admin role)
![image](https://user-images.githubusercontent.com/38545126/114207646-3611b500-9922-11eb-8e19-78cca00fd319.png)

