### PR TITLE
update chart-heat-map component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -14,6 +14,9 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
   @Input() categoryY = 'hour'; // property name in object inside array input data
   @Input() value;
   @Input() height = '350px' // valid css height to chart container
+  @Input() showTooltipValue: boolean = true; // show the value in tooltip
+  @Input() showGridBorders: boolean = false;
+  @Input() showHeatLegend: boolean = true; // lower legend with average values triggering by column hover
 
   private _name: string;
   get name() {
@@ -21,7 +24,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
   }
   @Input() set name(value) {
     this._name = value;
-    this.chartID = `chart-heat-map${this.name}`
+    this.chartID = `chart-heat-map-${this.name}`
   }
 
   private _data;
@@ -77,12 +80,24 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
     series.defaultState.transitionDuration = 3000;
 
     let bgColor = new am4core.InterfaceColorSet().getFor('background');
+    let bgColor2 = am4core.color('#adb5bd');
 
     let columnTemplate = series.columns.template;
     columnTemplate.strokeWidth = 1;
     columnTemplate.strokeOpacity = 0.2;
-    columnTemplate.stroke = bgColor;
-    columnTemplate.tooltipText = `{${this.categoryX}}, {${this.categoryY}}: {value.workingValue.formatNumber('#.')}`;
+
+    if (this.showGridBorders) {
+      columnTemplate.stroke = bgColor2;
+    } else {
+      columnTemplate.stroke = bgColor
+    }
+
+    let tooltipLegend = this.showTooltipValue
+      ? `{${this.categoryX}}, {${this.categoryY}}: {value.workingValue.formatNumber('#.')}`
+      : `{${this.categoryX}} - {${this.categoryY}}`;
+
+    columnTemplate.tooltipText = tooltipLegend;
+
     columnTemplate.width = am4core.percent(100);
     columnTemplate.height = am4core.percent(100);
 
@@ -92,6 +107,12 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
       min: am4core.color(bgColor),
       max: chart.colors.getIndex(0)
     });
+
+    this.loadChartData(chart);
+
+    if (!this.showHeatLegend) {
+      return;
+    }
 
     // heat legend
     let heatLegend = chart.bottomAxesContainer.createChild(am4charts.HeatLegend);
@@ -121,8 +142,6 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
         heatLegend.valueAxis.hideTooltip();
       }
     }
-
-    this.loadChartData(chart);
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -8,7 +8,7 @@
         </div>
     </div>
 
-    <div class="row mt-5">
+    <div class="row mt-5" *ngIf="selectedType === 'country'">
         <div class="col-12">
             <div class="pills-container">
                 <ul class="nav nav-pills nav-fill">
@@ -37,8 +37,25 @@
                     </ng-container>
                 </div>
                 <div class="card-body">
-                    <app-chart-heat-map [data]="categoriesXSector" [name]="selectedType + 'categories-by-retailer'"
-                        categoryX="retailer" categoryY="category" height="250px">
+                    <app-chart-heat-map [data]="categoriesXRetail" [name]="selectedType + 'categories-by-retailer'"
+                        categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
+                        [showGridBorders]="true" [showHeatLegend]="false">
+                    </app-chart-heat-map>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-5" *ngIf="selectedType === 'retailer'">
+        <div class="col-12 mt-4">
+            <div class="card">
+                <div class="card-header">
+                    <span class="h4">Categorías por sector</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-heat-map [data]="categoriesXSector" [name]="selectedType + 'categories-by-sector'"
+                        categoryX="sector" categoryY="category" height="250px" [showTooltipValue]="false"
+                        [showGridBorders]="true" [showHeatLegend]="false">
                     </app-chart-heat-map>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -53,421 +53,469 @@ export class OverviewWrapperComponent implements OnInit {
     }
   ];
 
