### PR TITLE
add basic template to google my business section

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
@@ -1,0 +1,3 @@
+<div class="chart" [style.height]="height">
+    <div [id]="chartID" style="height: 100%"></div>
+</div>

--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.spec.ts
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChartMultipleAxesComponent } from './chart-multiple-axes.component';
+
+describe('ChartMultipleAxesComponent', () => {
+  let component: ChartMultipleAxesComponent;
+  let fixture: ComponentFixture<ChartMultipleAxesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChartMultipleAxesComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChartMultipleAxesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.ts
@@ -1,0 +1,93 @@
+import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import * as am4core from '@amcharts/amcharts4/core';
+import * as am4charts from '@amcharts/amcharts4/charts';
+import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+
+@Component({
+  selector: 'app-chart-multiple-axes',
+  templateUrl: './chart-multiple-axes.component.html',
+  styleUrls: ['./chart-multiple-axes.component.scss']
+})
+export class ChartMultipleAxesComponent implements OnInit, AfterViewInit {
+  @Input() data;
+  @Input() height: string = '350px'; // height property value valid in css
+  @Input() value1: string = 'value1'; // object property represented as valueAxis1 (left axis)
+  @Input() value2: string = 'value2'; // object property represented as valueAxis2 (right axis)
+  @Input() valueName1: string = 'Value 1';
+  @Input() valueName2: string = 'Value 2';
+  @Input() valueFormat1: string;
+  @Input() valueFormat2: string;
+
+  private _name: string;
+  get name() {
+    return this._name;
+  }
+  @Input() set name(value) {
+    this._name = value;
+    this.chartID = `chart-multiple-axes-${this.name}`
+  }
+
+  chartID;
+  loadStatus: number = 0;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadChart();
+  }
+
+  loadChart() {
+    am4core.useTheme(am4themes_animated);
+    let chart = am4core.create(this.chartID, am4charts.XYChart);
+    chart.data = this.data;
+    chart.numberFormatter.numberFormat = "#.##";
+
+    // Create axes
+    let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
+    dateAxis.renderer.labels.template.fontSize = 12;
+
+    let valueAxis1 = chart.yAxes.push(new am4charts.ValueAxis());
+    valueAxis1.title.text = this.valueName1;
+    valueAxis1.renderer.labels.template.fontSize = 12;
+
+    let valueAxis2 = chart.yAxes.push(new am4charts.ValueAxis());
+    valueAxis2.title.text = this.valueName2;
+    valueAxis2.renderer.opposite = true;
+    valueAxis2.renderer.grid.template.disabled = true;
+    valueAxis2.renderer.labels.template.fontSize = 12;
+
+    // Create series
+    let series1 = chart.series.push(new am4charts.LineSeries());
+    series1.dataFields.valueY = this.value1;
+    series1.dataFields.dateX = 'date';
+    series1.name = this.valueName1;
+    series1.strokeWidth = 2;
+    series1.tensionX = 0.7;
+    series1.yAxis = valueAxis1;
+    series1.tooltipText = `{name}\n[bold font-size: 20]{valueY} ${this.valueFormat1 ? this.valueFormat1 : ''}[/]`;
+
+    let series2 = chart.series.push(new am4charts.LineSeries());
+    series2.dataFields.valueY = this.value2;
+    series2.dataFields.dateX = 'date';
+    series2.name = this.valueName2;
+    series2.strokeWidth = 2;
+    series2.tensionX = 0.7;
+    series2.yAxis = valueAxis2;
+    series2.tooltipText = `{name}\n[bold font-size: 20]{valueY} ${this.valueFormat2 ? this.valueFormat2 : ''}[/]`;
+
+    let bullet3 = series2.bullets.push(new am4charts.CircleBullet());
+    bullet3.circle.radius = 3;
+    bullet3.circle.strokeWidth = 2;
+    bullet3.circle.fill = am4core.color('#fff');
+
+    // Add cursor
+    chart.cursor = new am4charts.XYCursor();
+
+    // Add legend
+    chart.legend = new am4charts.Legend();
+    chart.legend.position = 'bottom';
+  }
+}

--- a/src/app/modules/dashboard/components/google-business/google-business.component.html
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.html
@@ -1,0 +1,110 @@
+<!-- filters -->
+<div class="row">
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="h4 mb-1">Provincia</small>
+        <mat-select [formControl]="provinces" multiple placeholder="Selecciona una Provincia">
+            <mat-select-trigger>
+                {{provinces.value ? provinces.value[0]?.name : ''}}
+                <span *ngIf="provinces.value?.length > 1" class="example-additional-selection">
+                    (+ {{provinces.value?.length === 2 ? 'otra' : 'otras'}}
+                    {{ provinces.value?.length === 2 ? '' : provinces.value.length - 1}})
+                </span>
+            </mat-select-trigger>
+            <mat-option *ngFor="let province of provinceList" [value]="province">{{province.name}}</mat-option>
+        </mat-select>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <small class="h4 mb-1">Ciudad</small>
+        <mat-select [formControl]="cities" multiple placeholder="Selecciona una Ciudad">
+            <mat-select-trigger>
+                {{cities.value ? cities.value[0]?.name : ''}}
+                <span *ngIf="cities.value?.length > 1" class="example-additional-selection">
+                    (+ {{cities.value?.length === 2 ? 'otra' : 'otras'}}
+                    {{ cities.value?.length === 2 ? '' : cities.value.length - 1}})
+                </span>
+            </mat-select-trigger>
+            <mat-option *ngFor="let city of cityList" [value]="city">{{city.name}}</mat-option>
+        </mat-select>
+    </div>
+    <div class="col-12 col-lg-6 mb-4">
+        <div class="button-container">
+            <button type="button" class="btn btn-primary">
+                <i class="fas fa-filter mr-2"></i>
+                Filtrar
+            </button>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <!-- al parecer esta sera una grafica de pareto por el %  -->
+                <app-chart-line-comparison [data]="visitsVsRate" name="visits-vs-rate" valueName1="Visitas"
+                    valueName2="% Visit Rate" valueFormat2="%" height="250px">
+                </app-chart-line-comparison>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="adaptable-container">
+            <table mat-table [dataSource]="dataSource">
+                <!-- province column -->
+                <ng-container matColumnDef="province">
+                    <th mat-header-cell *matHeaderCellDef> Provincia </th>
+                    <td mat-cell *matCellDef="let element"> {{element.province}} </td>
+                </ng-container>
+
+                <!-- city column -->
+                <ng-container matColumnDef="city">
+                    <th mat-header-cell *matHeaderCellDef> Ciudad </th>
+                    <td mat-cell *matCellDef="let element">
+                        <div class="lg-container">
+                            <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.product"
+                                matTooltipPosition="right" matTooltipClass="custom-tooltip">
+                                {{element.city}}
+                            </span>
+                        </div>
+                    </td>
+                </ng-container>
+
+                <!-- store column-->
+                <ng-container matColumnDef="store">
+                    <th mat-header-cell *matHeaderCellDef> Tienda</th>
+                    <td mat-cell *matCellDef="let element"> {{element.store}} </td>
+                </ng-container>
+
+                <!-- visits column -->
+                <ng-container matColumnDef="visits">
+                    <th mat-header-cell *matHeaderCellDef> Visitas</th>
+                    <td mat-cell *matCellDef="let element"> {{element.visits}}% </td>
+                </ng-container>
+
+                <!-- visitRate column -->
+                <ng-container matColumnDef="visitRate">
+                    <th mat-header-cell *matHeaderCellDef> % Visit Rate</th>
+                    <td mat-cell *matCellDef="let element"> {{element.visitRate}}% </td>
+                </ng-container>
+
+                <!-- disclaimer column -->
+                <ng-container matColumnDef="disclaimer">
+                    <td mat-footer-cell *matFooterCellDef colspan="3">
+                        <div class="text-danger text-center" *ngIf="getReqStatus === 3">
+                            Ocurrió un error al consultar los usuarios
+                        </div>
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
+                    [hidden]="getReqStatus !== 3"></tr>
+            </table>
+        </div>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/google-business/google-business.component.html
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.html
@@ -38,18 +38,40 @@
 
 <div class="row mt-5">
     <div class="col-12">
+        <div class="pills-container">
+            <ul class="nav nav-pills nav-fill">
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}" (click)="selectedTab1 = 1">Sin
+                        Store Visits</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}" (click)="selectedTab1 = 2">Con
+                        Store Visits</a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class="col-12 mt-4" *ngIf="selectedTab1 === 1">
         <div class="card">
             <div class="card-body">
