### PR TITLE
add basic template to retailer component (tab 2 - behaviour)

### DIFF
--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
@@ -1,1 +1,138 @@
-<p>behaviour-wrapper works!</p>
+<div class="row mt-4">
+
+    <!-- chart - line series -->
+    <div class="col-12 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Porcentaje de salidas, rebote y páginas vistas </span>
+            </div>
+            <div class="card-body">
+                <app-chart-line-series [series]="generalBehaviour" name="general-behaviour">
+                </app-chart-line-series>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- charts - pie -->
+<div class="row">
+    <!-- sessions new vs returning visitor -->
+    <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Sesiones nuevas vs Visitantes recurrentes</span>
+            </div>
+            <div class="card-body">
+                <app-chart-pie [data]="sessionsVsRetVisitor" name="sessions-ret-visitor">
+                </app-chart-pie>
+            </div>
+        </div>
+    </div>
+
+    <!-- sales new vs returning visitor -->
+    <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Ventas nuevas vs Visitantes recurrentes</span>
+            </div>
+            <div class="card-body">
+                <app-chart-pie [data]="salesVsRetVisitor" name="sales-ret-visitor">
+                </app-chart-pie>
+            </div>
+        </div>
+    </div>
+
+    <!-- sales by conversion source -->
+    <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Ventas por fuente de conversión</span>
+            </div>
+            <div class="card-body">
+                <app-chart-pie [data]="salesByConversionSource" name="sales-by-conv-sorce">
+                </app-chart-pie>
+            </div>
+        </div>
+    </div>
+
+    <!-- sales by sector -->
+    <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Ventas por Sector</span>
+            </div>
+            <div class="card-body">
+                <app-chart-pie [data]="salesBySector" name="sales-by-sorce">
+                </app-chart-pie>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <div class="mb-3 mt-0"><span class="h3">Prospecting / Remarketing</span></div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <div class="grid-container">
+            <!-- sessions by audience type -->
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">Sesiones por tipo de audiencia</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-pie [data]="sessionsByAudience" name="sessions-by-audience">
+                    </app-chart-pie>
+                </div>
+            </div>
+
+            <!-- new users by audience type -->
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">Usuarios nuevos por tipo de audiencia</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-pie [data]="sessionsByAudience" name="users-by-audience">
+                    </app-chart-pie>
+                </div>
+            </div>
+
+            <!-- quantity by audience type -->
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">Cantidad por tipo de audiencia</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-bar [data]="quantityByAudience" name="quantity-by-audience">
+                    </app-chart-bar>
+                </div>
+            </div>
+
+            <!-- revenue by audience type -->
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">Revenue por tipo de audiencia</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-bar [data]="revenueByAudience" name="revenue-by-audience">
+                    </app-chart-bar>
+                </div>
+            </div>
+
+            <!-- AUP by audience type -->
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">AUP por tipo de audiencia</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-bar [data]="AUPByAudience" name="aup-by-audience">
+                    </app-chart-bar>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
@@ -1,0 +1,13 @@
+.grid-container {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 20px;
+
+    @media screen and (min-width: 992px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media screen and (min-width: 1200px) {
+        grid-template-columns: repeat(5, 1fr);  
+    }
+}

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.ts
@@ -7,6 +7,89 @@ import { Component, OnInit } from '@angular/core';
 })
 export class BehaviourWrapperComponent implements OnInit {
 
+  generalBehaviour = [
+    {
+      name: 'Porcentaje de salidas',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 2500 },
+        { date: new Date(2021, 3, 16), value: 4700 },
+        { date: new Date(2021, 3, 17), value: 4600 },
+        { date: new Date(2021, 3, 18), value: 4700 },
+        { date: new Date(2021, 3, 19), value: 4500 },
+        { date: new Date(2021, 3, 20), value: 4300 },
+        { date: new Date(2021, 3, 21), value: 4400 }
+      ]
+    },
+    {
+      name: 'Porcentaje de rebote',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 2000 },
+        { date: new Date(2021, 3, 16), value: 3500 },
+        { date: new Date(2021, 3, 17), value: 3200 },
+        { date: new Date(2021, 3, 18), value: 3600 },
+        { date: new Date(2021, 3, 19), value: 3000 },
+        { date: new Date(2021, 3, 20), value: 3400 },
+        { date: new Date(2021, 3, 21), value: 3000 }
+      ]
+    },
+    {
+      name: 'Número de páginas vistas',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 4500 },
+        { date: new Date(2021, 3, 16), value: 3700 },
+        { date: new Date(2021, 3, 17), value: 3800 },
+        { date: new Date(2021, 3, 18), value: 3200 },
+        { date: new Date(2021, 3, 19), value: 3500 },
+        { date: new Date(2021, 3, 20), value: 4500 },
+        { date: new Date(2021, 3, 21), value: 4700 }
+      ]
+    }
+  ]
+
+  sessionsVsRetVisitor = [
+    { category: 'Sesiones nuevas', value: 3200 },
+    { category: 'Visitante recurrente', value: 2800 }
+  ]
+
+  salesVsRetVisitor = [
+    { category: 'Ventas nuevas', value: 130 },
+    { category: 'Visitante recurrente', value: 240 }
+  ]
+
+  salesByConversionSource = [
+    { category: 'Google', value: 100 },
+    { category: 'Display', value: 30 },
+    { category: 'Social', value: 40 },
+    { category: 'Others', value: 10 }
+  ]
+
+  salesBySector = [
+    { category: 'Search', value: 30 },
+    { category: 'Marketing', value: 240 },
+    { category: 'Ventas', value: 60 }
+  ]
+
+  sessionsByAudience = [
+    { category: 'Prospecting', value: 49500 },
+    { category: 'Remarketing', value: 15400 },
+  ]
+
+  quantityByAudience = [
+    { category: 'Prospecting', value: 357 },
+    { category: 'Remarketing', value: 18 },
+  ]
+
+  revenueByAudience = [
+    { category: 'Prospecting', value: 306000 },
+    { category: 'Remarketing', value: 11600 },
+  ]
+
+  AUPByAudience = [
+    { category: 'Prospecting', value: 850 },
+    { category: 'Remarketing', value: 631 },
+  ]
+
+
   constructor() { }
 
   ngOnInit(): void {

--- a/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
@@ -11,8 +11,8 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 export class ChartBarComponent implements OnInit, AfterViewInit {
 
   @Input() data;
-  @Input() value: string;
-  @Input() category: string;
+  @Input() value: string = 'value';
+  @Input() category: string = 'category';
   chartID;
   loadStatus: number = 0;
 

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -98,6 +98,10 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
       series.data = data;
       return series;
     }
+
+    // Add cursor
+    chart.cursor = new am4charts.XYCursor();
+    chart.cursor.xAxis = dateAxis;
   }
 
 