-  categoriesXSectorSearch: any[] = [
+  categoriesXRetailSearch: any[] = [
     {
       category: 'PS',
       retailer: 'Abcdin',
-      value: 2990
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Abcdin',
-      value: 2300
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Abcdin',
-      value: 2400
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Alkosto',
-      value: 1600
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Alkosto',
-      value: 1350
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Alkosto',
-      value: 2100
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Compumundo',
-      value: 3400
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Compumundo',
-      value: 1600
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Compumundo',
-      value: 2800
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Fravega',
-      value: 1950
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Fravega',
-      value: 2000
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Fravega',
-      value: 900
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Garbarino',
-      value: 1400
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Garbarino',
-      value: 1700
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Garbarino',
-      value: 1200
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Liverpool',
-      value: 1150
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Liverpool',
-      value: 1650
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Liverpool',
-      value: 2400
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Officemax',
-      value: 2100
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Officemax',
-      value: 3600
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Officemax',
-      value: 1200
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Panamericana',
-      value: 4200
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Panamericana',
-      value: 3600
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Panamericana',
-      value: 2800
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Pcfactory',
-      value: 2400
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Pcfactory',
-      value: 1400
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Pcfactory',
-      value: 1850
+      value: 0
     }
   ]
 
-  categoriesXSectorMkt: any[] = [
+  categoriesXRetailMkt: any[] = [
     {
       category: 'PS',
       retailer: 'Abcdin',
-      value: 980
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Abcdin',
-      value: 430
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Abcdin',
-      value: 220
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Alkosto',
-      value: 350
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Alkosto',
-      value: 260
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Alkosto',
-      value: 430
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Compumundo',
-      value: 640
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Compumundo',
-      value: 420
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Compumundo',
-      value: 160
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Fravega',
-      value: 120
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Fravega',
-      value: 240
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Fravega',
-      value: 450
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Garbarino',
-      value: 460
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Garbarino',
-      value: 240
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Garbarino',
-      value: 320
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Liverpool',
-      value: 250
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Liverpool',
-      value: 375
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Liverpool',
-      value: 421
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Officemax',
-      value: 250
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Officemax',
-      value: 231
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Officemax',
-      value: 450
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Panamericana',
-      value: 225
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Panamericana',
-      value: 245
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Panamericana',
-      value: 270
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Pcfactory',
-      value: 125
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Pcfactory',
-      value: 160
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Pcfactory',
-      value: 250
+      value: 0
     }
   ]
 
-  categoriesXSectorSales: any[] = [
+  categoriesXRetailSales: any[] = [
     {
       category: 'PS',
       retailer: 'Abcdin',
-      value: 1400
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Abcdin',
-      value: 1200
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Abcdin',
-      value: 1600
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Alkosto',
-      value: 800
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Alkosto',
-      value: 600
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Alkosto',
-      value: 1300
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Compumundo',
-      value: 700
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Compumundo',
-      value: 500
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Compumundo',
-      value: 1400
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Fravega',
-      value: 1250
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Fravega',
-      value: 1000
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Fravega',
-      value: 1440
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Garbarino',
-      value: 980
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Garbarino',
-      value: 970
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Garbarino',
-      value: 400
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Liverpool',
-      value: 430
+      value: 0
     },
     {
       category: 'Print',
       retailer: 'Liverpool',
-      value: 475
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Liverpool',
-      value: 480
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Officemax',
-      value: 1200
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Officemax',
-      value: 1000
+      value: 1
     },
     {
       category: 'Supplies',
       retailer: 'Officemax',
-      value: 600
+      value: 0
     },
     {
       category: 'PS',
       retailer: 'Panamericana',
-      value: 800
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Panamericana',
-      value: 950
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Panamericana',
-      value: 1000
+      value: 1
     },
     {
       category: 'PS',
       retailer: 'Pcfactory',
-      value: 800
+      value: 1
     },
     {
       category: 'Print',
       retailer: 'Pcfactory',
-      value: 700
+      value: 0
     },
     {
       category: 'Supplies',
       retailer: 'Pcfactory',
-      value: 600
+      value: 1
     }
   ]
 
-  categoriesXSector = this.categoriesXSectorSearch;
+  categoriesXRetail = this.categoriesXRetailSearch;
+
+  categoriesXSector: any[] = [
+    {
+      category: 'PS',
+      sector: 'Search',
+      value: 1
+    },
+    {
+      category: 'Print',
+      sector: 'Search',
+      value: 0
+    },
+    {
+      category: 'Supplies',
+      sector: 'Search',
+      value: 1
+    },
+    {
+      category: 'PS',
+      sector: 'Marketing',
+      value: 0
+    },
+    {
+      category: 'Print',
+      sector: 'Marketing',
+      value: 1
+    },
+    {
+      category: 'Supplies',
+      sector: 'Marketing',
+      value: 0
+    },
+    {
+      category: 'PS',
+      sector: 'Ventas',
+      value: 1
+    },
+    {
+      category: 'Print',
+      sector: 'Ventas',
+      value: 0
+    },
+    {
+      category: 'Supplies',
+      sector: 'Ventas',
+      value: 0
+    }
+  ]
 
   devicesByTraffic: any[] = [
     { id: 1, name: 'Escritorio', value: 2500 },
@@ -595,13 +643,13 @@ export class OverviewWrapperComponent implements OnInit {
 
   changeSectorData(category, selectedTab) {
     if (category === 'search') {
-      this.categoriesXSector = this.categoriesXSectorSearch;
+      this.categoriesXRetail = this.categoriesXRetailSearch;
       // this.valueName = 'Usuarios';
     } else if (category === 'marketing') {
-      this.categoriesXSector = this.categoriesXSectorMkt;
+      this.categoriesXRetail = this.categoriesXRetailMkt;
       // this.valueName = 'Ventas';
     } else if (category === 'sales') {
-      this.categoriesXSector = this.categoriesXSectorSales;
+      this.categoriesXRetail = this.categoriesXRetailSales;
       // this.valueName = 'Ventas';
     }
 


### PR DESCRIPTION
# Problem Description
- In order to use chart-heat-map component for different porpuses in necessary adapt its input properties in order to make it more custom

# Features
- Add the following inputs properties in chart-heat-map:
   - showTooltipValue (boolean) -> To show or not a value in cell tooltip in hover event
   - showGridBorders (boolean) -> To show or not grid borders (between cells)
   - showHeatLegend (boolean -> To show or not lower legend with average values triggering by column hover
- Use this properties to customize component instance in overview-wrappper component

# Where this change will be used
- Where chart-heat-map component is called

# More details
- chart-heat-map with default properties
![image](https://user-images.githubusercontent.com/38545126/115902736-5a908580-a428-11eb-8ed8-d0dbe63cd419.png)


- chart-heat-map with custom properties
![image](https://user-images.githubusercontent.com/38545126/115902603-35037c00-a428-11eb-820c-2f4fb623a66f.png)
