### PR TITLE
update conversions-wrapper template component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -8,14 +8,21 @@ import * as am4charts from '@amcharts/amcharts4/charts';
   styleUrls: ['./chart-line-comparison.component.scss']
 })
 export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
+  @Input() category: string = 'date';
 
-  @Input() data;
-  @Input() valueName1: string; // Property name shown in tooltip
-  @Input() valueName2: string; // Property name shown in tooltip
-  @Input() valueFormat: string; // USD MXN Copy shown in tooltip
-
+  chart;
   chartID;
+  series;
   loadStatus: number = 0;
+
+  private _data;
+  get data() {
+    return this._data;
+  }
+  @Input() set data(value) {
+    this._data = value;
+    this.chart && this.loadChartData(this.chart);
+  }
 
   private _name: string;
   get name() {
@@ -24,6 +31,42 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
   @Input() set name(value) {
     this._name = value;
     this.chartID = `chart-line-comparison-${this.name}`
+  }
+
+  private _valueName1: string; // Property name shown in tooltip
+  get valueName1() {
+    return this._valueName1;
+  }
+  @Input() set valueName1(value) {
+    this._valueName1 = value;
+    this.series && this.loadNamesAndFormats();
+  }
+
+  private _valueName2: string; // Property name shown in tooltip
+  get valueName2() {
+    return this._valueName2;
+  }
+  @Input() set valueName2(value) {
+    this._valueName2 = value;
+    this.series && this.loadNamesAndFormats();
+  }
+
+  private _valueFormat1: string; // USD MXN Copy shown in tooltip
+  get valueFormat1() {
+    return this._valueFormat1;
+  }
+  @Input() set valueFormat1(value) {
+    this._valueFormat1 = value;
+    this.series && this.loadNamesAndFormats();
+  }
+
+  private _valueFormat2: string; // USD MXN Copy shown in tooltip
+  get valueFormat2() {
+    return this._valueFormat2;
+  }
+  @Input() set valueFormat2(value) {
+    this._valueFormat2 = value;
+    this.series && this.loadNamesAndFormats();
   }
 
   constructor() { }
@@ -38,41 +81,34 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
   loadChart() {
     this.loadStatus = 1;
     // Create chart instance
-    var chart = am4core.create(this.chartID, am4charts.XYChart);
-    chart.data = this.data;
+    let chart = am4core.create(this.chartID, am4charts.XYChart);
+
 
     // Create axes
-    var dateAxis = chart.xAxes.push(new am4charts.DateAxis());
+    let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
     dateAxis.renderer.minGridDistance = 50;
     dateAxis.renderer.labels.template.fontSize = 12;
 
-    var valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
+    let valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
     valueAxis.renderer.labels.template.fontSize = 12;
 
-    // Create series
-    const serieName1 = this.valueName1 ? this.valueName1 : '{date.formatDate()}';
-    const serieName2 = this.valueName2 ? this.valueName2 : '{previousDate.formatDate()}';
-
     // serie 1
-    var series = chart.series.push(new am4charts.LineSeries());
-    series.dataFields.valueY = "value1";
-    series.dataFields.dateX = "date";
+    let series = chart.series.push(new am4charts.LineSeries());
+    series.dataFields.valueY = 'value1';
+    series.dataFields.dateX = this.category;
     series.strokeWidth = 2;
     series.minBulletDistance = 10;
-    series.tooltipText = `${serieName1}: [bold]${this.valueFormat ? this.valueFormat : ''} {value1}[/]\n ${serieName2}: [bold]${this.valueFormat ? this.valueFormat : ''} {value2}[/]`;
-    series.tooltip.pointerOrientation = "vertical";
+    series.tooltip.pointerOrientation = 'vertical';
     series.tensionX = 0.85;
-    series.name = serieName1;
 
     // serie 2
-    var series2 = chart.series.push(new am4charts.LineSeries());
-    series2.dataFields.valueY = "value2";
-    series2.dataFields.dateX = "date";
+    let series2 = chart.series.push(new am4charts.LineSeries());
+    series2.dataFields.valueY = 'value2';
+    series2.dataFields.dateX = this.category;
     series2.strokeWidth = 2;
-    series2.strokeDasharray = "3,4";
+    series2.strokeDasharray = '3,4';
     series2.stroke = series.stroke;
     series2.tensionX = 0.85; 1
-    series2.name = serieName2;
 
     // Add cursor
     chart.cursor = new am4charts.XYCursor();
@@ -81,6 +117,25 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
 
     chart.legend = new am4charts.Legend();
     chart.legend.position = 'bottom';
-    // this.loadStatus = 2;
+
+    this.series = { series1: series, series2: series2 };
+
+    this.loadChartData(chart);
+    this.loadNamesAndFormats();
+  }
+
+  loadChartData(chart) {
+    chart.data = this.data;
+    this.chart = chart;
+  }
+
+  loadNamesAndFormats() {
+    const serieName1 = this.valueName1 ? this.valueName1 : '{date.formatDate()}';
+    const serieName2 = this.valueName2 ? this.valueName2 : '{previousDate.formatDate()}';
+
+    this.series.series1.tooltipText = `${serieName1}: [bold]{value1} ${this.valueFormat1 ? this.valueFormat1 : ''} [/]\n ${serieName2}: [bold]{value2} ${this.valueFormat2 ? this.valueFormat2 : ''}[/]`;
+    this.series.series1.name = serieName1;
+
+    this.series.series2.name = serieName2;
   }
 }

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
@@ -85,30 +85,31 @@
 
     <div class="row mb-5">
         <div class="col-12">
