### PR TITLE
add basic template to retailer component (tab 2 - acquisition)

### DIFF
--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
@@ -1,0 +1,120 @@
+<div class="row mt-4">
+    <div class="col-12 col-lg-6 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Usuarios por sector</span>
+            </div>
+            <div class="card-body">
+                <app-graph-line-series [series]="usersBySectors" name="users-sector">
+                </app-graph-line-series>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 col-lg-6 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Usuarios por fuente</span>
+            </div>
+            <div class="card-body">
+                <app-graph-line-series [series]="usersBySources" name="users-source">
+                </app-graph-line-series>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="adaptable-container">
+            <table mat-table [dataSource]="dataSource">
+
+                <!-- name source -->
+                <ng-container matColumnDef="source">
+                    <th mat-header-cell *matHeaderCellDef> Fuente </th>
+                    <td mat-cell *matCellDef="let element"> {{element.source}} </td>
+                </ng-container>
+
+                <!-- investment way -->
+                <ng-container matColumnDef="way">
+                    <th mat-header-cell *matHeaderCellDef> Medio </th>
+                    <td mat-cell *matCellDef="let element"> {{element.way}} </td>
+                </ng-container>
+
+                <!-- campaign -->
+                <ng-container matColumnDef="campaign">
+                    <th mat-header-cell *matHeaderCellDef> Campaña</th>
+                    <td mat-cell *matCellDef="let element"> {{element.campaign}} </td>
+                </ng-container>
+
+                <!-- users -->
+                <ng-container matColumnDef="users">
+                    <th mat-header-cell *matHeaderCellDef> Usuarios</th>
+                    <td mat-cell *matCellDef="let element"> {{element.users}} </td>
+                </ng-container>
+
+                <!-- newUsers -->
+                <ng-container matColumnDef="newUsers">
+                    <th mat-header-cell *matHeaderCellDef> Nuevos usuarios</th>
+                    <td mat-cell *matCellDef="let element"> {{element.newUsers}} </td>
+                </ng-container>
+
+                <!-- sessions -->
+                <ng-container matColumnDef="sessions">
+                    <th mat-header-cell *matHeaderCellDef> Sesiones</th>
+                    <td mat-cell *matCellDef="let element"> {{element.sessions}} </td>
+                </ng-container>
+
+                <!-- pagesBySession -->
+                <ng-container matColumnDef="pagesBySession">
+                    <th mat-header-cell *matHeaderCellDef> Páginas por sesión</th>
+                    <td mat-cell *matCellDef="let element"> {{element.pagesBySession}} </td>
+                </ng-container>
+
+                <!-- bounceRate -->
+                <ng-container matColumnDef="bounceRate">
+                    <th mat-header-cell *matHeaderCellDef> Porcentaje de rebote</th>
+                    <td mat-cell *matCellDef="let element"> {{element.bounceRate}} </td>
+                </ng-container>
+
+                <!-- sessionDuration -->
+                <ng-container matColumnDef="sessionDuration">
+                    <th mat-header-cell *matHeaderCellDef> Duración media de la sesión</th>
+                    <td mat-cell *matCellDef="let element"> {{element.sessionDuration}} </td>
+                </ng-container>
+
+                <!-- amount -->
+                <ng-container matColumnDef="amount">
+                    <th mat-header-cell *matHeaderCellDef> Cantidad</th>
+                    <td mat-cell *matCellDef="let element"> {{element.amount}} </td>
+                </ng-container>
+
+                <!-- income -->
+                <ng-container matColumnDef="income">
+                    <th mat-header-cell *matHeaderCellDef> Ingresos del producto</th>
+                    <td mat-cell *matCellDef="let element"> {{element.income}} </td>
+                </ng-container>
+
+                <!-- yoy -->
+                <ng-container matColumnDef="yoy">
+                    <th mat-header-cell *matHeaderCellDef> %YoY</th>
+                    <td mat-cell *matCellDef="let element"> {{element.yoy}} </td>
+                </ng-container>
+
+                <!-- disclaimer column -->
+                <ng-container matColumnDef="disclaimer">
+                    <td mat-footer-cell *matFooterCellDef colspan="3">
+                        <div class="text-danger text-center" *ngIf="getReqStatus === 3">
+                            Ocurrió un error al consultar los usuarios
+                        </div>
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
+                    [hidden]="getReqStatus !== 3"></tr>
+            </table>
+        </div>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
@@ -1,0 +1,11 @@
+.card-header {
+    padding: 0.5rem 1.5rem;
+}
+
+table {
+    width: 100%;
+}
+
+.adaptable-container {
+    overflow: auto;
+}

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.spec.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AcquisitionWrapperComponent } from './acquisition-wrapper.component';
+
+describe('AcquisitionWrapperComponent', () => {
+  let component: AcquisitionWrapperComponent;
+  let fixture: ComponentFixture<AcquisitionWrapperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AcquisitionWrapperComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AcquisitionWrapperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -1,0 +1,123 @@
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+
+@Component({
+  selector: 'app-acquisition-wrapper',
+  templateUrl: './acquisition-wrapper.component.html',
+  styleUrls: ['./acquisition-wrapper.component.scss']
+})
+export class AcquisitionWrapperComponent implements OnInit, AfterViewInit {
+
+  usersBySectors = [
+    {
+      name: 'Search',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 2500 },
+        { date: new Date(2021, 2, 1), value: 4700 },
+        { date: new Date(2021, 3, 1), value: 5000 }
+      ]
+    },
+    {
+      name: 'Marketing',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 2000 },
+        { date: new Date(2021, 2, 1), value: 3500 },
+        { date: new Date(2021, 3, 1), value: 4000 }
+      ]
+    },
+    {
+      name: 'Ventas',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 4500 },
+        { date: new Date(2021, 2, 1), value: 3700 },
+        { date: new Date(2021, 3, 1), value: 4000 }
+      ]
+    }
+  ]
+
+  usersBySources = [
+    {
+      name: 'Fuente 1',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 2800 },
+        { date: new Date(2021, 2, 1), value: 1500 },
+        { date: new Date(2021, 3, 1), value: 3400 }
+      ]
+    },
+    {
+      name: 'Fuente 2',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 1400 },
+        { date: new Date(2021, 2, 1), value: 1300 },
+        { date: new Date(2021, 3, 1), value: 2700 }
+      ]
+    },
+    {
+      name: 'Fuente 3',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 4800 },
+        { date: new Date(2021, 2, 1), value: 2500 },
+        { date: new Date(2021, 3, 1), value: 3600 }
+      ]
+    },
+    {
+      name: 'Fuente 4',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 1300 },
+        { date: new Date(2021, 2, 1), value: 1850 },
+        { date: new Date(2021, 3, 1), value: 2100 }
+      ]
+    },
+    {
+      name: 'Fuente 5',
+      serie: [
+        { date: new Date(2021, 1, 1), value: 2300 },
+        { date: new Date(2021, 2, 1), value: 1500 },
+        { date: new Date(2021, 3, 1), value: 1600 }
+      ]
+    }
+  ]
+
+  displayedColumns: string[] = ['source', 'way', 'campaign', 'users', 'newUsers', 'sessions', 'pagesBySession', 'bounceRate', 'sessionDuration', 'amount', 'income', 'yoy'];
+  private acqBySources = [
+    { source: 'Fuente 1', way: 'Medio 1', campaign: 'Campaña 1', users: 7000, newUsers: 450, sessions: 1500, pagesBySession: 7, bounceRate: 50, sessionDuration: '3 min', amount: 50, income: 35000, yoy: 20 },
+    { source: 'Fuente 2', way: 'Medio 2', campaign: 'Campaña 2', users: 2000, newUsers: 120, sessions: 1200, pagesBySession: 6, bounceRate: 70, sessionDuration: '4 min', amount: 20, income: 28000, yoy: 18 },
+    { source: 'Fuente 3', way: 'Medio 3', campaign: 'Campaña 3', users: 1800, newUsers: 380, sessions: 1600, pagesBySession: 4, bounceRate: 60, sessionDuration: '6 min', amount: 15, income: 15000, yoy: 21 },
+    { source: 'Fuente 4', way: 'Medio 4', campaign: 'Campaña 4', users: 9750, newUsers: 270, sessions: 880, pagesBySession: 7, bounceRate: 55, sessionDuration: '2 min', amount: 50, income: 17000, yoy: 14 },
+
+  ];
+  dataSource = new MatTableDataSource<any>(this.acqBySources);
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadPaginator();
+  }
+
+  loadPaginator() {
+    // paginator setup
+    this.dataSource.paginator = this.paginator;
+    this.paginator._intl.itemsPerPageLabel = 'Registros por página';
+    this.paginator._intl.nextPageLabel = 'Siguiente';
+    this.paginator._intl.previousPageLabel = 'Anterior';
+    this.paginator._intl.getRangeLabel = (page: number, pageSize: number, length: number) => {
+      if (length == 0 || pageSize == 0) { return `0 de ${length}`; }
+
+      length = Math.max(length, 0);
+
+      const startIndex = page * pageSize;
+
+      // If the start index exceeds the list length, do not try and fix the end index to the end.
+      const endIndex = startIndex < length ?
+        Math.min(startIndex + pageSize, length) :
+        startIndex + pageSize;
+
+      return `${startIndex + 1} - ${endIndex} de ${length}`;
+    }
+  }
+}

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
@@ -1,0 +1,1 @@
+<p>behaviour-wrapper works!</p>

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.spec.ts
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BehaviourWrapperComponent } from './behaviour-wrapper.component';
+
+describe('BehaviourWrapperComponent', () => {
+  let component: BehaviourWrapperComponent;
+  let fixture: ComponentFixture<BehaviourWrapperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ BehaviourWrapperComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BehaviourWrapperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-behaviour-wrapper',
+  templateUrl: './behaviour-wrapper.component.html',
+  styleUrls: ['./behaviour-wrapper.component.scss']
+})
+export class BehaviourWrapperComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -25,6 +25,8 @@ import { GraphBarComponent } from './components/graphics/graph-bar/graph-bar.com
 import { GraphHeatMapComponent } from './components/graphics/graph-heat-map/graph-heat-map.component';
 import { GraphBarHorizontalComponent } from './components/graphics/graph-bar-horizontal/graph-bar-horizontal.component';
 import { GraphLollipopComponent } from './components/graphics/graph-lollipop/graph-lollipop.component';
