### PR TITLE
add basic template to retailer component (tab 2 - conversion)

### DIFF
--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -1,4 +1,4 @@
-<div class="card card-stats mb-4 mb-xl-0">
+<div class="card card-stats mb-4 mb-xl-0" [style.height]="height">
     <div class="card-body">
         <div class="metric-container">
             <div class="metric-data">

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
@@ -1,5 +1,4 @@
 .card-stats {
-    height: 120px;
     overflow: hidden;
     width: 100%;
 

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
@@ -8,6 +8,7 @@ import { Component, Input, OnInit } from '@angular/core';
 export class CardStatComponent implements OnInit {
 
   @Input() stat;
+  @Input() height: string = '120px' // valid css height property value
 
   constructor() { }
 

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.html
@@ -1,0 +1,3 @@
+<div class="chart" [style.height]="height">
+    <div [id]="chartID" style="height: 100%"></div>
+</div>

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.spec.ts
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChartColumnLineMixComponent } from './chart-column-line-mix.component';
+
+describe('ChartColumnLineMixComponent', () => {
+  let component: ChartColumnLineMixComponent;
+  let fixture: ComponentFixture<ChartColumnLineMixComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChartColumnLineMixComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChartColumnLineMixComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
@@ -1,0 +1,99 @@
+import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import * as am4core from '@amcharts/amcharts4/core';
+import * as am4charts from '@amcharts/amcharts4/charts';
+import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+
+@Component({
+  selector: 'app-chart-column-line-mix',
+  templateUrl: './chart-column-line-mix.component.html',
+  styleUrls: ['./chart-column-line-mix.component.scss']
+})
+export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
+
+  @Input() data;
+  @Input() category: string = 'category';
+  @Input() columnValue: string = 'column_value';
+  @Input() lineValue: string = 'line_value';
+  @Input() columnName: string;
+  @Input() lineName: string;
+  @Input() height: string = '350px' // height property value valid in css
+
+  chartID;
+  loadStatus: number = 0;
+
+  private _name: string;
+  get name() {
+    return this._name;
+  }
+  @Input() set name(value) {
+    this._name = value;
+    this.chartID = `chart-column-line-mix-${this.name}`
+  }
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadChart();
+  }
+
+  loadChart() {
+    this.loadStatus = 1;
+
+    am4core.useTheme(am4themes_animated);
+
+    // Create chart instance
+    var chart = am4core.create(this.chartID, am4charts.XYChart);
+    chart.data = this.data;
+
+    // chart.exporting.menu = new am4core.ExportMenu();
+
+    /* Create axes */
+    let categoryAxis = chart.xAxes.push(new am4charts.CategoryAxis());
+    categoryAxis.dataFields.category = this.category;
+    categoryAxis.renderer.minGridDistance = 30;
+    categoryAxis.renderer.labels.template.fontSize = 12;
+
+    /* Create value axis */
+    let valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
+    valueAxis.renderer.labels.template.fontSize = 12;
+
+    /* Create series */
+    let columnSeries = chart.series.push(new am4charts.ColumnSeries());
+    columnSeries.name = this.columnName ? this.columnName : this.columnValue;
+    columnSeries.dataFields.valueY = this.columnValue;
+    columnSeries.dataFields.categoryX = this.category;
+
+    columnSeries.columns.template.tooltipText = '[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 20px]{valueY}[/] [#fff]{additional}[/]'
+    columnSeries.columns.template.propertyFields.fillOpacity = 'fillOpacity';
+    columnSeries.columns.template.propertyFields.stroke = 'stroke';
+    columnSeries.columns.template.propertyFields.strokeWidth = 'strokeWidth';
+    columnSeries.columns.template.propertyFields.strokeDasharray = 'columnDash';
+    columnSeries.tooltip.label.textAlign = 'middle';
+    columnSeries.columns.template.column.cornerRadiusTopLeft = 10;
+    columnSeries.columns.template.column.cornerRadiusTopRight = 10;
+    columnSeries.columns.template.column.fillOpacity = 0.8;
+
+    let lineSeries = chart.series.push(new am4charts.LineSeries());
+    lineSeries.name = this.lineName ? this.lineName : this.lineValue;
+    lineSeries.dataFields.valueY = this.lineValue;
+    lineSeries.dataFields.categoryX = this.category;
+
+    lineSeries.stroke = am4core.color('#fdd400');
+    lineSeries.strokeWidth = 3;
+    lineSeries.propertyFields.strokeDasharray = 'lineDash';
+    lineSeries.tooltip.label.textAlign = 'middle';
+
+    let bullet = lineSeries.bullets.push(new am4charts.Bullet());
+    bullet.fill = am4core.color('#fdd400'); // tooltips grab fill from parent by default
+    bullet.tooltipText = '[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 20px]{valueY}[/] [#fff]{additional}[/]'
+    let circle = bullet.createChild(am4core.Circle);
+    circle.radius = 4;
+    circle.fill = am4core.color('#fff');
+    circle.strokeWidth = 3;
+  }
+
+
+}

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
@@ -1,0 +1,107 @@
+<div class="row mt-4 mb-5">
+    <div class="col-12 col-md-4" *ngFor="let stat of stats">
+        <app-card-stat [stat]="stat" [height]="auto"></app-card-stat>
+    </div>
+</div>
+
+<div class="row mb-5">
+    <div class="col-12">
+        <div class="adaptable-container">
+            <table mat-table [dataSource]="dataSource">
+                <!-- category column -->
+                <ng-container matColumnDef="category">
+                    <th mat-header-cell *matHeaderCellDef> Categoría </th>
+                    <td mat-cell *matCellDef="let element"> {{element.category}} </td>
+                </ng-container>
+
+                <!-- product column -->
+                <ng-container matColumnDef="product">
+                    <th mat-header-cell *matHeaderCellDef> Producto </th>
+                    <td mat-cell *matCellDef="let element"> {{element.product}} </td>
+                </ng-container>
+
+                <!-- amount -->
+                <ng-container matColumnDef="amount">
+                    <th mat-header-cell *matHeaderCellDef> Cantidad</th>
+                    <td mat-cell *matCellDef="let element"> {{element.amount}} </td>
+                </ng-container>
+
+                <!-- yoy_amount -->
+                <ng-container matColumnDef="yoy_amount">
+                    <th mat-header-cell *matHeaderCellDef> %YoY</th>
+                    <td mat-cell *matCellDef="let element"> {{element.yoy_amount}}% </td>
+                </ng-container>
+
+                <!-- product_revenue -->
+                <ng-container matColumnDef="product_revenue">
+                    <th mat-header-cell *matHeaderCellDef> Revenue del producto</th>
+                    <td mat-cell *matCellDef="let element"> {{element.product_revenue}} </td>
+                </ng-container>
+
+                <!-- yoy_product_revenue -->
+                <ng-container matColumnDef="yoy_product_revenue">
+                    <th mat-header-cell *matHeaderCellDef> %YoY</th>
+                    <td mat-cell *matCellDef="let element"> {{element.yoy_product_revenue}}% </td>
+                </ng-container>
+
+                <!-- aup -->
+                <ng-container matColumnDef="aup">
+                    <th mat-header-cell *matHeaderCellDef> AUP</th>
+                    <td mat-cell *matCellDef="let element"> {{element.aup}} </td>
+                </ng-container>
+
+                <!-- yoy_aup -->
+                <ng-container matColumnDef="yoy_aup">
+                    <th mat-header-cell *matHeaderCellDef> %YoY</th>
+                    <td mat-cell *matCellDef="let element"> {{element.yoy_aup}}% </td>
+                </ng-container>
+
+                <!-- disclaimer column -->
+                <ng-container matColumnDef="disclaimer">
+                    <td mat-footer-cell *matFooterCellDef colspan="3">
+                        <div class="text-danger text-center" *ngIf="getReqStatus === 3">
+                            Ocurrió un error al consultar los usuarios
+                        </div>
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
+                    [hidden]="getReqStatus !== 3"></tr>
+            </table>
+        </div>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>
+
+<div class="row mb-5">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Usuarios vs Transacciones</span>
+            </div>
+            <div class="card-body">
+                <app-chart-column-line-mix [data]="usersVsTransacctions" name="users-vs-transaccions" category="date"
+                    columnValue="users" lineValue="transaccions" columnName="Usuarios" lineName="Transacciones"
+                    height="250px">
+                </app-chart-column-line-mix>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mb-5">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4">Cantidad vs AUP</span>
+            </div>
+            <div class="card-body">
+                <app-chart-column-line-mix [data]="amountVsAUP" name="amount-vs-aup" category="date"
+                    columnValue="amount" lineValue="aup" columnName="Cantidad" lineName="AUP" height="250px">
+                </app-chart-column-line-mix>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
@@ -1,0 +1,7 @@
+table {
+    width: 100%;
+}
+
+.adaptable-container {
+    overflow: auto;
+}

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.spec.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConversionWrapperComponent } from './conversion-wrapper.component';
+
+describe('ConversionWrapperComponent', () => {
+  let component: ConversionWrapperComponent;
+  let fixture: ComponentFixture<ConversionWrapperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConversionWrapperComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConversionWrapperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -1,0 +1,95 @@
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import * as moment from 'moment';
+
+@Component({
+  selector: 'app-conversion-wrapper',
+  templateUrl: './conversion-wrapper.component.html',
+  styleUrls: ['./conversion-wrapper.component.scss']
+})
+export class ConversionWrapperComponent implements OnInit, AfterViewInit {
+
+  stats: any[] = [
+    {
+      metricTitle: 'Cantidad',
+      metricValue: '000',
+      icon: 'fas fa-chart-line',
+      iconBg: '#172b4d'
+    },
+    {
+      metricTitle: 'Revenue',
+      metricValue: '0000',
+      icon: 'fas fa-hand-holding-usd',
+      iconBg: '#2f9998'
+
+    },
+    {
+      metricTitle: 'AUP',
+      metricValue: '0%',
+      icon: 'fas fa-file-invoice-dollar',
+      iconBg: '#a77dcc'
+    }
+  ];
+
+  displayedColumns: string[] = ['category', 'product', 'amount', 'yoy_amount', 'product_revenue', 'yoy_product_revenue', 'aup', 'yoy_aup'];
+  private categories = [
+    { category: 'Category 1', product: 'Product 1', amount: 12, yoy_amount: 12, product_revenue: 50000, yoy_product_revenue: 15, aup: 820, yoy_aup: 8 },
+    { category: 'Category 2', product: 'Product 2', amount: 8, yoy_amount: 4, product_revenue: 20000, yoy_product_revenue: 7, aup: 650, yoy_aup: 4 },
+    { category: 'Category 3', product: 'Product 3', amount: 4, yoy_amount: -4, product_revenue: 10000, yoy_product_revenue: -2, aup: 350, yoy_aup: -1 }
+  ]
+  dataSource = new MatTableDataSource<any>(this.categories);
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  usersVsTransacctions = [
+    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), users: 1200, transaccions: 200 },
+    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), users: 1600, transaccions: 230 },
+    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), users: 1400, transaccions: 180 },
+    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), users: 1250, transaccions: 80 },
+    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), users: 800, transaccions: 60 },
+    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), users: 1000, transaccions: 110 },
+    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), users: 1100, transaccions: 120 }
+  ]
+
+  amountVsAUP = [
+    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), amount: 1200, aup: 400 },
+    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), amount: 1600, aup: 810 },
+    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), amount: 1400, aup: 320 },
+    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), amount: 1250, aup: 120 },
+    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), amount: 800, aup: 345 },
+    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), amount: 1000, aup: 850 },
+    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), amount: 1100, aup: 900 }
+  ]
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadPaginator();
+  }
+
+  loadPaginator() {
+    // paginator setup
+    this.dataSource.paginator = this.paginator;
+    this.paginator._intl.itemsPerPageLabel = 'Registros por página';
+    this.paginator._intl.nextPageLabel = 'Siguiente';
+    this.paginator._intl.previousPageLabel = 'Anterior';
+    this.paginator._intl.getRangeLabel = (page: number, pageSize: number, length: number) => {
+      if (length == 0 || pageSize == 0) { return `0 de ${length}`; }
+
+      length = Math.max(length, 0);
+
+      const startIndex = page * pageSize;
+
+      // If the start index exceeds the list length, do not try and fix the end index to the end.
+      const endIndex = startIndex < length ?
+        Math.min(startIndex + pageSize, length) :
+        startIndex + pageSize;
+
+      return `${startIndex + 1} - ${endIndex} de ${length}`;
+    }
+  }
+}

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -35,6 +35,8 @@ import { ChartLineComparisonComponent } from './components/charts/chart-line-com
 import { ChartLineSeriesComponent } from './components/charts/chart-line-series/chart-line-series.component';
 import { ChartLollipopComponent } from './components/charts/chart-lollipop/chart-lollipop.component';
 import { ChartPieComponent } from './components/charts/chart-pie/chart-pie.component';
