### PR TITLE
add basic template to country component

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,9 +1,8 @@
-<nav class="navbar navbar-top navbar-expand-md navbar-dark" id="navbar-main">
+<nav class="navbar navbar-expand-md sticky-top navbar-dark bg-primary " id="navbar-main">
+  <!-- navbar navbar-top navbar-expand-md navbar-dark sticky-top -->
   <div class="container-fluid">
     <!-- Brand -->
-    <a class="h4 mb-0 text-white text-uppercase d-none d-lg-inline-block" routerLinkActive="active"
-      [routerLink]="['/dashboard/investment']">
-
+    <a class="h4 mb-0 text-white text-uppercase d-none d-lg-inline-block" routerLinkActive="active">
       {{ customTitle ? customTitle + (customSubtitle ? ' - ' + customSubtitle : '') : getTitleByRoute() }}
     </a>
     <!-- User -->

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -13,7 +13,7 @@
         </div>
         <div class="submetric-container text-muted" *ngIf="stat.subMetricTitle">
             <div class="submetric-data">
-                <span class="text-nowrap h5 mr-2 text-muted">{{ stat.subMetricTitle }}</span>
+                <span class="text-nowrap h5 mr-2 text-muted text-uppercase">{{ stat.subMetricTitle }}</span>
                 <span>{{ stat.subMetricValue }}</span>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -1,0 +1,21 @@