+import { BehaviourWrapperComponent } from './components/behaviour-wrapper/behaviour-wrapper.component';
+import { AcquisitionWrapperComponent } from './components/acquisition-wrapper/acquisition-wrapper.component';
 
 
 
@@ -44,7 +46,9 @@ import { GraphLollipopComponent } from './components/graphics/graph-lollipop/gra
     GraphBarComponent,
     GraphHeatMapComponent,
     GraphBarHorizontalComponent,
-    GraphLollipopComponent
+    GraphLollipopComponent,
+    BehaviourWrapperComponent,
+    AcquisitionWrapperComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -65,7 +65,17 @@
                         <!-- CTR -->
                         <ng-container matColumnDef="ctr">
                             <th mat-header-cell *matHeaderCellDef> CTR</th>
-                            <td mat-cell *matCellDef="let element"> {{element.ctr}} </td>
+
+                            <td mat-cell *matCellDef="let element">
+                                <div class="value-container">
+                                    <span>{{element.ctr}}</span>
+                                    <i class="fas fa-arrow-up text-success"
+                                        *ngIf="element.ctr >= element.ctr_benchmark"></i>
+                                    <i class="fas fa-arrow-down text-danger"
+                                        *ngIf="element.ctr < element.ctr_benchmark"></i>
+                                </div>
+                            </td>
+
                         </ng-container>
 
                         <!-- CPM -->