+import { ConversionWrapperComponent } from './components/conversion-wrapper/conversion-wrapper.component';
+import { ChartColumnLineMixComponent } from './components/charts/chart-column-line-mix/chart-column-line-mix.component';
 
 
 @NgModule({
@@ -55,7 +57,9 @@ import { ChartPieComponent } from './components/charts/chart-pie/chart-pie.compo
     ChartLineComparisonComponent,
     ChartLineSeriesComponent,
     ChartLollipopComponent,
-    ChartPieComponent
+    ChartPieComponent,
+    ConversionWrapperComponent,
+    ChartColumnLineMixComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -223,7 +223,7 @@
                             <span class="h3 mb-0">Conversión</span>
                         </mat-panel-title>
                     </mat-expansion-panel-header>
-                    <p>Contenido de conversión</p>
+                    <app-conversion-wrapper *ngIf="extPanelIsOpen.panel4"></app-conversion-wrapper>
                 </mat-expansion-panel>
             </mat-accordion>
         </div>


### PR DESCRIPTION
# Problem Description
- Is necessary create a basic template of retailer page in order to begin to organize the components structure
- Add template to conversion collapse panel

# Features
- Add chart-column-line-mix component
- Add conversion-wrapper component
- Show conversion-wrapper component in retailer component panel
- Other implications:
   - Add height as input in card-stat component

# Where this change will be used
- In retailer page at /dashboard/retailer path (conversion collapse panel)

# More details
![image](https://user-images.githubusercontent.com/38545126/115471331-6815f780-a1fd-11eb-86bc-f6274b8aeb71.png)
![image](https://user-images.githubusercontent.com/38545126/115471353-7106c900-a1fd-11eb-8acb-b7f440a4d531.png)

