### PR TITLE
use general-filters component in dashboard base component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -676,6 +676,14 @@
         "tslib": "^2.0.0"
       }
     },
+    "@angular/material-moment-adapter": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/@angular/material-moment-adapter/-/material-moment-adapter-11.2.8.tgz",
+      "integrity": "sha512-zSwaYkp3M/8r+igcnPrUp9gsbXMxT68hdx22wTfsOKUG/iL8nEXhrRoQLtc74lM4Pp9vS7yvP0fpATj9eZnnAg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@angular/platform-browser": {
       "version": "10.1.4",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-10.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@angular/http": "7.2.16",
     "@angular/localize": "^10.1.4",
     "@angular/material": "^10.2.7",
+    "@angular/material-moment-adapter": "^11.2.8",
     "@angular/platform-browser": "10.1.4",
     "@angular/platform-browser-dynamic": "10.1.4",
     "@angular/router": "10.1.4",

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -1,20 +1,34 @@
 <div class="row">
-    <div class="col-4">
-        <mat-select placeholder="Select a sector" [(value)]="selectedSector">
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="text-muted mb-1"><b>Periodo</b></small>
+        <mat-form-field appearance="fill">
+            <mat-date-range-input [rangePicker]="picker">
+                <input matStartDate placeholder="Fecha inicio">
+                <input matEndDate placeholder="Fecha fin">
+            </mat-date-range-input>
+            <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+            <mat-date-range-picker #picker></mat-date-range-picker>
+        </mat-form-field>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="text-muted mb-1"><b>Sector</b></small>
+        <mat-select [(value)]="selectedSector" placeholder="Selecciona un sector">
             <mat-option *ngFor="let sector of sectors" [value]="sector">
                 {{ sector.name }}
             </mat-option>
         </mat-select>
     </div>
-    <div class="col-4">
-        <mat-select placeholder="Select a category" [(value)]="selectedCategory">
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="text-muted mb-1"><b>Categoría</b></small>
+        <mat-select [(value)]="selectedCategory" placeholder="Selecciona una categoría">
             <mat-option *ngFor="let category of categories" [value]="category">
                 {{ category.name }}
             </mat-option>
         </mat-select>
     </div>
-    <div class="col-4">
-        <mat-select placeholder="Select a campaign" [(value)]="selectedCampaign">
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="text-muted mb-1"><b>Campaña</b></small>
+        <mat-select [(value)]="selectedCampaign" placeholder="Selecciona una campaña">
             <mat-option *ngFor="let campaign of campaigns" [value]="campaign">
                 {{ campaign.name }}
             </mat-option>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -1,0 +1,23 @@
+<div class="row">
+    <div class="col-4">
+        <mat-select placeholder="Select a sector" [(value)]="selectedSector">
+            <mat-option *ngFor="let sector of sectors" [value]="sector">
+                {{ sector.name }}
+            </mat-option>
+        </mat-select>
+    </div>
+    <div class="col-4">
+        <mat-select placeholder="Select a category" [(value)]="selectedCategory">
+            <mat-option *ngFor="let category of categories" [value]="category">
+                {{ category.name }}
+            </mat-option>
+        </mat-select>
+    </div>
+    <div class="col-4">
+        <mat-select placeholder="Select a campaign" [(value)]="selectedCampaign">
+            <mat-option *ngFor="let campaign of campaigns" [value]="campaign">
+                {{ campaign.name }}
+            </mat-option>
+        </mat-select>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.spec.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GeneralFiltersComponent } from './general-filters.component';
+
+describe('GeneralFiltersComponent', () => {
+  let component: GeneralFiltersComponent;
+  let fixture: ComponentFixture<GeneralFiltersComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ GeneralFiltersComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GeneralFiltersComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -1,10 +1,35 @@
 import { Component, OnInit } from '@angular/core';
 import { UsersMngmtService } from 'src/app/modules/users-mngmt/services/users-mngmt.service';
+import { MomentDateAdapter, MAT_MOMENT_DATE_ADAPTER_OPTIONS } from '@angular/material-moment-adapter';
+import { DateAdapter, MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
+
+
+export const MY_FORMATS = {
+  parse: {
+    dateInput: ['YYYY-MM-DD']
+  },
+  display: {
+    dateInput: 'DD-MM-YYYY',
+    monthYearLabel: 'MMM YYYY',
+    dateA11yLabel: 'LL',
+    monthYearA11yLabel: 'MMMM YYYY',
+  },
+};
+
 
 @Component({
   selector: 'app-general-filters',
   templateUrl: './general-filters.component.html',
-  styleUrls: ['./general-filters.component.scss']
+  styleUrls: ['./general-filters.component.scss'],
+  providers: [
+    {
+      provide: DateAdapter,
+      useClass: MomentDateAdapter,
+      deps: [MAT_DATE_LOCALE, MAT_MOMENT_DATE_ADAPTER_OPTIONS]
+    },
+
+    { provide: MAT_DATE_FORMATS, useValue: MY_FORMATS },
+  ],
 })
 export class GeneralFiltersComponent implements OnInit {
 
@@ -49,14 +74,21 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   getCampaigns() {
-    this.usersMngmtService.getCategories()
-      .subscribe(
-        (res: any[]) => {
-          this.campaigns = res;
-        },
-        error => {
-          console.error(`[general-filers.component]: ${error}`);
-        }
-      );
+    // this.usersMngmtService.getCategories()
+    //   .subscribe(
+    //     (res: any[]) => {
+    //       this.campaigns = res;
+    //     },
+    //     error => {
+    //       console.error(`[general-filers.component]: ${error}`);
+    //     }
+    //   );
+
+    this.campaigns = [
+      { id: 1, name: 'Campaña 1' },
+      { id: 2, name: 'Campaña 2' },
+      { id: 3, name: 'Campaña 3' },
+      { id: 4, name: 'Campaña 4' }
+    ]
   }
 }

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -1,0 +1,62 @@
+import { Component, OnInit } from '@angular/core';
+import { UsersMngmtService } from 'src/app/modules/users-mngmt/services/users-mngmt.service';
+
+@Component({
+  selector: 'app-general-filters',
+  templateUrl: './general-filters.component.html',
+  styleUrls: ['./general-filters.component.scss']
+})
+export class GeneralFiltersComponent implements OnInit {
+
+  sectors: any[];
+  categories: any[];
+  campaigns: any[];
+
+  selectedSector: any;
+  selectedCategory: any;
+  selectedCampaign: any;
+
+  constructor(private usersMngmtService: UsersMngmtService) { }
+
+  ngOnInit(): void {
+    this.getSectors();
+    this.getCategories();
+    this.getCampaigns();
+  }
+
+  getSectors() {
+    this.usersMngmtService.getSectors()
+      .subscribe(
+        (res: any[]) => {
+          this.sectors = res;
+        },
+        error => {
+          console.error(`[general-filers.component]: ${error}`);
+        }
+      );
+  }
+
+  getCategories() {
+    this.usersMngmtService.getCategories()
+      .subscribe(
+        (res: any[]) => {
+          this.categories = res;
+        },
+        error => {
+          console.error(`[general-filers.component]: ${error}`);
+        }
+      );
+  }
+
+  getCampaigns() {
+    this.usersMngmtService.getCategories()
+      .subscribe(
+        (res: any[]) => {
+          this.campaigns = res;
+        },
+        error => {
+          console.error(`[general-filers.component]: ${error}`);
+        }
+      );
+  }
+}

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -2,9 +2,6 @@
 </div>
 
 <div class="container-fluid mt-4">
-    <div class="row">
-        <div class="col-12">
-            <router-outlet></router-outlet>
-        </div>
-    </div>
+    <app-general-filters></app-general-filters>
+    <router-outlet></router-outlet>
 </div>

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -7,6 +7,9 @@ import { RetailerComponent } from './pages/retailer/retailer.component';
 import { DashboardRoutes } from './dashboard.routing';
 import { GeneralFiltersComponent } from './components/general-filters/general-filters.component';
 import { MatSelectModule } from '@angular/material/select';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 
 
@@ -20,7 +23,11 @@ import { MatSelectModule } from '@angular/material/select';
   imports: [
     CommonModule,
     RouterModule.forChild(DashboardRoutes),
-    MatSelectModule
-  ]
+    MatSelectModule,
+    MatDatepickerModule,
+    MatNativeDateModule,
+    MatRippleModule
+  ],
+  providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { floatLabel: 'never' } }]
 })
 export class DashboardModule { }

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -5,6 +5,8 @@ import { DashboardComponent } from './dashboard.component';
 import { CountryComponent } from './pages/country/country.component';
 import { RetailerComponent } from './pages/retailer/retailer.component';
 import { DashboardRoutes } from './dashboard.routing';