+<div class="card card-stats mb-4 mb-xl-0">
+    <div class="card-body">
+        <div class="metric-container">
+            <div class="metric-data">
+                <h5 class="card-title text-uppercase text-muted mb-0">{{ stat.metricTitle }}</h5>
+                <span class="h3 font-weight-bold mb-0">{{ stat.metricValue }}</span>
+            </div>
+            <div class="metric-icon">
+                <div class="icon icon-shape text-white rounded-circle shadow" [style.background-color]="stat.iconBg">
+                    <i [ngClass]="stat.icon"></i>
+                </div>
+            </div>
+        </div>
+        <div class="submetric-container text-muted" *ngIf="stat.subMetricTitle">
+            <div class="submetric-data">
+                <span class="text-nowrap h5 mr-2 text-muted">{{ stat.subMetricTitle }}</span>
+                <span>{{ stat.subMetricValue }}</span>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
@@ -26,7 +26,6 @@
         width: 100%;
     
         .submetric-data {
-            border-top: 2px solid #e6e6e6;
             padding: 0.3rem 1.5rem; 
         }
     }

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
@@ -1,0 +1,33 @@
+.card-stats {
+    height: 120px;
+    overflow: hidden;
+    width: 100%;
+
+    .card-body {
+        padding: 0;
+    }
+    
+    .metric-container {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 16px;
+        padding: 1rem 1.5rem;
+
+        .icon {
+            height: 2rem;
+            width: 2rem;
+        }
+    }
+    
+    .submetric-container {
+        background-color: #f0f0f0;
+        bottom: 0;
+        position: absolute;
+        width: 100%;
+    
+        .submetric-data {
+            border-top: 2px solid #e6e6e6;
+            padding: 0.3rem 1.5rem; 
+        }
+    }
+}

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.spec.ts
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardStatComponent } from './card-stat.component';
+
+describe('CardStatComponent', () => {
+  let component: CardStatComponent;
+  let fixture: ComponentFixture<CardStatComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CardStatComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CardStatComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
@@ -1,0 +1,17 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-card-stat',
+  templateUrl: './card-stat.component.html',
+  styleUrls: ['./card-stat.component.scss']
+})
+export class CardStatComponent implements OnInit {
+
+  @Input() stat;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.html
+++ b/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.html
@@ -1,0 +1,5 @@
+<div class="chart">
+    <div [id]="graphID" style="height: 100%" [hidden]="loadStatus !== 2"></div>
+
+    <div class="bar-loader" [hidden]="loadStatus !== 1"></div>
+</div>

--- a/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.spec.ts
+++ b/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GraphLineMultipleComponent } from './graph-line-multiple.component';
+
+describe('GraphLineMultipleComponent', () => {
+  let component: GraphLineMultipleComponent;
+  let fixture: ComponentFixture<GraphLineMultipleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ GraphLineMultipleComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GraphLineMultipleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.ts
+++ b/src/app/modules/dashboard/components/graphics/graph-line-multiple/graph-line-multiple.component.ts
@@ -1,0 +1,75 @@
+import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import * as am4core from '@amcharts/amcharts4/core';
+import * as am4charts from '@amcharts/amcharts4/charts';
+
+@Component({
+  selector: 'app-graph-line-multiple',
+  templateUrl: './graph-line-multiple.component.html',
+  styleUrls: ['./graph-line-multiple.component.scss']
+})
+export class GraphLineMultipleComponent implements OnInit, AfterViewInit {
+
+  @Input() data;
+  graphID;
+  loadStatus: number = 0;
+
+  private _name: string;
+  get name() {
+    return this._name;
+  }
+  @Input() set name(value) {
+    this._name = value;
+    this.graphID = `chart-m-line${this.name}`
+  }
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadGraph();
+  }
+
+  loadGraph() {
+    this.loadStatus = 1;
+    // Create chart instance
+    var chart = am4core.create(this.graphID, am4charts.XYChart);
+    chart.data = this.data;
+
+    // Create axes
+    var dateAxis = chart.xAxes.push(new am4charts.DateAxis());
+    dateAxis.renderer.minGridDistance = 50;
+    dateAxis.renderer.labels.template.fontSize = 12;
+
+    var valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
+    valueAxis.renderer.labels.template.fontSize = 12;
+
+    // Create series
+    var series = chart.series.push(new am4charts.LineSeries());
+    series.dataFields.valueY = "value1";
+    series.dataFields.dateX = "date";
+    series.strokeWidth = 2;
+    series.minBulletDistance = 10;
+    series.tooltipText = "[bold]{date.formatDate()}:[/] {value1}\n[bold]{previousDate.formatDate()}:[/] {value2}";
+    series.tooltip.pointerOrientation = "vertical";
+
+    // Create series
+    var series2 = chart.series.push(new am4charts.LineSeries());
+    series2.dataFields.valueY = "value2";
+    series2.dataFields.dateX = "date";
+    series2.strokeWidth = 2;
+    series2.strokeDasharray = "3,4";
+    series2.stroke = series.stroke;
+
+
+
+    // Add cursor
+    chart.cursor = new am4charts.XYCursor();
+    chart.cursor.xAxis = dateAxis;
+
+    this.loadStatus = 2;
+
+  }
+
+}

--- a/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.html
+++ b/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.html
@@ -1,0 +1,5 @@
+<div class="chart">
+    <div [id]="graphID" style="height: 100%" [hidden]="loadStatus !== 2"></div>
+
+    <div class="bar-loader" [hidden]="loadStatus !== 1"></div>
+</div>

--- a/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.scss
+++ b/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.scss
@@ -1,0 +1,7 @@
+.chart {
+    width: 100%;
+    height: 200px;
+    @media screen and (max-width: 480px) {
+        height: 350px;
+    }
+}

--- a/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.spec.ts
+++ b/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GraphPieComponent } from './graph-pie.component';
+
+describe('GraphPieComponent', () => {
+  let component: GraphPieComponent;
+  let fixture: ComponentFixture<GraphPieComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ GraphPieComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GraphPieComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.ts
+++ b/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.ts
@@ -127,24 +127,10 @@ export class GraphPieComponent implements OnInit, AfterViewInit {
 
       pieSeries.colors.list = [
         am4core.color('#0096d6'),
-
-
-
         am4core.color('#CA70A0'),
         am4core.color('#9DADBC'),
-
         am4core.color('#923C6C'),
         am4core.color('#394856'),
-
-        // am4core.color('#fbc001'),
-        // am4core.color('#cc0766'),
-        // am4core.color('#5603ad'),
-
-        // am4core.color('#f799ff'),
-
-
-
-        // am4core.color('#288000'),
 
       ]
 

--- a/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.ts
+++ b/src/app/modules/dashboard/components/graphics/graph-pie/graph-pie.component.ts
@@ -1,0 +1,156 @@
+import { AfterViewInit, Component, Inject, Input, NgZone, OnInit, PLATFORM_ID } from '@angular/core';
+import * as am4core from '@amcharts/amcharts4/core';
+import * as am4charts from '@amcharts/amcharts4/charts';
+import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { isPlatformBrowser } from '@angular/common';
+
+@Component({
+  selector: 'app-graph-pie',
+  templateUrl: './graph-pie.component.html',
+  styleUrls: ['./graph-pie.component.scss']
+})
+export class GraphPieComponent implements OnInit, AfterViewInit {
+  private chart: am4charts.XYChart;
+
+  @Input() data;
+  @Input() value: string;
+  @Input() category: string;
+
+  graphID;
+  loadStatus: number = 0;
+
+  private _name: string;
+  get name() {
+    return this._name;
+  }
+  @Input() set name(value) {
+    this._name = value;
+    this.graphID = `chart-pie-${this.name}`
+  }
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId,
+    private zone: NgZone) { }
+
+  // Run the function only in the browser
+  browserOnly(f: () => void) {
+    if (isPlatformBrowser(this.platformId)) {
+      this.zone.runOutsideAngular(() => {
+        f();
+      });
+    }
+  }
+
+  ngOnInit(): void { }
+
+  ngAfterViewInit() {
+    this.loadGraph();
+  }
+
+  loadGraph() {
+    this.browserOnly(() => {
+      this.loadStatus = 1;
+      // Chart code goes in here
+      am4core.useTheme(am4themes_animated);
+      let chart = am4core.create(this.graphID, am4charts.PieChart);
+      chart.data = this.data;
+
+      // Add and configure Series
+      let pieSeries = chart.series.push(new am4charts.PieSeries());
+      pieSeries.dataFields.value = this.value;
+      pieSeries.dataFields.category = this.category;
+
+      // Let's cut a hole in our Pie chart the size of 30% the radius
+      chart.innerRadius = am4core.percent(50);
+
+      // Put a thick white border around each Slice
+      pieSeries.slices.template.stroke = am4core.color('#fff');
+      pieSeries.slices.template.strokeWidth = 2;
+      pieSeries.slices.template.strokeOpacity = 1;
+      pieSeries.slices.template
+        // change the cursor on hover to make it apparent the object can be interacted with
+        .cursorOverStyle = [
+          {
+            'property': 'cursor',
+            'value': 'pointer'
+          }
+        ];
+
+      pieSeries.labels.template.disabled = true;
+      pieSeries.ticks.template.disabled = true;
+
+      // Create a base filter effect (as if it's not there) for the hover to return to
+      let shadow = pieSeries.slices.template.filters.push(new am4core.DropShadowFilter);
+      shadow.opacity = 0;
+
+      // Create hover state
+      let hoverState = pieSeries.slices.template.states.getKey('hover'); // normally we have to create the hover state, in this case it already exists
+
+      // Slightly shift the shadow and make it more prominent on hover
+      let hoverShadow = hoverState.filters.push(new am4core.DropShadowFilter);
+      hoverShadow.opacity = 0.7;
+      hoverShadow.blur = 5;
+
+      // Add a legend
+      chart.legend = new am4charts.Legend();
+      chart.legend.position = 'left';
+      chart.legend.fontSize = 12;
+      chart.legend.useDefaultMarker = true;
+      let marker = chart.legend.markers.template.children.getIndex(0);
+      marker.strokeWidth = 2;
+      marker.strokeOpacity = 1;
+      marker.height = 15;
+      marker.width = 15;
+      chart.responsive.enabled = true;
+      chart.responsive.rules.push({
+        relevant: function (target) {
+          if (target.pixelWidth <= 600) {
+            return true;
+          }
+          return false;
+        },
+        state: function (target, stateId) {
+          if (target instanceof am4charts.PieSeries) {
+            var state = target.states.create(stateId);
+
+            var labelState = target.labels.template.states.create(stateId);
+            labelState.properties.disabled = true;
+
+            var tickState = target.ticks.template.states.create(stateId);
+            tickState.properties.disabled = true;
+            return state;
+          }
+
+          return null;
+        }
+      });
+
+      pieSeries.colors.list = [
+        am4core.color('#0096d6'),
+
+
+
+        am4core.color('#CA70A0'),
+        am4core.color('#9DADBC'),
+
+        am4core.color('#923C6C'),
+        am4core.color('#394856'),
+
+        // am4core.color('#fbc001'),
+        // am4core.color('#cc0766'),
+        // am4core.color('#5603ad'),
+
+        // am4core.color('#f799ff'),
+
+
+
+        // am4core.color('#288000'),
+
+      ]
+
+      this.loadStatus = 2;
+    })
+
+  }
+
+}

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -1,6 +1,3 @@
-<div class="header bg-primary pb-4 pt-5 pt-md-6">
-</div>
-
 <div class="container-fluid mt-4">
     <app-general-filters></app-general-filters>
     <router-outlet></router-outlet>

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -12,6 +12,7 @@ import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { CardStatComponent } from './components/card-stat/card-stat.component';
 import { GraphPieComponent } from './components/graphics/graph-pie/graph-pie.component';
+import { GraphLineMultipleComponent } from './components/graphics/graph-line-multiple/graph-line-multiple.component';
 
 
 
@@ -22,7 +23,8 @@ import { GraphPieComponent } from './components/graphics/graph-pie/graph-pie.com
     RetailerComponent,
     GeneralFiltersComponent,
     CardStatComponent,
-    GraphPieComponent
+    GraphPieComponent,
+    GraphLineMultipleComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -10,6 +10,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
+import { CardStatComponent } from './components/card-stat/card-stat.component';
 
 
 
@@ -18,7 +19,8 @@ import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
     DashboardComponent,
     CountryComponent,
     RetailerComponent,
-    GeneralFiltersComponent
+    GeneralFiltersComponent,
+    CardStatComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -11,6 +11,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { CardStatComponent } from './components/card-stat/card-stat.component';
+import { GraphPieComponent } from './components/graphics/graph-pie/graph-pie.component';
 
 
 
@@ -20,7 +21,8 @@ import { CardStatComponent } from './components/card-stat/card-stat.component';
     CountryComponent,
     RetailerComponent,
     GeneralFiltersComponent,
-    CardStatComponent
+    CardStatComponent,
+    GraphPieComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -4,4 +4,13 @@
             <p class="text-uppercase text-muted mb-4"><b>{{ countryName }} - Visión general</b></p>
         </div>
     </div>
+
+    <!-- CARD STATS -->
+    <div class="row">
+        <div class="col-12">
+            <div class="stats-container">
+                <app-card-stat *ngFor="let stat of stats" [stat]="stat"></app-card-stat>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,7 +1,7 @@
 <div class="main-container mt-4">
     <div class="row">
         <div class="col-12">
-            <p class="text-uppercase text-muted mb-4"><b>{{ countryName }} - Visión general</b></p>
+            <p class="h2 text-uppercase text-muted mb-4"><b>Visión general</b></p>
         </div>
     </div>
 
@@ -13,4 +13,62 @@
             </div>
         </div>
     </div>
+
+
+
+    <div class="row mt-6">
+        <!-- devices -->
+        <div class="col-12 col-lg-6 mb-4">
+            <div class="card">
+                <div class="card-header">
+                    <span class="text-uppercase text-sm text-muted"><b>Inversión por mes</b></span>
+                </div>
+                <div class="card-body">
+                    <app-graph-pie [data]="devices" name="devices-per-sector" value="value" category="name">
+                    </app-graph-pie>
+                </div>
+            </div>
+        </div>
+
+        <!-- gender -->
+        <div class="col-12 col-lg-6 mb-4">
+            <div class="card">
+                <div class="card-header">
+                    <span class="text-uppercase text-sm text-muted"><b>Género</b></span>
+                </div>
+                <div class="card-body">
+                    <app-graph-pie [data]="gender" name="gender" value="value" category="name">
+                    </app-graph-pie>
+                </div>
+            </div>
+        </div>
+
+        <!-- users by sector -->
+        <div class="col-12 col-lg-6 mb-4">
+            <div class="card">
+                <div class="card-header">
+                    <span class="text-uppercase text-sm text-muted"><b>Usuarios por sector</b></span>
+                </div>
+                <div class="card-body">
+                    <app-graph-pie [data]="usersBySector" name="users-sector" value="value" category="name">
+                    </app-graph-pie>
+                </div>
+            </div>
+        </div>
+
+        <!-- sales by sector -->
+        <div class="col-12 col-lg-6 mb-4">
+            <div class="card">
+                <div class="card-header">
+                    <span class="text-uppercase text-sm text-muted"><b>Ventas por sector</b></span>
+                </div>
+                <div class="card-body">
+                    <app-graph-pie [data]="salesBySector" name="sales-sector" value="value" category="name">
+                    </app-graph-pie>
+                </div>
+            </div>
+        </div>
+    </div>
+
+
 </div>

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,8 +1,12 @@
 <div class="main-container mt-4">
-    <div class="row">
+    <!-- <div class="row">
         <div class="col-12">
             <p class="h2 text-uppercase text-muted mb-4"><b>Visión general</b></p>
         </div>
+    </div> -->
+
+    <div class="header bg-light mb-4">
+        <p class="h2 text-uppercase text-muted py-2 ml-3 mr-3"><b>Visión general</b></p>
     </div>
 
     <!-- CARD STATS -->
@@ -14,9 +18,7 @@
         </div>
     </div>
 
-
-
-    <div class="row mt-6">
+    <div class="row mt-5">
         <!-- devices -->
         <div class="col-12 col-lg-6 mb-4">
             <div class="card">
@@ -70,5 +72,17 @@
         </div>
     </div>
 
-
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <span class="text-uppercase text-sm text-muted"><b>Inversión vs Revenue</b></span>
+                </div>
+                <div class="card-body">
+                    <app-graph-line-multiple [data]="investmentVsRevenue" name="investment-vs-revenue">
+                    </app-graph-line-multiple>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/src/app/modules/dashboard/pages/country/country.component.scss
+++ b/src/app/modules/dashboard/pages/country/country.component.scss
@@ -1,0 +1,18 @@
+.stats-container {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 20px;
+
+    @media screen and (max-width: 1200px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    @media screen and (max-width: 1000px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media screen and (max-width: 480px) {
+        grid-template-columns: 1fr;
+    }
+}
+

--- a/src/app/modules/dashboard/pages/country/country.component.scss
+++ b/src/app/modules/dashboard/pages/country/country.component.scss
@@ -19,3 +19,7 @@
 .card-header {
     padding: 0.5rem 1.5rem;
 }
+
+.header {
+   border-radius: 0.375rem;;
+}

--- a/src/app/modules/dashboard/pages/country/country.component.scss
+++ b/src/app/modules/dashboard/pages/country/country.component.scss
@@ -16,3 +16,6 @@
     }
 }
 
+.card-header {
+    padding: 0.5rem 1.5rem;
+}

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
-import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-country',
@@ -9,6 +8,49 @@ import { switchMap } from 'rxjs/operators';
 })
 export class CountryComponent implements OnInit {
   countryName: string;
+  stats: any[] = [
+    {
+      metricTitle: 'Inversión',
+      metricValue: 'USD 35,000',
+      icon: 'fas fa-wallet',
+      iconBg: '#172b4d'
+    },
+    {
+      metricTitle: 'Clicks',
+      metricValue: '280,0000',
+      subMetricTitle: 'CTR',
+      subMetricValue: '000',
+      icon: 'fas fa-hand-pointer',
+      iconBg: '#2f9998'
+
+    },
+    {
+      metricTitle: 'Bounce Rate',
+      metricValue: '12%',
+      subMetricTitle: 'Usuarios',
+      subMetricValue: '27000',
+      icon: 'fas fa-stopwatch',
+      iconBg: '#a77dcc'
+    },
+    {
+      metricTitle: 'Transacciones',
+      metricValue: '3,500',
+      subMetricTitle: 'CR',
+      subMetricValue: '000',
+      icon: 'fas fa-shopping-basket',
+      iconBg: '#f89934'
+    },
+    {
+      metricTitle: 'Revenue',
+      metricValue: '3,500',
+      subMetricTitle: 'ROAS',
+      subMetricValue: '000',
+      icon: 'fas fa-hand-holding-usd',
+
+      iconBg: '#fbc001'
+
+    }
+  ];
 
   constructor(private route: ActivatedRoute) { }
 

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -91,6 +91,16 @@ export class CountryComponent implements OnInit {
       name: 'Ventas',
       value: 85700
     }
+  ];
+
+  investmentVsRevenue = [
+    { date: new Date(2021, 3, 12), value1: 12000, value2: 4370, previousDate: new Date(2021, 2, 5) },
+    { date: new Date(2021, 3, 13), value1: 25000, value2: 40500, previousDate: new Date(2021, 2, 6) },
+    { date: new Date(2021, 3, 14), value1: 40000, value2: 35000, previousDate: new Date(2021, 2, 7) },
+    { date: new Date(2021, 3, 15), value1: 15000, value2: 25000, previousDate: new Date(2021, 2, 8) },
+    { date: new Date(2021, 3, 16), value1: 13200, value2: 10000, previousDate: new Date(2021, 2, 9) },
+    { date: new Date(2021, 3, 17), value1: 12400, value2: 12000, previousDate: new Date(2021, 2, 10) },
+    { date: new Date(2021, 3, 18), value1: 80000, value2: 14000, previousDate: new Date(2021, 2, 11) }
   ]
 
 

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -52,6 +52,48 @@ export class CountryComponent implements OnInit {
     }
   ];
 