@@ -104,7 +114,7 @@
         <app-retail-filters></app-retail-filters>
 
         <!-- CARD STATS -->
-        <div class="row mt-4">
+        <div class="row mt-5">
             <div class="col-12">
                 <div class="stats-container">
                     <app-card-stat *ngFor="let stat of stats" [stat]="stat"></app-card-stat>
@@ -178,7 +188,7 @@
 
 
         <!-- ACCORDION -->
-        <div class="mt-4">
+        <div class="mt-5">
             <mat-accordion multi>
                 <mat-expansion-panel (opened)="panelChange('panel1',true)" (closed)="panelChange('panel1',false)">
                     <mat-expansion-panel-header>
@@ -186,7 +196,7 @@
                             <span class="h3 mb-0">Audiencias</span>
                         </mat-panel-title>
                     </mat-expansion-panel-header>
-                    <app-audiences-wrapper></app-audiences-wrapper>
+                    <app-audiences-wrapper *ngIf="extPanelIsOpen.panel1"></app-audiences-wrapper>
                 </mat-expansion-panel>
 
                 <mat-expansion-panel (opened)="panelChange('panel2',true)" (closed)="panelChange('panel2',false)">
@@ -195,7 +205,7 @@
                             <span class="h3 mb-0">Adquisición</span>
                         </mat-panel-title>
                     </mat-expansion-panel-header>
