### PR TITLE
add sidebar behaviour for users with retailer role

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -45,6 +45,7 @@ export class NavbarComponent implements OnInit {
     // custom title
     this.appStateService.selectedCountry$.subscribe(resp => {
       this.customTitle = resp;
+      this.customizeTitle();
     }, error => {
       console.error(`[navbar.component]: ${error}`);
     });
@@ -52,6 +53,7 @@ export class NavbarComponent implements OnInit {
     // custom subtitle
     this.appStateService.selectedRetailer$.subscribe(resp => {
       this.customSubtitle = resp;
+      this.customizeTitle();
     }, error => {
       console.error(`[navbar.component]: ${error}`);
     });
@@ -62,6 +64,7 @@ export class NavbarComponent implements OnInit {
     if (params['country'] || params['retailer']) {
       this.customTitle = params['country'];
       this.customSubtitle = params['retailer'];
+      this.customizeTitle();
     }
   }
 
@@ -81,6 +84,13 @@ export class NavbarComponent implements OnInit {
       }
     }
     return 'Dashboard';
+  }
+
+  customizeTitle() {
+    if (!this.customTitle && this.customSubtitle) {
+      this.customTitle = this.customSubtitle;
+      delete this.customSubtitle;
+    }
   }
 
   logout() {


### PR DESCRIPTION
# Problem Description
- In sidebar for users with retailer role is necessary to show retailers list as options

# Features
- Show retailers list in sidebar when the user role is **country**
- Show countries list in sidebar when the user role is **admin**, **hp** or **country**
- Preselect sidebar selection and titles in navbar (it works after page reload or select a default item after a real user selection)

# Where this change will be used
- In dashboard module and its pages at `/dashboard/*` path

# More details
- Sidebar view:
![image](https://user-images.githubusercontent.com/38545126/114624184-ee6a9080-9c75-11eb-99a0-58ad39ccf884.png)