-                <!-- al parecer esta sera una grafica de pareto por el %  -->
-                <app-chart-line-comparison [data]="visitsVsRate" name="visits-vs-rate" valueName1="Visitas"
-                    valueName2="% Visit Rate" valueFormat2="%" height="250px">
-                </app-chart-line-comparison>
+                <app-chart-multiple-axes [data]="visitsVsRate" valueName1="Visitas" valueName2="% Visit Rate"
+                    value1="visits" value2="visits_rate" valueFormat2="%" name="visits-vs-rate">
+                </app-chart-multiple-axes>
+            </div>
+        </div>
+    </div>
+    <div class="col-12 mt-4" *ngIf="selectedTab1 === 2">
+        <div class="card">
+            <div class="card-body">
+                <app-chart-multiple-axes [data]="visitsVsRate" valueName1="Visitas" valueName2="% Store Visits Rate"
+                    value1="visits" value2="visits_rate" valueFormat2="%" name="visits-vs-rate-2">
+                </app-chart-multiple-axes>
             </div>
         </div>
     </div>
 </div>
 
-<div class="row mt-5">
+<div class="row mt-5" *ngIf="selectedTab1 === 1">
     <div class="col-12">
         <div class="adaptable-container">
             <table mat-table [dataSource]="dataSource">
