### PR TITLE
work in sidebar behaviour details

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -83,7 +83,7 @@
               {{ menuItem.title | titlecase }}
             </a>
 
-            <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">
+            <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen && submenuReqStatus === 2">
               <li class="{{menuItemL2.class}} nav-item" *ngFor="let menuItemL2 of menuItem.submenu">
                 <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItemL2 === selectedSubItem }"
                   (click)="selectItem(menuItemL2, menuItem);">
@@ -95,9 +95,10 @@
         </ng-container>
       </ul>
 
-      <div class="text-danger mt-5 pl-3 pr-3" *ngIf="menuReqStatus === 3">
+      <div class="text-danger mt-5 pl-3 pr-3" *ngIf="menuReqStatus === 3 || submenuReqStatus === 3">
         <small>
-          Ocurrió un error al consultar los países o retailers a los que tienes acceso. Intenta más tarde.
+          Ocurrió un error al consultar los {{ userRole === 'retailer' ? 'retailers' : 'países o retailers' }} a los que
+          tienes acceso. Intenta más tarde.
         </small>
       </div>
 

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -147,7 +147,7 @@ export class SidebarComponent implements OnInit, AfterViewInit {
 
   getAvailableRetailers() {
     this.submenuReqStatus = 1;
-    // add country as a param in the requests sería opcional
+    // add country as an optional param in the requests
     return this.usersMngmtService.getRetailers()
       .toPromise()
       .then((retailers: any[]) => {
@@ -175,8 +175,9 @@ export class SidebarComponent implements OnInit, AfterViewInit {
 
   async selectItem(item, parent?) {
     if (item.submenu && item.levelName === 'country') {
-      // if country already has a a submenu.lenght>1 avoid this requests
-      item.submenu = await this.getAvailableRetailers();
+      if (item.submenu.length < 1) {
+        item.submenu = await this.getAvailableRetailers();
+      }
       item.submenuOpen = !item.submenuOpen;
     }
 

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -31,15 +31,16 @@ export const ROUTES = [
 })
 export class SidebarComponent implements OnInit, AfterViewInit {
 
-  public menuItems: any[];
-  public isCollapsed = true;
+  public userRole: string;
   public userIsAdmin: boolean;
-  public menuReqStatus: number = 0;
-  public errorMsg: string;
 
-  userRole: string;
-  selectedItem: RouteInfo;
-  selectedSubItem: RouteInfo;
+  public menuItems: any[];
+  public selectedItem: RouteInfo;
+  public selectedSubItem: RouteInfo;
+  public menuReqStatus: number = 0;
+  public submenuReqStatus: number = 0;
+  public isCollapsed = true;
+
 
   constructor(
     private router: Router,
@@ -58,12 +59,20 @@ export class SidebarComponent implements OnInit, AfterViewInit {
       this.isCollapsed = true;
     });
 
-    if (this.userRole === 'admin' || this.userRole === 'hp' || this.userRole === 'country') {
-      await this.getAvailableCountries();
-    } else if (this.userRole === 'retailer') {
-      const newMenuItems = await this.getAvailableRetailers();
-      this.menuItems = [... this.menuItems, ...newMenuItems];
+    try {
+      this.menuReqStatus = 1;
+      if (this.userRole === 'admin' || this.userRole === 'hp' || this.userRole === 'country') {
+        await this.getAvailableCountries();
+      } else if (this.userRole === 'retailer') {
+        const newMenuItems = await this.getAvailableRetailers();
+        this.menuItems = [... this.menuItems, ...newMenuItems];
+      }
+      this.menuReqStatus = 2;
+
+    } catch (error) {
+      this.menuReqStatus = 3;
     }
+
 
     // Admin routes
     const menuItem = {
@@ -110,8 +119,6 @@ export class SidebarComponent implements OnInit, AfterViewInit {
   }
 
   getAvailableCountries() {
-    this.menuReqStatus = 1;
-
     return this.usersMngmtService.getCountries()
       .toPromise()
       .then((resp: any[]) => {
@@ -129,19 +136,17 @@ export class SidebarComponent implements OnInit, AfterViewInit {
           this.menuItems.push(menuItem);
         }
         this.appStateService.updateSidebarData(this.menuItems);
-        this.errorMsg && delete this.errorMsg;
-        this.menuReqStatus = 2;
       })
       .catch(error => {
-        this.errorMsg = error?.error?.message ? error.error.message : error?.message
-        console.error(this.errorMsg);
-        this.menuReqStatus = 3;
+        const errMsg = error?.error?.message ? error.error.message : error?.message;
         this.router.navigate(['dashboard/investment']);
+        console.error(`[sidebar.component]: ${errMsg}`);
+        throw (new Error(errMsg));
       });
   }
 
   getAvailableRetailers() {
-    this.menuReqStatus = 1;
+    this.submenuReqStatus = 1;
     // add country as a param in the requests sería opcional
     return this.usersMngmtService.getRetailers()
       .toPromise()
@@ -157,13 +162,14 @@ export class SidebarComponent implements OnInit, AfterViewInit {
           }
         })
 
-        this.menuReqStatus = 2;
+        this.submenuReqStatus = 2;
         return menuItems;
       })
       .catch(error => {
-        console.error(`[sidebar.component]: ${error}`);
-        this.menuReqStatus = 3;
-        throw (new Error(error));
+        const errMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[sidebar.component]: ${errMsg}`);
+        this.submenuReqStatus = 3;
+        throw (new Error(errMsg));
       });
   }
 


### PR DESCRIPTION
# Problem Description
- For cases which countries o retailers requests fail is necessary show an error message
- Avoid making multiple requests when a option (country) is selected to get its retailers

# Features
- Handle error request for countries and retailers endpoints
- Get retailers by country only when there isn't retailers saved in object property

# Where this change will be used
- In dashboard module and its pages at `/dashboard/*` path