### PR TITLE
update heat-map component instances in overview-wrapper

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -17,6 +17,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
   @Input() showTooltipValue: boolean = true; // show the value in tooltip
   @Input() showGridBorders: boolean = false;
   @Input() showHeatLegend: boolean = true; // lower legend with average values triggering by column hover
+  @Input() initialColor: string; // valid css color
 
   private _name: string;
   get name() {
@@ -104,7 +105,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
     series.heatRules.push({
       target: columnTemplate,
       property: 'fill',
-      min: am4core.color(bgColor),
+      min: this.initialColor ? am4core.color(this.initialColor) : am4core.color(bgColor),
       max: chart.colors.getIndex(0)
     });
 

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -90,7 +90,8 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     this.valueAxis = valueAxis;
 
     chart.legend = new am4charts.Legend();
-    chart.legend.contentAlign = 'right';
+    chart.legend.contentAlign = 'left';
+    chart.legend.fontSize = 12;
 
     // Create series
     let male = chart.series.push(new am4charts.ColumnSeries());
@@ -103,7 +104,6 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     let maleLabel = male.bullets.push(new am4charts.LabelBullet());
     maleLabel.label.hideOversized = false;
     maleLabel.label.truncate = false;
-    maleLabel.label.horizontalCenter = 'right';
     maleLabel.label.dx = -10;
     maleLabel.label.fontSize = 12;
 
@@ -121,7 +121,6 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     let femaleLabel = female.bullets.push(new am4charts.LabelBullet());
     femaleLabel.label.hideOversized = false;
     femaleLabel.label.truncate = false;
-    femaleLabel.label.horizontalCenter = 'left';
     femaleLabel.label.dx = 10;
     femaleLabel.label.fontSize = 12;
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -37,9 +37,19 @@
                     </ng-container>
                 </div>
                 <div class="card-body">
+                    <div class="chart-legend mt-0 mb-2">
+                        <div class="legend-container">
+                            <div class="legend-square on"></div>
+                            <div class="legend-label">On</div>
+                        </div>
+                        <div class="legend-container ml-3">
+                            <div class="legend-square off"></div>
+                            <div class="legend-label">Off</div>
+                        </div>
+                    </div>
                     <app-chart-heat-map [data]="categoriesXRetail" [name]="selectedType + 'categories-by-retailer'"
                         categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false">
+                        [showGridBorders]="true" [showHeatLegend]="false" initialColor="#fafafa">
                     </app-chart-heat-map>
                 </div>
             </div>
@@ -53,9 +63,19 @@
                     <span class="h4">Categorías por Sector</span>
                 </div>
                 <div class="card-body">
+                    <div class="chart-legend mt-0 mb-2">
+                        <div class="legend-container">
+                            <div class="legend-square on"></div>
+                            <div class="legend-label">On</div>
+                        </div>
+                        <div class="legend-container ml-3">
+                            <div class="legend-square off"></div>
+                            <div class="legend-label">Off</div>
+                        </div>
+                    </div>
                     <app-chart-heat-map [data]="categoriesXSector" [name]="selectedType + 'categories-by-sector'"
                         categoryX="sector" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false">
+                        [showGridBorders]="true" [showHeatLegend]="false" initialColor="#fafafa">
                     </app-chart-heat-map>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
@@ -35,3 +35,35 @@
         width: 100%;
     }
 }
+
+.chart-legend {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 15px;
+
+    .legend-container {
+        align-items: center;
+        display: flex;
+       
+        .legend-square {
+            border-radius: 4px;
+            height: 25px;
+            margin-right: 4px;
+            width: 25px;
+
+            &.on {
+                background-color: #67B6DC;
+            }
+
+            &.off {
+                background-color: #F3F3F3;
+            }
+        }
+
+        .legend-label {
+            color: #000000;
+            font-size: 12px;
+        }
+    }
+}


### PR DESCRIPTION
# Problem Description
- In order to make the heat-maps component instances in overview-wrapper more understandable is necessary add some legends in the chart

# Features
- Add initialColor in chart-heat-map component to use it as the lighter color scale
- Add legends in chart-heat-map component instances from overview-wrapper component

# Where this change will be used
- In country and retailer overview at `/dashboard/country` and `/dashboard/retailer` paths

# More details
- Country view
![image](https://user-images.githubusercontent.com/38545126/116491658-01798500-a860-11eb-979c-589fa2437782.png)

- Retailer view
![image](https://user-images.githubusercontent.com/38545126/116491624-eb6bc480-a85f-11eb-9d22-e1ae5c3fd13f.png)