+import { GeneralFiltersComponent } from './components/general-filters/general-filters.component';
+import { MatSelectModule } from '@angular/material/select';
 
 
 
@@ -12,11 +14,13 @@ import { DashboardRoutes } from './dashboard.routing';
   declarations: [
     DashboardComponent,
     CountryComponent,
-    RetailerComponent
+    RetailerComponent,
+    GeneralFiltersComponent
   ],
   imports: [
     CommonModule,
     RouterModule.forChild(DashboardRoutes),
+    MatSelectModule
   ]
 })
 export class DashboardModule { }

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -1,6 +1,5 @@
 import { Routes } from '@angular/router';
 
-import { InvestmentComponent } from '../../pages/investment/investment.component';
 import { CountryComponent } from './pages/country/country.component';
 import { RetailerComponent } from './pages/retailer/retailer.component';
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -74,6 +74,7 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
 
 // *** select ***
 .mat-select-trigger {
+  background-color: #ffffff;
   border-radius: 0.375rem;
   box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
   border: 0;
@@ -110,6 +111,86 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
 }
 
 
+// *** mat-form-field ***
+.mat-form-field  {
+  width: 100%;
+
+  &.mat-form-field-appearance-fill {
+    .mat-form-field-flex {
+      align-items: center;
+      background-color: #ffffff;
+      border-radius: 0.375rem;
+      box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
+      height: 41px;
+      padding: 0;
+    }
+  
+    .mat-form-field-infix {
+      border-top: none;
+      font-size: 14px;
+      padding: 0.625rem 0.75rem;
+    }
+  
+    .mat-form-field-underline {
+      position: initial;
+      &::before {
+        background-color: transparent;
+      }
+    }
+  
+    .mat-form-field-ripple {
+      height: 1px;
+    }
+  
+    &:not(.mat-form-field-disabled) .mat-form-field-flex:hover~.mat-form-field-underline .mat-form-field-ripple {
+      background-color: transparent; 
+    }
+  
+    .mat-datepicker-toggle button:focus {
+      outline: none;
+    }
+    
+    .mat-button-ripple-round {
+      background-color: transparent;
+    }
+    
+    .mat-icon-button.cdk-program-focused .mat-button-focus-overlay {
+      opacity: 0;
+    }
+    
+    .mat-start-date, .mat-date-range-input-inner {
+      color: #767676;
+      &::-webkit-input-placeholder {
+        color: rgba(0, 0, 0, 0.42);
+      }
+      
+      &:-ms-input-placeholder {
+        color: rgba(0, 0, 0, 0.42);
+      }
+      
+      &::placeholder {
+        color: rgba(0, 0, 0, 0.42);
+      }
+    }
+    
+    .mat-button-wrapper {
+      color: #adb5bd;
+      font-size: 14px;
+    }
+  } 
+
+  .mat-form-field-wrapper {
+    padding-bottom: 0;
+  }
+}
+
+.mat-form-field.mat-focused .mat-form-field-ripple {
+  background-color: transparent;
+  border-bottom: 1px solid #2196f3;
+  border-radius: 0.375rem;
+  height: 41px;
+}
+
 // **** OTHERS ****
 
 // *** sidebar ***
@@ -124,6 +205,14 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
 
 ::-webkit-scrollbar-thumb {
   background-color: #dee2e6;
+}
+
+// .mat-form-field-appearance-fill {
+//   height: 1px !important
+// }
+
+.mat-form-field-appearance-fill {
+  background-color: transparent !important;
 }
 
 // *** loaders ***


### PR DESCRIPTION
# Problem Description
- Is necessary that /country and /retailers pages share the same header. In this header general filters will be displayed 

# Features
- Create general-filters component
- Use angular material components to show selects and date range picker as filter
- Add custom styles for mat-date-range-input (Angular material component)

# Where this change will be used
- In `/dashboard/country` and `/dashboard/retailer` paths

# More details
![image](https://user-images.githubusercontent.com/38545126/114758416-8f168a00-9d22-11eb-8bee-fc031b9d2a3a.png)
![image](https://user-images.githubusercontent.com/38545126/114758465-9ccc0f80-9d22-11eb-9d74-276b0e2b265f.png)
