### PR TITLE
add sidebar behaviour for users with role admin, hp and country

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { SessionInterceptor } from './services/interceptor.service';
 import { LoginGuard } from './login.guard';
 import { ConfigurationProvider } from './app.constants';
 import { SharedModule } from './modules/shared/shared.module';
+import { AppStateService } from './services/app-state.service';
 
 @NgModule({
   imports: [
@@ -45,6 +46,7 @@ import { SharedModule } from './modules/shared/shared.module';
     UserService,
     CookieService,
     LoginGuard,
+    AppStateService,
     {
       provide: HTTP_INTERCEPTORS,
       useClass: SessionInterceptor,

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -10,7 +10,7 @@ import { LoginGuard } from './login.guard';
 const routes: Routes = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
   {
-    path: 'dashboard',
+    path: '',
     component: AdminLayoutComponent,
     children: [
       {

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -5,7 +5,6 @@
       [routerLink]="['/dashboard/investment']">
 
       {{ customTitle ? customTitle + (customSubtitle ? ' - ' + customSubtitle : '') : getTitleByRoute() }}
-      <!-- {{getTitleByRoute()}} -->
     </a>
     <!-- User -->
     <ul class="navbar-nav align-items-center d-none d-md-flex">

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -2,7 +2,11 @@
   <div class="container-fluid">
     <!-- Brand -->
     <a class="h4 mb-0 text-white text-uppercase d-none d-lg-inline-block" routerLinkActive="active"
-      [routerLink]="['/dashboard/investment']">{{getTitle()}}</a>
+      [routerLink]="['/dashboard/investment']">
+
+      {{ customTitle ? customTitle + (customSubtitle ? ' - ' + customSubtitle : '') : getTitleByRoute() }}
+      <!-- {{getTitleByRoute()}} -->
+    </a>
     <!-- User -->
     <ul class="navbar-nav align-items-center d-none d-md-flex">
       <li class="nav-item" ngbDropdown placement="bottom-right">

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -3,6 +3,7 @@ import { Location } from '@angular/common';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/models/user';
 import { AppStateService } from 'src/app/services/app-state.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-navbar',
@@ -22,13 +23,16 @@ export class NavbarComponent implements OnInit {
   constructor(
     location: Location,
     private userService: UserService,
-    private appStateService: AppStateService
+    private appStateService: AppStateService,
+    private route: ActivatedRoute,
   ) {
     this.location = location;
   }
 
   ngOnInit() {
     this.user = this.userService.user;
+
+    this.getTitlesByParams();
 
     // sidebar titles
     this.appStateService.sidebarData$.subscribe(resp => {
@@ -51,6 +55,14 @@ export class NavbarComponent implements OnInit {
     }, error => {
       console.error(`[navbar.component]: ${error}`);
     });
+  }
+
+  getTitlesByParams() {
+    const params = this.route.snapshot.queryParams;
+    if (params['country'] || params['retailer']) {
+      this.customTitle = params['country'];
+      this.customSubtitle = params['retailer'];
+    }
   }
 
   getTitleByRoute() {

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,9 +1,8 @@
-import { Component, OnInit, ElementRef } from '@angular/core';
-import { ROUTES } from '../sidebar/sidebar.component';
-import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
-import { Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Location } from '@angular/common';
 import { UserService } from 'src/app/services/user.service';
 import { User } from 'src/app/models/user';
+import { AppStateService } from 'src/app/services/app-state.service';
 
 @Component({
   selector: 'app-navbar',
@@ -12,24 +11,49 @@ import { User } from 'src/app/models/user';
 })
 export class NavbarComponent implements OnInit {
   public focus;
-  public listTitles: any[];
+  public listTitles: any[] = [];
   public location: Location;
   public user: User;
+  public customTitle: string;
+  public customSubtitle: string;
+  public routes: any[] = [];
+
 
   constructor(
     location: Location,
-    private element: ElementRef,
-    private router: Router,
-    private userService: UserService
+    private userService: UserService,
+    private appStateService: AppStateService
   ) {
     this.location = location;
   }
 
   ngOnInit() {
-    this.listTitles = ROUTES.filter(listTitle => listTitle);
     this.user = this.userService.user;
+
+    // sidebar titles
+    this.appStateService.sidebarData$.subscribe(resp => {
+      this.routes = resp;
+      this.listTitles = this.routes.filter(listTitle => listTitle);
+    }, error => {
+      console.error(`[navbar.component]: ${error}`);
+    })
+
+    // custom title
+    this.appStateService.selectedCountry$.subscribe(resp => {
+      this.customTitle = resp;
+    }, error => {
+      console.error(`[navbar.component]: ${error}`);
+    });
+
+    // custom subtitle
+    this.appStateService.selectedRetailer$.subscribe(resp => {
+      this.customSubtitle = resp;
+    }, error => {
+      console.error(`[navbar.component]: ${error}`);
+    });
   }
-  getTitle() {
+
+  getTitleByRoute() {
     var titlee = this.location.prepareExternalUrl(this.location.path());
     if (titlee.charAt(0) === '#') {
       titlee = titlee.slice(1);

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -71,10 +71,25 @@
       <ul class="navbar-nav" *ngIf="menuReqStatus >= 2">
         <ng-container *ngFor="let menuItem of menuItems">
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
-            <a routerLinkActive="active" [routerLink]="[menuItem.path]" class="nav-link">
-              <i class="ni {{menuItem.icon}}"></i>
-              {{menuItem.title}}
+            <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItem === selectedItem }"
+              (click)="selectItem(menuItem, 1)">
+              <!-- caret for submenus -->
+              <i *ngIf="menuItem.submenu" class="fas fa-caret-right menu-caret"></i>
+
+              <!-- custom icon -->
+              <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i>
+
+              {{ menuItem.title | titlecase }}
             </a>
+
+            <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">
+              <li class="{{menuItemL2.class}} nav-item" *ngFor="let menuItemL2 of menuItem.submenu">
+                <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItemL2 === selectedSubItem }"
+                  (click)="selectItem(menuItemL2, 2, menuItem);">
+                  {{ menuItemL2.title | titlecase }}
+                </a>
+              </li>
+            </ul>
           </li>
         </ng-container>
       </ul>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -74,7 +74,8 @@
             <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItem === selectedItem }"
               (click)="selectItem(menuItem)">
               <!-- caret for submenus -->
-              <i *ngIf="menuItem.submenu" class="fas fa-caret-right menu-caret"></i>
+              <i [hidden]="!menuItem.submenu || menuItem.submenuOpen" class="menu-caret fas fa-caret-right"></i>
+              <i [hidden]="!menuItem.submenuOpen" class="menu-caret fas fa-caret-down"></i>
 
               <!-- custom icon -->
               <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -72,7 +72,7 @@
         <ng-container *ngFor="let menuItem of menuItems">
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
             <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItem === selectedItem }"
-              (click)="selectItem(menuItem, 1)">
+              (click)="selectItem(menuItem)">
               <!-- caret for submenus -->
               <i *ngIf="menuItem.submenu" class="fas fa-caret-right menu-caret"></i>
 
@@ -85,7 +85,7 @@
             <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">
               <li class="{{menuItemL2.class}} nav-item" *ngFor="let menuItemL2 of menuItem.submenu">
                 <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItemL2 === selectedSubItem }"
-                  (click)="selectItem(menuItemL2, 2, menuItem);">
+                  (click)="selectItem(menuItemL2, menuItem);">
                   {{ menuItemL2.title | titlecase }}
                 </a>
               </li>

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -11,7 +11,7 @@ li {
 }
 
 .menu-caret {
-    min-width: 1rem !important;
+    min-width: 1.5rem !important;
 }
 
 ::-webkit-scrollbar {

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -1,3 +1,25 @@
 .text-danger {
     line-height: 1rem; 
 }
+
+li {
+    cursor: pointer;
+}
+
+.navbar-sub-nav {
+    list-style: none;
+}
+
+.menu-caret {
+    min-width: 1rem !important;
+}
+
+::-webkit-scrollbar {
+    width: 6px;
+}
+
+@media (min-width: 768px) {
+    .navbar-vertical.navbar-expand-md .navbar-nav .nav-link {
+        padding: 0.65rem 2rem !important;
+    }
+}

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -13,6 +13,7 @@ declare interface RouteInfo {
   submenu?: RouteInfo[];
   submenuOpen?: boolean;
   level: number;
+  levelName?: string;
 }
 
 export const ROUTES = [
@@ -82,7 +83,8 @@ export class SidebarComponent implements OnInit, AfterViewInit {
             isForAdmin: false,
             submenu: [],
             submenuOpen: false,
-            level: 2
+            level: 2,
+            levelName: 'country',
           }
 
           this.menuItems.push(menuItem);
@@ -108,19 +110,27 @@ export class SidebarComponent implements OnInit, AfterViewInit {
       }
     }
 
+    let queryParams;
+
     if (menuLevel === 1) {
       this.selectedItem !== item && delete this.selectedSubItem;
       this.selectedItem = item;
 
+      queryParams = { [this.selectedItem.levelName]: this.selectedItem.param };
+
     } else if (menuLevel === 2) {
       this.selectedItem = parent;
       this.selectedSubItem = item;
+
+      queryParams = {
+        [this.selectedItem.levelName]: this.selectedItem.param,
+        [this.selectedSubItem.levelName]: this.selectedSubItem.param
+      };
     }
 
     if (item.path) {
       if (item.param) {
-        this.router.navigate([item.path, item.param]);
-
+        this.router.navigate([item.path], { queryParams: queryParams });
       } else {
         this.router.navigate([item.path]);
       }
@@ -140,7 +150,8 @@ export class SidebarComponent implements OnInit, AfterViewInit {
             param: item.name.toLowerCase(),
             title: item.name,
             isForAdmin: false,
-            level: 3
+            level: 3,
+            levelName: 'retailer',
           }
         })
 

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -92,7 +92,7 @@ export class SidebarComponent implements OnInit, AfterViewInit {
         }
 
       } else if (retailer) {
-        // existe retailer pero no country   -> retailer role
+        // retailer role
       }
     }
     else {
@@ -165,7 +165,7 @@ export class SidebarComponent implements OnInit, AfterViewInit {
       }
     }
 
-    // probablelemente aqui sse tenga que mandar un id tambien
+    // consider the possibility to add id property
     switch (item.levelName) {
       case 'country':
         this.appStateService.selectCountry(this.selectedItem.title);
@@ -181,14 +181,13 @@ export class SidebarComponent implements OnInit, AfterViewInit {
         this.appStateService.selectCountry();
         this.appStateService.selectRetailer();
     }
-  } s
+  }
 
   getAvailableRetailers() {
     // add country as a param in the requests
     return this.usersMngmtService.getRetailers()
       .toPromise()
       .then((retailers: any[]) => {
-        // console.log('retailers', retailers);
         let menuItem: RouteInfo[];
         menuItem = retailers.map(item => {
           return {

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -12,7 +12,6 @@ declare interface RouteInfo {
   isForAdmin: boolean;
   submenu?: RouteInfo[];
   submenuOpen?: boolean;
-  level: number;
   levelName?: string;
 }
 
@@ -20,8 +19,7 @@ export const ROUTES = [
   {
     path: '/dashboard/investment',
     title: 'Inversión',
-    isForAdmin: false,
-    level: 1
+    isForAdmin: false
   }
 ]
 
@@ -61,8 +59,7 @@ export class SidebarComponent implements OnInit, AfterViewInit {
     const menuItem = {
       path: '/dashboard/users',
       title: 'Administrar usuarios',
-      isForAdmin: true,
-      level: 1
+      isForAdmin: true
     }
     this.menuItems.push(menuItem);
   }
@@ -83,7 +80,6 @@ export class SidebarComponent implements OnInit, AfterViewInit {
             isForAdmin: false,
             submenu: [],
             submenuOpen: false,
-            level: 2,
             levelName: 'country',
           }
 
@@ -100,25 +96,22 @@ export class SidebarComponent implements OnInit, AfterViewInit {
       });
   }
 
-  async selectItem(item, menuLevel, parent?) {
+  async selectItem(item, parent?) {
     if (item.submenu) {
       // if country already has a a submenu.lenght>1 avoid this requests
       item.submenu = await this.getAvailableRetailers()
-
-      if (menuLevel === 1) {
-        item.submenuOpen = !item.submenuOpen;
-      }
+      item.submenuOpen = !item.submenuOpen;
     }
 
     let queryParams;
 
-    if (menuLevel === 1) {
+    if (!parent) {
       this.selectedItem !== item && delete this.selectedSubItem;
       this.selectedItem = item;
 
       queryParams = { [this.selectedItem.levelName]: this.selectedItem.param };
 
-    } else if (menuLevel === 2) {
+    } else {
       this.selectedItem = parent;
       this.selectedSubItem = item;
 
@@ -150,7 +143,6 @@ export class SidebarComponent implements OnInit, AfterViewInit {
             param: item.name.toLowerCase(),
             title: item.name,
             isForAdmin: false,
-            level: 3,
             levelName: 'retailer',
           }
         })

--- a/src/app/layouts/admin-layout/admin-layout.module.ts
+++ b/src/app/layouts/admin-layout/admin-layout.module.ts
@@ -12,6 +12,7 @@ import { MapsComponent } from '../../pages/maps/maps.component';
 import { UserProfileComponent } from '../../pages/user-profile/user-profile.component';
 import { TablesComponent } from '../../pages/tables/tables.component';
 import { UsersMngmtGuard } from 'src/app/modules/users-mngmt/users-mngmt.guard';
+import { DashboardModule } from 'src/app/modules/dashboard/dashboard.module';
 
 // import { ToastrModule } from 'ngx-toastr';
 
@@ -21,7 +22,8 @@ import { UsersMngmtGuard } from 'src/app/modules/users-mngmt/users-mngmt.guard';
     RouterModule.forChild(AdminLayoutRoutes),
     NgbModule,
     ClipboardModule,
-    UsersMngmtModule
+    UsersMngmtModule,
+    DashboardModule
   ],
   declarations: [
     DashboardComponent,

--- a/src/app/layouts/admin-layout/admin-layout.routing.ts
+++ b/src/app/layouts/admin-layout/admin-layout.routing.ts
@@ -11,7 +11,6 @@ import { UsersMngmtComponent } from 'src/app/modules/users-mngmt/users-mngmt.com
 import { UsersMngmtGuard } from 'src/app/modules/users-mngmt/users-mngmt.guard';
 
 export const AdminLayoutRoutes: Routes = [
-    { path: 'investment', component: DashboardComponent },
     { path: 'chart-js', component: ChartJsComponent },
     { path: 'amcharts', component: AmchartsComponent },
     { path: 'user-profile', component: UserProfileComponent },
@@ -24,7 +23,15 @@ export const AdminLayoutRoutes: Routes = [
     { path: 'mexico', component: ChartJsComponent },
     { path: 'panama', component: ChartJsComponent },
     {
-        path: 'users',
+        path: 'dashboard',
+        component: UsersMngmtComponent,
+        loadChildren: () =>
+            import('src/app/modules/dashboard/dashboard.module').then(
+                m => m.DashboardModule
+            )
+    },
+    {
+        path: 'dashboard/users',
         component: UsersMngmtComponent,
         loadChildren: () =>
             import('src/app/modules/users-mngmt/users-mngmt.module').then(

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { CountryComponent } from './pages/country/country.component';
+import { RetailerComponent } from './pages/retailer/retailer.component';
+import { RouterModule } from '@angular/router';
+import { DashboardRoutes } from './dashboard.routing';
+
+
+
+@NgModule({
+  declarations: [CountryComponent, RetailerComponent],
+  imports: [
+    CommonModule,
+    RouterModule.forChild(DashboardRoutes),
+  ]
+})
+export class DashboardModule { }

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -6,6 +6,6 @@ import { RetailerComponent } from './pages/retailer/retailer.component';
 
 export const DashboardRoutes: Routes = [
     { path: 'investment', component: DashboardComponent },
-    { path: 'country/:country_id', component: CountryComponent },
-    { path: 'retailer/:retailer_id', component: RetailerComponent },
+    { path: 'country', component: CountryComponent },
+    { path: 'retailer', component: RetailerComponent },
 ];

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -1,0 +1,11 @@
+import { Routes } from '@angular/router';
+
+import { DashboardComponent } from '../../pages/dashboard/dashboard.component';
+import { CountryComponent } from './pages/country/country.component';
+import { RetailerComponent } from './pages/retailer/retailer.component';
+
+export const DashboardRoutes: Routes = [
+    { path: 'investment', component: DashboardComponent },
+    { path: 'country/:country_id', component: CountryComponent },
+    { path: 'retailer/:retailer_id', component: RetailerComponent },
+];

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,0 +1,1 @@
+<p>country works!</p>

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,1 +1,7 @@
-<p>country works!</p>
+<div class="main-container mt-4">
+    <div class="row">
+        <div class="col-12">
+            <p class="text-uppercase text-muted mb-4"><b>{{ countryName }} - Visión general</b></p>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/pages/country/country.component.spec.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CountryComponent } from './country.component';
+
+describe('CountryComponent', () => {
+  let component: CountryComponent;
+  let fixture: ComponentFixture<CountryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CountryComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CountryComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-country',
+  templateUrl: './country.component.html',
+  styleUrls: ['./country.component.scss']
+})
+export class CountryComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-country',
@@ -6,10 +8,13 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./country.component.scss']
 })
 export class CountryComponent implements OnInit {
+  countryName: string;
 
-  constructor() { }
+  constructor(private route: ActivatedRoute) { }
 
   ngOnInit(): void {
+    this.route.queryParams.subscribe((params: Params) => {
+      this.countryName = params['country'];
+    });
   }
-
 }

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -1,0 +1,1 @@
+<p>retailer works!</p>

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -1,1 +1,9 @@
-<p>retailer works!</p>
+<div class="main-container mt-4">
+    <div class="row">
+        <div class="col-12">
+            <p class="text-uppercase text-muted mb-4"><b>{{ retailerName }}</b>
+                <small class="ml-2">{{ countryName }}</small>
+            </p>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.spec.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RetailerComponent } from './retailer.component';
+
+describe('RetailerComponent', () => {
+  let component: RetailerComponent;
+  let fixture: ComponentFixture<RetailerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ RetailerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RetailerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-retailer',
+  templateUrl: './retailer.component.html',
+  styleUrls: ['./retailer.component.scss']
+})
+export class RetailerComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
 
 @Component({
   selector: 'app-retailer',
@@ -7,9 +8,16 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RetailerComponent implements OnInit {
 
-  constructor() { }
+  countryName;
+  retailerName;
+
+  constructor(private route: ActivatedRoute) { }
 
   ngOnInit(): void {
+    this.route.queryParams.subscribe((params: Params) => {
+      this.countryName = params['country'];
+      this.retailerName = params['retailer']
+    });
   }
 
 }

--- a/src/app/services/app-state.service.spec.ts
+++ b/src/app/services/app-state.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AppStateService } from './app-state.service';
+
+describe('AppStateService', () => {
+  let service: AppStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppStateService {
+
+  // sidebar
+  private sidebarSource = new Subject<any>();
+  sidebarData$ = this.sidebarSource.asObservable();
+
+  // selected country
+  private countrySource = new Subject<any>();
+  selectedCountry$ = this.countrySource.asObservable();
+
+  // selected retailer
+  private retailerSource = new Subject<any>();
+  selectedRetailer$ = this.retailerSource.asObservable();
+
+  constructor() { }
+
+  selectCountry(country?) {
+    if (country) {
+      this.countrySource.next(country);
+    } else {
+      this.countrySource.next();
+    }
+  }
+
+  selectRetailer(retailer?) {
+    if (retailer) {
+      this.retailerSource.next(retailer);
+    } else {
+      this.retailerSource.next();
+    }
+
+  }
+
+  updateSidebarData(data) {
+    this.sidebarSource.next(data);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -112,6 +112,20 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
 
 // **** OTHERS ****
 
+// *** sidebar ***
+::-webkit-scrollbar-track {
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  background-color: #F5F5F5;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: #dee2e6;
+}
+
 // *** loaders ***
 @keyframes indeterm-shimmer {
   0% {


### PR DESCRIPTION
# Problem Description
-  In sidebar for users with admin, hp and country roles is necessary to show countries list as options and retailers as its subotions.

# Features
- Show countries and retailers in sidebar component (load retailers after a country is selected)
- Create dashboard module with country and retailer components as pages
- Use query params to access to country and retailer components
- Save sidebar selection (item and if sub-tiem; if applies) in app-state service and share this data with navbar component
- Preselect sidebar selection and titles in navbar (it works after page reload or select a default item after a real user selection)

# Where this change will be used
- In dashboard module and its pages at `/dashboard/*` path

# More details
- Sidebar without user selection (page loaded after login)
![image](https://user-images.githubusercontent.com/38545126/114607748-8494bb80-9c62-11eb-9860-b2e41a06bf18.png)

- Sidebar after select some country
![image](https://user-images.githubusercontent.com/38545126/114607618-5fa04880-9c62-11eb-8f83-98cb12ca0a94.png)

- Sidebar after select some retailer
![image](https://user-images.githubusercontent.com/38545126/114607659-6af37400-9c62-11eb-89b4-27e89efbc3fe.png)
