### PR TITLE
get retailers by country in sidebar component

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -44,7 +44,7 @@ export class NavbarComponent implements OnInit {
 
     // custom title
     this.appStateService.selectedCountry$.subscribe(resp => {
-      this.customTitle = resp;
+      this.customTitle = resp?.name;
       this.customizeTitle();
     }, error => {
       console.error(`[navbar.component]: ${error}`);
@@ -52,7 +52,7 @@ export class NavbarComponent implements OnInit {
 
     // custom subtitle
     this.appStateService.selectedRetailer$.subscribe(resp => {
-      this.customSubtitle = resp;
+      this.customSubtitle = resp?.name;
       this.customizeTitle();
     }, error => {
       console.error(`[navbar.component]: ${error}`);

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -68,7 +68,7 @@
         </div>
       </form>
       <!-- Navigation -->
-      <ul class="navbar-nav" *ngIf="menuReqStatus >= 2">
+      <ul class="navbar-nav" *ngIf="menuItems.length > 1">
         <ng-container *ngFor="let menuItem of menuItems">
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
             <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItem === selectedItem }"
@@ -83,7 +83,7 @@
               {{ menuItem.title | titlecase }}
             </a>
 
-            <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen && submenuReqStatus === 2">
+            <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">
               <li class="{{menuItemL2.class}} nav-item" *ngFor="let menuItemL2 of menuItem.submenu">
                 <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItemL2 === selectedSubItem }"
                   (click)="selectItem(menuItemL2, menuItem);">

--- a/src/app/modules/users-mngmt/services/users-mngmt.service.ts
+++ b/src/app/modules/users-mngmt/services/users-mngmt.service.ts
@@ -42,8 +42,11 @@ export class UsersMngmtService {
     return this.http.get(`${this.baseUrl}/countries`);
   }
 
-  getRetailers() {
-    return this.http.get(`${this.baseUrl}/retailers`);
+  getRetailers(countryID?) {
+    const endpoint = countryID
+      ? `?country=${countryID}`
+      : '';
+    return this.http.get(`${this.baseUrl}/retailers${endpoint}`);
   }
 
   getSectors() {


### PR DESCRIPTION
# Problem Description
- Sow countries list in sidebar and after user selection show retailers by selected country.
Note: This change only applies for users with admin, hp or country roles

# Features
- Update /retailer request to pass selected countryID as a query param
- Save id and name of the country and/or retailer selected
- Update navbar component to show the saved name properties of country and/or retailer

# Where this change will be used
- In dashboard sidebar and dashboard/country and /dashboard/retailers pages

# More details
![image](https://user-images.githubusercontent.com/38545126/114907293-8b493d00-9de0-11eb-9065-840e31f9d359.png)