### PR TITLE
load dynamic data in chart-line-series component

### DIFF
--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
@@ -1,22 +1,25 @@
 <div class="row mt-4">
-    <div class="col-12 col-lg-6 mt-4 mb-5">
+    <div class="col-12">
+        <div class="pills-container">
+            <ul class="nav nav-pills nav-fill">
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
+                        (click)="changeData('sector', 1)">Usuarios por sector</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
+                        (click)="changeData('source', 2)">Usuarios por fuente</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-12 mt-4 mb-5">
         <div class="card">
             <div class="card-header">
                 <span class="h4">Usuarios por sector</span>
             </div>
             <div class="card-body">
-                <app-chart-line-series [series]="usersBySectors" name="users-sector">
-                </app-chart-line-series>
-            </div>
-        </div>
-    </div>
-    <div class="col-12 col-lg-6 mt-4 mb-5">
-        <div class="card">
-            <div class="card-header">
-                <span class="h4">Usuarios por fuente</span>
-            </div>
-            <div class="card-body">
-                <app-chart-line-series [series]="usersBySources" name="users-source">
+                <app-chart-line-series [series]="usersByCategory" name="users-sector">
                 </app-chart-line-series>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
@@ -9,3 +9,12 @@ table {
 .adaptable-container {
     overflow: auto;
 }
+
+
+.pills-container {
+    width: 60%;
+
+    @media screen and (max-width: 820px) {
+        width: 100%;
+    }
+}

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.scss
@@ -14,6 +14,10 @@ table {
 .pills-container {
     width: 60%;
 
+    .nav-item .nav-link {
+        cursor: pointer;
+    }
+
     @media screen and (max-width: 820px) {
         width: 100%;
     }

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -93,49 +93,49 @@ export class AcquisitionWrapperComponent implements OnInit, AfterViewInit {
     {
       name: 'Google',
       serie: [
-        { date: new Date(2021, 3, 15), value: 2800 },
-        { date: new Date(2021, 3, 16), value: 1500 },
-        { date: new Date(2021, 3, 17), value: 3400 },
-        { date: new Date(2021, 3, 18), value: 3200 },
-        { date: new Date(2021, 3, 19), value: 3150 },
-        { date: new Date(2021, 3, 20), value: 2900 },
-        { date: new Date(2021, 3, 21), value: 3400 }
+        { date: new Date(2021, 3, 15), value: 350 },
+        { date: new Date(2021, 3, 16), value: 280 },
+        { date: new Date(2021, 3, 17), value: 120 },
+        { date: new Date(2021, 3, 18), value: 400 },
+        { date: new Date(2021, 3, 19), value: 450 },
+        { date: new Date(2021, 3, 20), value: 100 },
+        { date: new Date(2021, 3, 21), value: 80 }
       ]
     },
     {
       name: 'Display',
       serie: [
-        { date: new Date(2021, 3, 15), value: 1400 },
-        { date: new Date(2021, 3, 16), value: 1300 },
-        { date: new Date(2021, 3, 17), value: 1250 },
-        { date: new Date(2021, 3, 18), value: 1100 },
-        { date: new Date(2021, 3, 19), value: 1300 },
-        { date: new Date(2021, 3, 20), value: 1450 },
-        { date: new Date(2021, 3, 21), value: 1580 }
+        { date: new Date(2021, 3, 15), value: 80 },
+        { date: new Date(2021, 3, 16), value: 150 },
+        { date: new Date(2021, 3, 17), value: 120 },
+        { date: new Date(2021, 3, 18), value: 100 },
+        { date: new Date(2021, 3, 19), value: 70 },
+        { date: new Date(2021, 3, 20), value: 85 },
+        { date: new Date(2021, 3, 21), value: 160 }
       ]
     },
     {
       name: 'Social',
       serie: [
-        { date: new Date(2021, 3, 15), value: 4800 },
-        { date: new Date(2021, 3, 16), value: 2500 },
-        { date: new Date(2021, 3, 17), value: 3600 },
-        { date: new Date(2021, 3, 18), value: 3700 },
-        { date: new Date(2021, 3, 19), value: 3600 },
-        { date: new Date(2021, 3, 20), value: 3650 },
-        { date: new Date(2021, 3, 21), value: 3800 }
+        { date: new Date(2021, 3, 15), value: 40 },
+        { date: new Date(2021, 3, 16), value: 60 },
+        { date: new Date(2021, 3, 17), value: 95 },
+        { date: new Date(2021, 3, 18), value: 120 },
+        { date: new Date(2021, 3, 19), value: 121 },
+        { date: new Date(2021, 3, 20), value: 96 },
+        { date: new Date(2021, 3, 21), value: 88 }
       ]
     },
     {
       name: 'Otros',
       serie: [
-        { date: new Date(2021, 3, 15), value: 1300 },
-        { date: new Date(2021, 3, 16), value: 1850 },
-        { date: new Date(2021, 3, 17), value: 2100 },
-        { date: new Date(2021, 3, 18), value: 2150 },
-        { date: new Date(2021, 3, 19), value: 2200 },
-        { date: new Date(2021, 3, 20), value: 2300 },
-        { date: new Date(2021, 3, 21), value: 2400 }
+        { date: new Date(2021, 3, 15), value: 44 },
+        { date: new Date(2021, 3, 16), value: 56 },
+        { date: new Date(2021, 3, 17), value: 75 },
+        { date: new Date(2021, 3, 18), value: 95 },
+        { date: new Date(2021, 3, 19), value: 80 },
+        { date: new Date(2021, 3, 20), value: 120 },
+        { date: new Date(2021, 3, 21), value: 200 }
       ]
     }
   ]

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -9,6 +9,47 @@ import { MatTableDataSource } from '@angular/material/table';
 })
 export class AcquisitionWrapperComponent implements OnInit, AfterViewInit {
 
+  selectedTab1: number = 1;
+
+  usersByCategory = [
+    {
+      name: 'Search',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 2500 },
+        { date: new Date(2021, 3, 16), value: 4700 },
+        { date: new Date(2021, 3, 17), value: 4600 },
+        { date: new Date(2021, 3, 18), value: 4700 },
+        { date: new Date(2021, 3, 19), value: 4500 },
+        { date: new Date(2021, 3, 20), value: 4300 },
+        { date: new Date(2021, 3, 21), value: 4400 }
+      ]
+    },
+    {
+      name: 'Marketing',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 2000 },
+        { date: new Date(2021, 3, 16), value: 3500 },
+        { date: new Date(2021, 3, 17), value: 3200 },
+        { date: new Date(2021, 3, 18), value: 3600 },
+        { date: new Date(2021, 3, 19), value: 3000 },
+        { date: new Date(2021, 3, 20), value: 3400 },
+        { date: new Date(2021, 3, 21), value: 3000 }
+      ]
+    },
+    {
+      name: 'Ventas',
+      serie: [
+        { date: new Date(2021, 3, 15), value: 4500 },
+        { date: new Date(2021, 3, 16), value: 3700 },
+        { date: new Date(2021, 3, 17), value: 3800 },
+        { date: new Date(2021, 3, 18), value: 3200 },
+        { date: new Date(2021, 3, 19), value: 3500 },
+        { date: new Date(2021, 3, 20), value: 4500 },
+        { date: new Date(2021, 3, 21), value: 4700 }
+      ]
+    }
+  ]
+
   usersBySectors = [
     {
       name: 'Search',
@@ -139,5 +180,15 @@ export class AcquisitionWrapperComponent implements OnInit, AfterViewInit {
 
       return `${startIndex + 1} - ${endIndex} de ${length}`;
     }
+  }
+
+  changeData(category, selectedTab) {
+    if (category === 'source') {
+      this.usersByCategory = this.usersBySources;
+    } else if (category === 'sector') {
+      this.usersByCategory = this.usersBySectors;
+    }
+
+    this.selectedTab1 = selectedTab;
   }
 }

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -10,7 +10,7 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 })
 export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
 