@@ -101,6 +123,72 @@
 
                 <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
                 <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
+                    [hidden]="getReqStatus !== 3"></tr>
+            </table>
+        </div>
+        <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
+    </div>
+</div>
+
+<div class="row mt-5" *ngIf="selectedTab1 === 2">
+    <div class="col-12">
+        <div class="adaptable-container">
+            <table mat-table [dataSource]="dataSource">
+                <!-- province column -->
+                <ng-container matColumnDef="province">
+                    <th mat-header-cell *matHeaderCellDef> Provincia </th>
+                    <td mat-cell *matCellDef="let element"> {{element.province}} </td>
+                </ng-container>
+
+                <!-- city column -->
+                <ng-container matColumnDef="city">
+                    <th mat-header-cell *matHeaderCellDef> Ciudad </th>
+                    <td mat-cell *matCellDef="let element">
+                        <div class="lg-container">
+                            <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.product"
+                                matTooltipPosition="right" matTooltipClass="custom-tooltip">
+                                {{element.city}}
+                            </span>
+                        </div>
+                    </td>
+                </ng-container>
+
+                <!-- store column-->
+                <ng-container matColumnDef="store">
+                    <th mat-header-cell *matHeaderCellDef> Tienda</th>
+                    <td mat-cell *matCellDef="let element"> {{element.store}} </td>
+                </ng-container>
+
+                <!-- visits column -->
+                <ng-container matColumnDef="visits">
+                    <th mat-header-cell *matHeaderCellDef> Visitas</th>
+                    <td mat-cell *matCellDef="let element"> {{element.visits}}% </td>
+                </ng-container>
+
+                <!-- visitRate column -->
+                <ng-container matColumnDef="visitRate">
+                    <th mat-header-cell *matHeaderCellDef> % Visit Rate</th>
+                    <td mat-cell *matCellDef="let element"> {{element.visitRate}}% </td>
+                </ng-container>
+
+                <!-- storeVisitsRate column -->
+                <ng-container matColumnDef="storeVisitsRate">
+                    <th mat-header-cell *matHeaderCellDef> % Store Visit Rate</th>
+                    <td mat-cell *matCellDef="let element"> {{element.storeVisitsRate}}% </td>
+                </ng-container>
+
+                <!-- disclaimer column -->
+                <ng-container matColumnDef="disclaimer">
+                    <td mat-footer-cell *matFooterCellDef colspan="3">
+                        <div class="text-danger text-center" *ngIf="getReqStatus === 3">
+                            Ocurrió un error al consultar los usuarios
+                        </div>
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns2"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns2;"></tr>
                 <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
                     [hidden]="getReqStatus !== 3"></tr>
             </table>

--- a/src/app/modules/dashboard/components/google-business/google-business.component.scss
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.scss
@@ -1,0 +1,15 @@
+.button-container {
+    align-items: flex-end;
+    display: flex;
+    height: 100%;
+    justify-content: flex-end;
+}
+
+table {
+    width: 100%;
+
+    th:nth-of-type(n + 4),
+    td:nth-of-type(n + 4) {
+        text-align: center;
+    }
+}