-            <div class="card">
-                <div class="card-header">
-                    <span class="h4">Usuarios vs Transacciones</span>
-                </div>
-                <div class="card-body">
-                    <app-chart-column-line-mix [data]="usersVsTransacctions" name="users-vs-transaccions"
-                        category="date" columnValue="users" lineValue="transaccions" columnName="Usuarios"
-                        lineName="Transacciones" height="250px">
-                    </app-chart-column-line-mix>
-                </div>
+            <div class="pills-container">
+                <ul class="nav nav-pills nav-fill">
+                    <li class="nav-item">
+                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 1}"
+                            (click)="changeData('users', 1)">Usuarios - Transacciones</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 2}"
+                            (click)="changeData('amount_aup', 2)">Cantidad - AUP</a>
+                    </li>
+                </ul>
             </div>
         </div>
-    </div>
-
-    <div class="row mb-5">
-        <div class="col-12">
+        <div class="col-12 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">Cantidad vs AUP</span>
+                    <span class="h4" [hidden]="selectedTab === 2">Usuarios vs Transacciones</span>
+                    <span class="h4" [hidden]="selectedTab === 1">Cantidad vs AUP</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-column-line-mix [data]="amountVsAUP" name="amount-vs-aup" category="date"
-                        columnValue="amount" lineValue="aup" columnName="Cantidad" lineName="AUP" height="250px">
-                    </app-chart-column-line-mix>
+                    <app-chart-line-comparison [data]="data" name="users-vs-transaccions"
+                        [valueName1]="selectedTab === 1 ? 'Usuarios' : 'Cantidad'"
+                        [valueName2]="selectedTab === 1 ? 'Transacciones' : 'AUP'"
+                        [valueFormat2]="selectedTab === 2 && 'USD'" height="250px">
+                    </app-chart-line-comparison>
                 </div>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
@@ -23,3 +23,15 @@
         }
     }
 }
+
+.pills-container {
+    width: 60%;
+
+    .nav-item .nav-link {
+        cursor: pointer;
+    }
+
+    @media screen and (max-width: 820px) {
+        width: 100%;
+    }
+}

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -34,33 +34,37 @@ export class ConversionWrapperComponent implements OnInit, AfterViewInit {
 
   displayedColumns: string[] = ['category', 'product', 'amount', 'yoy_amount', 'product_revenue', 'yoy_product_revenue', 'aup', 'yoy_aup'];
   private categories = [
-    { category: 'Category 1', product: 'Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1', amount: 12, yoy_amount: 12, product_revenue: 50000, yoy_product_revenue: 15, aup: 820, yoy_aup: 8 },
-    { category: 'Category 2', product: 'Product 2', amount: 8, yoy_amount: 4, product_revenue: 20000, yoy_product_revenue: 7, aup: 650, yoy_aup: 4 },
-    { category: 'Category 3', product: 'Product 3', amount: 4, yoy_amount: -4, product_revenue: 10000, yoy_product_revenue: -2, aup: 350, yoy_aup: -1 }
+    { category: 'Category 1', product: 'Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1', value1: 12, yoy_amount: 12, product_revenue: 50000, yoy_product_revenue: 15, value2: 820, yoy_aup: 8 },
+    { category: 'Category 2', product: 'Product 2', value1: 8, yoy_amount: 4, product_revenue: 20000, yoy_product_revenue: 7, value2: 650, yoy_aup: 4 },
+    { category: 'Category 3', product: 'Product 3', value1: 4, yoy_amount: -4, product_revenue: 10000, yoy_product_revenue: -2, value2: 350, yoy_aup: -1 }
   ]
   dataSource = new MatTableDataSource<any>(this.categories);
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
   usersVsTransacctions = [
-    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), users: 1200, transaccions: 200 },
-    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), users: 1600, transaccions: 230 },
-    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), users: 1400, transaccions: 180 },
-    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), users: 1250, transaccions: 80 },
-    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), users: 800, transaccions: 60 },
-    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), users: 1000, transaccions: 110 },
-    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), users: 1100, transaccions: 120 }
+    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 200 },
+    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 230 },
+    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 180 },
+    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 80 },
+    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 60 },
+    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 110 },
+    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 120 }
   ]
 
   amountVsAUP = [
-    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), amount: 1200, aup: 400 },
-    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), amount: 1600, aup: 810 },
-    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), amount: 1400, aup: 320 },
-    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), amount: 1250, aup: 120 },
-    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), amount: 800, aup: 345 },
-    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), amount: 1000, aup: 850 },
-    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), amount: 1100, aup: 900 }
+    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 400 },
+    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 810 },
+    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 320 },
+    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 120 },
+    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 345 },
+    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 850 },
+    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 900 }
   ]
+
+  data: any[] = this.usersVsTransacctions;
+
+  selectedTab: number = 1;
 
   constructor() { }
 
@@ -92,4 +96,16 @@ export class ConversionWrapperComponent implements OnInit, AfterViewInit {
       return `${startIndex + 1} - ${endIndex} de ${length}`;
     }
   }
+
+
+  changeData(category, selectedTab) {
+    if (category === 'users') {
+      this.data = this.usersVsTransacctions
+    } else if (category === 'amount_aup') {
+      this.data = this.amountVsAUP;
+    }
+
+    this.selectedTab = selectedTab;
+  }
+
 }


### PR DESCRIPTION
# Problem Description
- Is necessary replace type charts in conversions-wrapper component to show data with a lage amount of months

# Features
- Replace chart-colum-line-mix instance by chart-line-comparison in conversion wrapper
- Add dinamyc inputs in chart-line-comparison component

# Where this change will be used
- In retailer view (`/dasbhoad/retailer`) -> "Campaña en el retail" section and conversions collapsable panel

# More details
![image](https://user-images.githubusercontent.com/38545126/116484152-164d1d00-a84e-11eb-9734-b0c49061551e.png)
