### PR TITLE
add basic template to other-tools component

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -80,7 +80,7 @@
               <!-- custom icon -->
               <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i>
 
-              {{ menuItem.title | titlecase }}
+              {{ menuItem.title}}
             </a>
 
             <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -34,9 +34,9 @@ export class ConversionWrapperComponent implements OnInit, AfterViewInit {
 
   displayedColumns: string[] = ['category', 'product', 'amount', 'yoy_amount', 'product_revenue', 'yoy_product_revenue', 'aup', 'yoy_aup'];
   private categories = [
-    { category: 'Category 1', product: 'Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1', value1: 12, yoy_amount: 12, product_revenue: 50000, yoy_product_revenue: 15, value2: 820, yoy_aup: 8 },
-    { category: 'Category 2', product: 'Product 2', value1: 8, yoy_amount: 4, product_revenue: 20000, yoy_product_revenue: 7, value2: 650, yoy_aup: 4 },
-    { category: 'Category 3', product: 'Product 3', value1: 4, yoy_amount: -4, product_revenue: 10000, yoy_product_revenue: -2, value2: 350, yoy_aup: -1 }
+    { category: 'Category 1', product: 'Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1', amount: 12, yoy_amount: 12, product_revenue: 50000, yoy_product_revenue: 15, value2: 820, yoy_aup: 8 },
+    { category: 'Category 2', product: 'Product 2', amount: 8, yoy_amount: 4, product_revenue: 20000, yoy_product_revenue: 7, value2: 650, yoy_aup: 4 },
+    { category: 'Category 3', product: 'Product 3', amount: 4, yoy_amount: -4, product_revenue: 10000, yoy_product_revenue: -2, value2: 350, yoy_aup: -1 }
   ]
   dataSource = new MatTableDataSource<any>(this.categories);
 

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -1,1 +1,31 @@
-<p>other-tools works!</p>
+<div class="main-container mt-4">
+    <ul class="nav nav-tabs mb-4">
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}" (click)="activeTabView = 1">
+                <span class="h2 py-2 ml-3 mr-3">Indexado</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}" (click)="activeTabView = 2">
+                <span class="h2 py-2 ml-3 mr-3">PC Selector</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}" (click)="activeTabView = 3">
+                <span class="h2 py-2 ml-3 mr-3">OmniChat</span>
+            </a>
+        </li>
+    </ul>
+
+    <ng-container *ngIf="activeTabView === 1">
+        <p class="text-muted">Indexado</p>
+    </ng-container>
+
+    <ng-container *ngIf="activeTabView === 2">
+        <p class="text-muted">PC Selector</p>
+    </ng-container>
+
+    <ng-container *ngIf="activeTabView === 3">
+        <p class="text-muted">OmniChat</p>
+    </ng-container>
+</div>

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.scss
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.scss
@@ -1,0 +1,3 @@
+.nav-link {
+    cursor: pointer;
+}

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -7,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
 })
 export class OtherToolsComponent implements OnInit {
 
+  activeTabView = 1;
+
   constructor() { }
 
   ngOnInit(): void {


### PR DESCRIPTION
# Problem Description
- Add basic template to other-tools component

# Features
- Show options tabs in template

# Where this change will be used
- In other tools for each retailer in a country at `/dashboard/tools` path

# More details
![image](https://user-images.githubusercontent.com/38545126/116632339-95108b80-a91c-11eb-93c8-f3c2d24a56e1.png)