--- a/src/app/modules/dashboard/components/google-business/google-business.component.scss
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.scss
@@ -13,3 +13,15 @@ table {
         text-align: center;
     }
 }
+
+.pills-container {
+    width: 60%;
+
+    .nav-item .nav-link {
+        cursor: pointer;
+    }
+
+    @media screen and (max-width: 820px) {
+        width: 100%;
+    }
+}

--- a/src/app/modules/dashboard/components/google-business/google-business.component.spec.ts
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GoogleBusinessComponent } from './google-business.component';
+
+describe('GoogleBusinessComponent', () => {
+  let component: GoogleBusinessComponent;
+  let fixture: ComponentFixture<GoogleBusinessComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ GoogleBusinessComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GoogleBusinessComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/google-business/google-business.component.ts
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.ts
@@ -1,0 +1,74 @@
+import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatTableDataSource } from '@angular/material/table';
+import * as moment from 'moment'
+
+@Component({
+  selector: 'app-google-business',
+  templateUrl: './google-business.component.html',
+  styleUrls: ['./google-business.component.scss']
+})
+export class GoogleBusinessComponent implements OnInit, AfterViewInit {
+
+  provinces = new FormControl();
+  provinceList: any[] = [{ id: 1, name: 'Provincia 1' }, { id: 2, name: 'Provincia 2' }, { id: 3, name: 'Provincia 3' }, { id: 4, name: 'Provincia 4' }];
+
+  cities = new FormControl();
+  cityList: any[] = [{ id: 1, name: 'Ciudad 1' }, { id: 2, name: 'Ciudad 2' }, { id: 3, name: 'Ciudad 3' }, { id: 4, name: 'Ciudad 4' }, { id: 5, name: 'Ciudad 5' }, { id: 3, name: 'Ciudad 6' }];
+  constructor() { }
+
+  visitsVsRate = [
+    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 200 },
+    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 230 },
+    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 180 },
+    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 80 },
+    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 60 },
+    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 110 },
+    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 120 }
+  ]
+
+  displayedColumns: string[] = ['province', 'city', 'store', 'visits', 'visitRate'];
+  private categories = [
+    { province: 'Buenos Aires', city: 'Moreno', store: 'Francisco Narciso de Laprida 386', visits: 250, visitRate: 14.45 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Flores', store: 'Laprida 394', visits: 114, visitRate: 14.85 },
+    { province: 'Córdoba', city: 'Córdoba', store: 'Avenida Cabildo 2075', visits: 150, visitRate: 13.14 },
+    { province: 'Buenos Aires', city: 'Castelar', store: 'Hipolito Yrigoyen 769 (Ex ruta 197)', visits: 130, visitRate: 14.12 },
+    { province: 'Mendoza', city: 'Ciudad Autonoma de Buenos Aires', store: 'Belgrano', visits: 118, visitRate: 14.10 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Buenos Aires', store: 'Av Gral. Fernández de la Cruz 4602', visits: 195, visitRate: 8.85 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Belgrano', store: 'Avenida Rivadavia 5249', visits: 180, visitRate: 12.26 },
+  ]
+  dataSource = new MatTableDataSource<any>(this.categories);
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+
+  ngOnInit(): void {
+  }
+
+  ngAfterViewInit() {
+    this.loadPaginator();
+  }
+
+  loadPaginator() {
+    // paginator setup
+    this.dataSource.paginator = this.paginator;
+    this.paginator._intl.itemsPerPageLabel = 'Registros por página';
+    this.paginator._intl.nextPageLabel = 'Siguiente';
+    this.paginator._intl.previousPageLabel = 'Anterior';
+    this.paginator._intl.getRangeLabel = (page: number, pageSize: number, length: number) => {
+      if (length == 0 || pageSize == 0) { return `0 de ${length}`; }
+
+      length = Math.max(length, 0);
+
+      const startIndex = page * pageSize;
+
+      // If the start index exceeds the list length, do not try and fix the end index to the end.
+      const endIndex = startIndex < length ?
+        Math.min(startIndex + pageSize, length) :
+        startIndex + pageSize;
+
+      return `${startIndex + 1} - ${endIndex} de ${length}`;
+    }
+  }
+}