-  @Input() series;
+  // @Input() series;
   chartID;
   loadStatus: number = 0;
 
@@ -21,6 +21,15 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
   @Input() set name(value) {
     this._name = value;
     this.chartID = `chart-line-series-${this.name}`
+  }
+
+  private _series;
+  get series() {
+    return this._series;
+  }
+  @Input() set series(value) {
+    this._series = value;
+    this.chart && this.loadChartData(this.chart)
   }
 
   chart;
@@ -46,9 +55,7 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     dateAxis.renderer.labels.template.fontSize = 12;
     valueAxis.renderer.labels.template.fontSize = 12;
 
-    for (var i = 0; i < this.series.length; i++) {
-      createSeries('value' + i, this.series[i].name, this.series[i].serie);
-    }
+    this.loadChartData(chart);
 
     chart.legend = new am4charts.Legend();
     chart.legend.position = 'top';
@@ -61,6 +68,19 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     chart.legend.itemContainers.template.events.on('out', function (event) {
       processOut(chart, event.target.dataItem.dataContext);
     })
+
+    // Add cursor
+    chart.cursor = new am4charts.XYCursor();
+    chart.cursor.xAxis = dateAxis;
+    this.chart = chart;
+  }
+
+  loadChartData(chart) {
+
+    chart.series.clear();
+    for (var i = 0; i < this.series.length; i++) {
+      createSeries('value' + i, this.series[i].name, this.series[i].serie);
+    }
 
     function createSeries(s, name, serie) {
       let series = chart.series.push(new am4charts.LineSeries());
@@ -98,13 +118,7 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
       series.data = data;
       return series;
     }
-
-    // Add cursor
-    chart.cursor = new am4charts.XYCursor();
-    chart.cursor.xAxis = dateAxis;
   }
-
-
 }
 
 function processOver(chart, hoveredSeries) {


### PR DESCRIPTION
# Problem Description
- In acquisition collapsable panel inside retailer page instead of create a new instance of chart-lines-series after a nav-tab is selected is necessary only load new data but still using the same chart

# Features
- Listen series changes in chart-line-series component
- Use dynamic data in chart of acquisition-wrapper component
- Update data chart-line-series of acquisition wrapper component

# Where this change will be used
- In acquisition collapsable panel inside retailer page at /dashboard/retailer path

# More details
![image](https://user-images.githubusercontent.com/38545126/115589743-d4443a00-a295-11eb-9eba-b1e902863449.png)
![image](https://user-images.githubusercontent.com/38545126/115589770-db6b4800-a295-11eb-9d8f-39bcd2c68502.png)