-                    <p>Contenido de adiquisición</p>
+                    <app-acquisition-wrapper *ngIf="extPanelIsOpen.panel2"></app-acquisition-wrapper>
                 </mat-expansion-panel>
 
                 <mat-expansion-panel (opened)="panelChange('panel3',true)" (closed)="panelChange('panel3',false)">

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.scss
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.scss
@@ -46,3 +46,9 @@ table {
 .nav-link {
     cursor: pointer;
 }
+
+.value-container {
+    display: grid;
+    grid-template-columns: 40px auto;
+    gap: 8px;
+}

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Params } from '@angular/router';
@@ -14,7 +14,7 @@ import { MatFormFieldControl } from '@angular/material/form-field';
     { provide: MatFormFieldControl, useExisting: RetailerComponent }
   ]
 })
-export class RetailerComponent implements OnInit {
+export class RetailerComponent implements OnInit, AfterViewInit {
 
   countryName;
   retailerName;
@@ -57,9 +57,9 @@ export class RetailerComponent implements OnInit {
 
   displayedColumns: string[] = ['name', 'investment', 'impressions', 'clicks', 'ctr', 'cpm', 'cpc'];
   private campaigns = [
-    { name: 'Campaign 1', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, cpm: 750, cpc: 50 },
-    { name: 'Campaign 2', investment: 7000, impressions: 150000, clicks: 8000, ctr: 20.55, cpm: 450, cpc: 30 },
-    { name: 'Campaign 3', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, cpm: 120, cpc: 80 }
+    { name: 'Campaign 1', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50 },
+    { name: 'Campaign 2', investment: 7000, impressions: 150000, clicks: 8000, ctr: 25.55, ctr_benchmark: 22.12, cpm: 450, cpc: 30 },
+    { name: 'Campaign 3', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80 }
   ];
   dataSource = new MatTableDataSource<any>(this.campaigns);
   getReqStatus: number = 0;
@@ -126,8 +126,35 @@ export class RetailerComponent implements OnInit {
     });
   }
 
+  ngAfterViewInit() {
+    this.loadPaginator();
+  }
+
+
   panelChange(panel, value) {
     this.extPanelIsOpen[panel] = value
+  }
+
+  loadPaginator() {
+    // paginator setup
+    this.dataSource.paginator = this.paginator;
+    this.paginator._intl.itemsPerPageLabel = 'Registros por página';
+    this.paginator._intl.nextPageLabel = 'Siguiente';
+    this.paginator._intl.previousPageLabel = 'Anterior';
+    this.paginator._intl.getRangeLabel = (page: number, pageSize: number, length: number) => {
+      if (length == 0 || pageSize == 0) { return `0 de ${length}`; }
+
+      length = Math.max(length, 0);
+
+      const startIndex = page * pageSize;
+
+      // If the start index exceeds the list length, do not try and fix the end index to the end.
+      const endIndex = startIndex < length ?
+        Math.min(startIndex + pageSize, length) :
+        startIndex + pageSize;
+
+      return `${startIndex + 1} - ${endIndex} de ${length}`;
+    }
   }
 
 }


### PR DESCRIPTION
# Problem Description
- Is necessary create a basic template of retailer page in order to begin to organize the components structure
- Add template to acquisition collapse panel 

# Features
- show series chart and table in acquisition collapse panel 

# Where this change will be used
- In retailer page at `/dashboard/retailer` path (acquisition collapse panel)

# More details
![image](https://user-images.githubusercontent.com/38545126/115075640-ff5b1200-9ec0-11eb-8896-d383b8f7ab46.png)