--- a/src/app/modules/dashboard/components/google-business/google-business.component.ts
+++ b/src/app/modules/dashboard/components/google-business/google-business.component.ts
@@ -18,30 +18,52 @@ export class GoogleBusinessComponent implements OnInit, AfterViewInit {
   cityList: any[] = [{ id: 1, name: 'Ciudad 1' }, { id: 2, name: 'Ciudad 2' }, { id: 3, name: 'Ciudad 3' }, { id: 4, name: 'Ciudad 4' }, { id: 5, name: 'Ciudad 5' }, { id: 3, name: 'Ciudad 6' }];
   constructor() { }
 
-  visitsVsRate = [
-    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 200 },
-    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 230 },
-    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 180 },
-    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 80 },
-    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 60 },
-    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 110 },
-    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 120 }
-  ]
+  visitsVsRate = [{
+    'date': '2021-03-15',
+    'visits': 1298,
+    'visits_rate': 0.68,
+  }, {
+    'date': '2021-03-16',
+    'visits': 816,
+    'visits_rate': 0.71,
+  }, {
+    'date': '2021-03-17',
+    'visits': 1963,
+    'visits_rate': 0.7,
+  }, {
+    'date': '2021-03-18',
+    'visits': 1809,
+    'visits_rate': 0.83,
+  }, {
+    'date': '2021-03-19',
+    'visits': 1434,
+    'visits_rate': 0.8,
+  }, {
+    'date': '2021-03-20',
+    'visits': 2359,
+    'visits_rate': 0.91,
+  }, {
+    'date': '2021-03-21',
+    'visits': 2114,
+    'visits_rate': 1,
+  },];
 
   displayedColumns: string[] = ['province', 'city', 'store', 'visits', 'visitRate'];