+  devices: any[] = [
+    { id: 1, name: 'Escritorio', value: 3000 },
+    { id: 2, name: 'Tablet', value: 500 },
+    { id: 3, name: 'Celular', value: 10500 }
+  ]
+
+  gender: any[] = [
+    { id: 1, name: 'Hombre', value: 1200 },
+    { id: 2, name: 'Mujer', value: 12800 },
+  ]
+
+  usersBySector: any[] = [
+    {
+      name: 'Search',
+      value: 3500
+    },
+    {
+      name: 'Marketing',
+      value: 1500
+    },
+    {
+      name: 'Ventas',
+      value: 9000
+    }
+  ]
+
+  salesBySector: any[] = [
+    {
+      name: 'Search',
+      value: 250000
+    },
+    {
+      name: 'Marketing',
+      value: 37500
+    },
+    {
+      name: 'Ventas',
+      value: 85700
+    }
+  ]
+
+
   constructor(private route: ActivatedRoute) { }
 
   ngOnInit(): void {

--- a/src/app/modules/users-mngmt/users-mngmt.component.html
+++ b/src/app/modules/users-mngmt/users-mngmt.component.html
@@ -1,9 +1,3 @@
-<div class="header bg-primary pb-4 pt-5 pt-md-6">
-    <div class="container-fluid">
-        <div class="header-body">
-        </div>
-    </div>
-</div>
 <div class="container-fluid mt-4">
     <router-outlet></router-outlet>
 </div>

--- a/src/app/pages/investment/investment.component.html
+++ b/src/app/pages/investment/investment.component.html
@@ -1,4 +1,4 @@
-<div class="header bg-primary pb-4 pt-5 pt-md-6">
+<div class="header bg-primary pb-4">
   <div class="container-fluid">
     <div class="header-body">
       <!-- Card stats -->


### PR DESCRIPTION
# Problem Description
- Is necessary create a basic template of country page in order to begin to organize the components structure

# Features
- Add card-stat component
- Add graph-pie component
- Add graph-line-multiple component
- Use added components in country page
- Add sticky-top property to navbar

# Where this change will be used
- In `/dashboard/country` page

# More details
![image](https://user-images.githubusercontent.com/38545126/114801425-4a5e1380-9d61-11eb-87ff-4873e55b75d1.png)
![image](https://user-images.githubusercontent.com/38545126/114801445-52b64e80-9d61-11eb-84ca-fa5d7f9804da.png)