--- a/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.scss
@@ -1,7 +1,7 @@
 .chart {
-    width: 100%;
-    height: 200px;
-    @media screen and (max-width: 480px) {
-        height: 350px;
-    }
+    // width: 100%;
+    // height: 200px;
+    // @media screen and (max-width: 480px) {
+    //     height: 350px;
+    // }
 }

--- a/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
@@ -13,8 +13,8 @@ export class ChartPieComponent implements OnInit, AfterViewInit {
   private chart: am4charts.XYChart;
 
   @Input() data;
-  @Input() value: string;
-  @Input() category: string;
+  @Input() value: string = 'value';
+  @Input() category: string = 'category';
 
   chartID;
   loadStatus: number = 0;

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -214,7 +214,7 @@
                             <span class="h3 mb-0">Comportamiento</span>
                         </mat-panel-title>
                     </mat-expansion-panel-header>
-                    <p>Contenido de comportamiento</p>
+                    <app-behaviour-wrapper *ngIf="extPanelIsOpen.panel3"></app-behaviour-wrapper>
                 </mat-expansion-panel>
 
                 <mat-expansion-panel (opened)="panelChange('panel4',true)" (closed)="panelChange('panel4',false)">


### PR DESCRIPTION
# Problem Description
- Is necessary create a basic template of retailer page in order to begin to organize the components structure
- Add template to behaviour collapse panel

# Features
-  Add template to behaviour-wrapper component
-  Show behaviour-wrapper component in retailer component panel
- Other implications:
  -  add default values to inputs in bar and pie components
  - disable chart container style in chart-pie component
  - add cursor functionality to chart-line-series component

# Where this change will be used
- In retailer page at /dashboard/retailer path (behaviour collapse panel)

# More details
![image](https://user-images.githubusercontent.com/38545126/115438202-b9f55800-a1d2-11eb-9633-ef4f21577b33.png)
![image](https://user-images.githubusercontent.com/38545126/115438241-c679b080-a1d2-11eb-85b2-0150f5d2a0db.png)
![image](https://user-images.githubusercontent.com/38545126/115438285-d5606300-a1d2-11eb-8d68-5bef49b66dc3.png)