+  displayedColumns2: string[] = ['province', 'city', 'store', 'visits', 'visitRate', 'storeVisitsRate'];
   private categories = [
-    { province: 'Buenos Aires', city: 'Moreno', store: 'Francisco Narciso de Laprida 386', visits: 250, visitRate: 14.45 },
-    { province: 'Ciudad autonoma de buenos Aires', city: 'Flores', store: 'Laprida 394', visits: 114, visitRate: 14.85 },
-    { province: 'Córdoba', city: 'Córdoba', store: 'Avenida Cabildo 2075', visits: 150, visitRate: 13.14 },
-    { province: 'Buenos Aires', city: 'Castelar', store: 'Hipolito Yrigoyen 769 (Ex ruta 197)', visits: 130, visitRate: 14.12 },
-    { province: 'Mendoza', city: 'Ciudad Autonoma de Buenos Aires', store: 'Belgrano', visits: 118, visitRate: 14.10 },
-    { province: 'Ciudad autonoma de buenos Aires', city: 'Buenos Aires', store: 'Av Gral. Fernández de la Cruz 4602', visits: 195, visitRate: 8.85 },
-    { province: 'Ciudad autonoma de buenos Aires', city: 'Belgrano', store: 'Avenida Rivadavia 5249', visits: 180, visitRate: 12.26 },
+    { province: 'Buenos Aires', city: 'Moreno', store: 'Francisco Narciso de Laprida 386', visits: 250, visitRate: 14.45, storeVisitsRate: 12.12 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Flores', store: 'Laprida 394', visits: 114, visitRate: 14.85, storeVisitsRate: 14.05 },
+    { province: 'Córdoba', city: 'Córdoba', store: 'Avenida Cabildo 2075', visits: 150, visitRate: 13.14, storeVisitsRate: 13.01 },
+    { province: 'Buenos Aires', city: 'Castelar', store: 'Hipolito Yrigoyen 769 (Ex ruta 197)', visits: 130, visitRate: 11.25, storeVisitsRate: 14.11 },
+    { province: 'Mendoza', city: 'Ciudad Autonoma de Buenos Aires', store: 'Belgrano', visits: 118, visitRate: 14.10, storeVisitsRate: 13.12 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Buenos Aires', store: 'Av Gral. Fernández de la Cruz 4602', visits: 195, visitRate: 8.85, storeVisitsRate: 8.32 },
+    { province: 'Ciudad autonoma de buenos Aires', city: 'Belgrano', store: 'Avenida Rivadavia 5249', visits: 180, visitRate: 12.26, storeVisitsRate: 9.45 },
   ]
   dataSource = new MatTableDataSource<any>(this.categories);
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
 
+  selectedTab1 = 1;
 
   ngOnInit(): void {
   }

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -18,6 +18,7 @@ import { DashboardComponent } from './dashboard.component';
 import { GeneralFiltersComponent } from './components/general-filters/general-filters.component';
 import { RetailFiltersComponent } from './components/retail-filters/retail-filters.component';
 import { CardStatComponent } from './components/card-stat/card-stat.component';
+import { GoogleBusinessComponent } from './components/google-business/google-business.component';
 import { DashboardRoutes } from './dashboard.routing';
 
 // pages
@@ -73,6 +74,7 @@ import { ChartPyramidComponent } from './components/charts/chart-pyramid/chart-p
     OverviewWrapperComponent,
     CampaignsTablesComponent,
     ChartPyramidComponent,
+    GoogleBusinessComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -18,6 +18,7 @@ import { DashboardComponent } from './dashboard.component';
 import { GeneralFiltersComponent } from './components/general-filters/general-filters.component';
 import { RetailFiltersComponent } from './components/retail-filters/retail-filters.component';
 import { CardStatComponent } from './components/card-stat/card-stat.component';
+import { CampaignsTablesComponent } from './components/campaigns-tables/campaigns-tables.component';
 import { GoogleBusinessComponent } from './components/google-business/google-business.component';
 import { DashboardRoutes } from './dashboard.routing';
 
@@ -27,9 +28,11 @@ import { RetailerComponent } from './pages/retailer/retailer.component';
 import { OtherToolsComponent } from './pages/other-tools/other-tools.component';
 
 // wrappers
+import { OverviewWrapperComponent } from './components/overview-wrapper/overview-wrapper.component';
 import { AudiencesWrapperComponent } from './components/audiences-wrapper/audiences-wrapper.component';
 import { AcquisitionWrapperComponent } from './components/acquisition-wrapper/acquisition-wrapper.component';
 import { BehaviourWrapperComponent } from './components/behaviour-wrapper/behaviour-wrapper.component';
+import { ConversionWrapperComponent } from './components/conversion-wrapper/conversion-wrapper.component';
 
 // charts
 import { ChartBarComponent } from './components/charts/chart-bar/chart-bar.component';
@@ -40,12 +43,10 @@ import { ChartLineComparisonComponent } from './components/charts/chart-line-com
 import { ChartLineSeriesComponent } from './components/charts/chart-line-series/chart-line-series.component';
 import { ChartLollipopComponent } from './components/charts/chart-lollipop/chart-lollipop.component';
 import { ChartPieComponent } from './components/charts/chart-pie/chart-pie.component';
-import { ConversionWrapperComponent } from './components/conversion-wrapper/conversion-wrapper.component';
 import { ChartColumnLineMixComponent } from './components/charts/chart-column-line-mix/chart-column-line-mix.component';
 import { ChartPictorialComponent } from './components/charts/chart-pictorial/chart-pictorial.component';
-import { OverviewWrapperComponent } from './components/overview-wrapper/overview-wrapper.component';
-import { CampaignsTablesComponent } from './components/campaigns-tables/campaigns-tables.component';
 import { ChartPyramidComponent } from './components/charts/chart-pyramid/chart-pyramid.component';
+import { ChartMultipleAxesComponent } from './components/charts/chart-multiple-axes/chart-multiple-axes.component';
 
 
 @NgModule({
@@ -75,6 +76,7 @@ import { ChartPyramidComponent } from './components/charts/chart-pyramid/chart-p
     CampaignsTablesComponent,
     ChartPyramidComponent,
     GoogleBusinessComponent,
+    ChartMultipleAxesComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -183,6 +183,6 @@
     </ng-container>
 
     <ng-container *ngIf="activeTabView === 4">
-        <p class="text-muted">Google My Business...</p>
+        <app-google-business></app-google-business>
     </ng-container>
 </div>


### PR DESCRIPTION
# Problem Description
- Create a basic template to "Google My Business" section into retailer view

# Features
- Add google-business component
- Use google-business component in retailer component
- Add basic template to google-business component
- Add chart-multiple-axes
- Use chart-multiple-axes component in google-business component

# Where this change will be used
- In Google My Business section and retailer view at `/dashboard/retailer` path

# More details
![image](https://user-images.githubusercontent.com/38545126/116584082-991cb900-a8dc-11eb-8c39-b66a0b81d631.png)
![image](https://user-images.githubusercontent.com/38545126/116584116-a2a62100-a8dc-11eb-8614-4a4298d7951f.png)
