### PR TITLE
add country view functionality to overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -43,8 +43,8 @@
                         <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial [data]="devices" [name]="selectedType + 'devices'" category="name"
-                            iconType="monitor" height="280px">
+                        <app-chart-pictorial [data]="devices" name="devices" category="name" iconType="monitor"
+                            height="280px">
                         </app-chart-pictorial>
                     </div>
                 </div>
@@ -60,8 +60,7 @@
                         <span *ngSwitchCase="4" class="h4">BR por Género</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial [data]="gender" [name]="selectedType + 'gender'" category="name"
-                            height="280px">
+                        <app-chart-pictorial [data]="gender" name="gender" category="name" height="280px">
                         </app-chart-pictorial>
                     </div>
                 </div>
@@ -80,8 +79,8 @@
                         <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar [data]="devices" [name]="selectedType + 'devices'" valueFormat="USD"
-                            category="name" height="280px" [legendsByCategory]="true">
+                        <app-chart-bar [data]="devices" name="devices" valueFormat="USD" category="name" height="280px"
+                            [legendsByCategory]="true">
                         </app-chart-bar>
                     </div>
                 </div>
@@ -97,8 +96,8 @@
                         <span *ngSwitchCase="4" class="h4">BR por Género</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar [data]="gender" [name]="selectedType + 'gender'" valueFormat="USD"
-                            category="name" height="280px" [legendsByCategory]="true">
+                        <app-chart-bar [data]="gender" name="gender" valueFormat="USD" category="name" height="280px"
+                            [legendsByCategory]="true">
                         </app-chart-bar>
                     </div>
                 </div>
@@ -125,7 +124,7 @@
                                         <div class="legend-label">Desktop {{ desktopByBR[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="desktopByBR" [name]="selectedType + 'devices-desktop'"
+                                <app-chart-pictorial [data]="desktopByBR" name="devices-desktop"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -137,7 +136,7 @@
                                         <div class="legend-label">Mobile {{ mobileByBR[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="mobileByBR" [name]="selectedType + 'devices-mobile'"
+                                <app-chart-pictorial [data]="mobileByBR" name="devices-mobile"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -165,7 +164,7 @@
                                         <div class="legend-label">Hombres {{ menByBR[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="menByBR" [name]="selectedType + 'gender-man'"
+                                <app-chart-pictorial [data]="menByBR" name="gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" height="280px">
                                 </app-chart-pictorial>
                             </div>
@@ -177,7 +176,7 @@
                                         <div class="legend-label">Mujeres {{ womenByBR[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="womenByBR" [name]="selectedType + 'gender-woman'"
+                                <app-chart-pictorial [data]="womenByBR" name="gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" height="280px">
                                 </app-chart-pictorial>
                             </div>
@@ -197,7 +196,7 @@
                     <span *ngSwitchCase="4" class="h4">BR por Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="age" [name]="selectedType + 'age'" category="age"
+                    <app-chart-lollipop [data]="age" name="age" category="age"
                         [valueFormat]="selectedTab1 !== 3 ? '%' : 'USD'" height="280px">
                     </app-chart-lollipop>
                 </div>
@@ -215,13 +214,12 @@
                 </div>
                 <div class="card-body">
                     <ng-container *ngIf="selectedTab1 !== 3">
-                        <app-chart-pyramid [data]="ageByGender" [name]="selectedType + 'age-and-gender'" valueFormat="%"
-                            height="280px">
+                        <app-chart-pyramid [data]="ageByGender" name="age-and-gender" valueFormat="%" height="280px">
                         </app-chart-pyramid>
                     </ng-container>
                     <ng-container *ngIf="selectedTab1 === 3">
-                        <app-chart-pyramid [data]="ageByGender" [name]="selectedType + 'age-and-gender-2'"
-                            height="280px" valueFormat="USD">
+                        <app-chart-pyramid [data]="ageByGender" name="age-and-gender-2" height="280px"
+                            valueFormat="USD">
                         </app-chart-pyramid>
                     </ng-container>
                 </div>

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -10,7 +10,10 @@
                             {{ stat.metricValue | currency }}
                         </span>
                         <span *ngSwitchCase="'percentage'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue | number : '1.2-3' }}%
+                            {{ stat.metricValue | number : '1.2-2' }}%
+                        </span>
+                        <span *ngSwitchCase="'decimals'" class="h3 font-weight-bold mb-0">
+                            {{ stat.metricValue | number : '1.2-2' }}
                         </span>
                         <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
                             {{ stat.metricValue }}
@@ -40,7 +43,10 @@
                             {{ stat.subMetricValue | currency }}
                         </span>
                         <span *ngSwitchCase="'percentage'">
-                            {{ stat.subMetricValue | number : '1.2-3' }}%
+                            {{ stat.subMetricValue | number : '1.2-2' }}%
+                        </span>
+                        <span *ngSwitchCase="'decimals'">
+                            {{ stat.subMetricValue | number : '1.2-2' }}
                         </span>
                         <span *ngSwitchDefault>
                             {{ stat.subMetricValue }}

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -3,7 +3,26 @@
         <div class="metric-container">
             <div class="metric-data">
                 <h4 class="card-title text-uppercase text-muted mb-0">{{ stat.metricTitle }}</h4>
-                <span class="h3 font-weight-bold mb-0">{{ stat.metricValue }}</span>
+                <!-- content -->
+                <ng-container *ngIf="!loader">
+                    <ng-container [ngSwitch]="stat.metricFormat">
+                        <span *ngSwitchCase="'currency'" class="h3 font-weight-bold mb-0">
+                            {{ stat.metricValue | currency }}
+                        </span>
+                        <span *ngSwitchCase="'percentage'" class="h3 font-weight-bold mb-0">
+                            {{ stat.metricValue }}%
+                        </span>
+                        <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
+                            {{ stat.metricValue }}
+                        </span>
+                    </ng-container>
+                    <span class="h3 font-weight-bold mb-0">{{ stat.metricSymbol }}</span>
+                </ng-container>
+
+                <!-- loader -->
+                <ng-container *ngIf="loader">
+                    <div class="bar-loader"></div>
+                </ng-container>
             </div>
             <div class="metric-icon">
                 <div class="icon icon-shape text-white rounded-circle shadow" [style.background-color]="stat.iconBg">
@@ -14,7 +33,26 @@
         <div class="submetric-container text-muted" *ngIf="stat.subMetricTitle">
             <div class="submetric-data">
                 <span class="text-nowrap h5 mr-2 text-muted text-uppercase"><b>{{ stat.subMetricTitle }}</b></span>
-                <span>{{ stat.subMetricValue }}</span>
+                <!-- content -->
+                <ng-container *ngIf="!loader">
+                    <ng-container [ngSwitch]="stat.subMetricFormat">
+                        <span *ngSwitchCase="'currency'">
+                            {{ stat.subMetricValue | currency }}
+                        </span>
+                        <span *ngSwitchCase="'percentage'">
+                            {{ stat.subMetricValue }}%
+                        </span>
+                        <span *ngSwitchDefault>
+                            {{ stat.subMetricValue }}
+                        </span>
+                    </ng-container>
+                    <span>{{ stat.subMetricSymbol }}</span>
+                </ng-container>
+
+                <!-- loader -->
+                <ng-container *ngIf="loader">
+                    <div class="bar-loader"></div>
+                </ng-container>
             </div>
         </div>
     </div>

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -10,7 +10,7 @@
                             {{ stat.metricValue | currency }}
                         </span>
                         <span *ngSwitchCase="'percentage'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue }}%
+                            {{ stat.metricValue | number : '1.2-3' }}%
                         </span>
                         <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
                             {{ stat.metricValue }}
@@ -40,7 +40,7 @@
                             {{ stat.subMetricValue | currency }}
                         </span>
                         <span *ngSwitchCase="'percentage'">
-                            {{ stat.subMetricValue }}%
+                            {{ stat.subMetricValue | number : '1.2-3' }}%
                         </span>
                         <span *ngSwitchDefault>
                             {{ stat.subMetricValue }}

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
@@ -9,6 +9,7 @@ export class CardStatComponent implements OnInit {
 
   @Input() stat;
   @Input() height: string = '120px' // valid css height property value
+  @Input() loader: boolean;
 
   constructor() { }
 

--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.html
@@ -1,3 +1,13 @@
 <div class="chart" [style.height]="height">
-    <div [id]="chartID" style="height: 100%"></div>
+    <!-- loader -->
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
+
+    <!-- ready -->
+    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -18,6 +18,8 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
   @Input() showGridBorders: boolean = false;
   @Input() showHeatLegend: boolean = true; // lower legend with average values triggering by column hover
   @Input() initialColor: string; // valid css color
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   private _name: string;
   get name() {
@@ -39,7 +41,6 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
 
   chart;
   chartID;
-  loadStatus: number = 0;
 
   constructor() { }
 

--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -82,16 +82,17 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
     series.defaultState.transitionDuration = 3000;
 
     let bgColor = new am4core.InterfaceColorSet().getFor('background');
-    let bgColor2 = am4core.color('#adb5bd');
 
     let columnTemplate = series.columns.template;
-    columnTemplate.strokeWidth = 1;
-    columnTemplate.strokeOpacity = 0.2;
 
     if (this.showGridBorders) {
+      let bgColor2 = am4core.color('#ffffff');
       columnTemplate.stroke = bgColor2;
+      columnTemplate.strokeWidth = 2;
     } else {
       columnTemplate.stroke = bgColor
+      columnTemplate.strokeWidth = 1;
+      columnTemplate.strokeOpacity = 0.2;
     }
 
     let tooltipLegend = this.showTooltipValue

--- a/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.html
@@ -1,0 +1,5 @@
+<div class="loader">
+    <span></span>
+    <span></span>
+    <span></span>
+</div>

--- a/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.scss
@@ -1,0 +1,39 @@
+.loader {
+    align-items: center;
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+}
+
+.loader span {
+    background-color: #d7d7d7;
+    border-radius: 100%;
+    display: inline-block;
+    height: 20px;
+    margin: 0px 8px;
+    opacity: 0;
+    width: 20px;
+}
+  
+.loader span:nth-child(1) {
+    animation: opacitychange 1s ease-in-out infinite;
+}
+  
+.loader span:nth-child(2) {
+    animation: opacitychange 1s ease-in-out 0.33s infinite;
+}
+  
+.loader span:nth-child(3) {
+    animation: opacitychange 1s ease-in-out 0.66s infinite;
+}
+  
+@keyframes opacitychange {
+    0%, 100%{
+      opacity: 0;
+    }
+  
+    60%{
+      opacity: 1;
+    }
+}

--- a/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.spec.ts
+++ b/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ChartLoaderComponent } from './chart-loader.component';
+
+describe('ChartLoaderComponent', () => {
+  let component: ChartLoaderComponent;
+  let fixture: ComponentFixture<ChartLoaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ChartLoaderComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ChartLoaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-loader/chart-loader.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-chart-loader',
+  templateUrl: './chart-loader.component.html',
+  styleUrls: ['./chart-loader.component.scss']
+})
+export class ChartLoaderComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
@@ -1,3 +1,13 @@
 <div class="chart" [style.height]="height">
+    <!-- loader -->
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
+
+    <!-- ready -->
     <div [id]="graphID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -13,9 +13,10 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
   @Input() value: string = 'value';
   @Input() category: string = 'category';
   @Input() height: string = '350px'; // height property value valid in css
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   graphID;
-  loadStatus: number = 0;
 
   private _name: string;
   get name() {

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -10,7 +10,6 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 })
 export class ChartLollipopComponent implements OnInit, AfterViewInit {
 
-  @Input() value: string = 'value';
   @Input() category: string = 'category';
   @Input() height: string = '350px'; // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
@@ -33,8 +32,22 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
   }
   @Input() set data(value) {
     this._data = value;
-    this.chart && this.loadChartData(this.chart);
+    if (this.chart) {
+      this.loadChartData(this.chart);
+    }
   }
+
+  private _value = 'value';
+  get value() {
+    return this._value;
+  }
+  @Input() set value(value) {
+    this._value = value;
+    if (this.series) {
+      this.series.dataFields.valueY = this.value;
+    }
+  }
+
 
   private _valueFormat;
   get valueFormat() {
@@ -106,7 +119,10 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
   }
 
   loadChartData(chart) {
+    console.log('loadChartData')
     chart.data = this.data;
+
+    console.log('chart.data', chart.data)
     this.chart = chart;
   }
 

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
@@ -1,3 +1,13 @@
 <div class="chart" [style.height]="height">
-    <div [id]="chartID" style="height: 100%"></div>
+    <!-- loader -->
+    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+
+    <!-- ready -->
+    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -16,10 +16,11 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit {
   @Input() iconType: string = 'human';
   @Input() height: string = '350px'; // height property value valid in css
   @Input() uniqueDimensionConf: OneDimensionPictorial;
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   chart;
   chartID;
-  loadStatus: number = 0;
 
   private _name: string;
   get name() {
@@ -70,13 +71,14 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit {
     series.labels.template.disabled = true;
     series.ticks.template.disabled = true;
 
+
     if (!this.uniqueDimensionConf) {
       // default settings
       chart.legend = new am4charts.Legend();
       chart.legend.position = 'left';
       chart.legend.valign = 'bottom';
       chart.legend.fontSize = 12;
-      chart.responsive.enabled = true;
+
     } else {
       // customize the unique serie
       series.colors.list = [
@@ -91,6 +93,7 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit {
       });
     }
 
+    chart.responsive.enabled = true;
     this.loadChartData(chart);
   }
 

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
@@ -1,3 +1,13 @@
 <div class="chart" [style.height]="height">
-    <div [id]="chartID" style="height: 100%"></div>
+    <!-- loader -->
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
+
+    <!-- ready -->
+    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -16,6 +16,8 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
   @Input() valueName1: string = 'Hombres';
   @Input() valueName2: string = 'Mujeres';
   @Input() height: string = '350px'; // height property value valid in css
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   private _name: string;
   get name() {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -14,15 +14,15 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="changeSectorData('search', 1)">Search</a>
+                            (click)="getCategoriesBySector('search', 1)">Search</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="changeSectorData('marketing', 2)">Marketing</a>
+                            (click)="getCategoriesBySector('marketing', 2)">Marketing</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                            (click)="changeSectorData('sales', 3)">Ventas</a>
+                            (click)="getCategoriesBySector('sales', 3)">Ventas</a>
                     </li>
                 </ul>
             </div>
@@ -47,7 +47,7 @@
                             <div class="legend-label">Inactivas</div>
                         </div>
                     </div>
-                    <app-chart-heat-map [data]="categoriesXRetail" [name]="selectedType + 'categories-by-retailer'"
+                    <app-chart-heat-map [data]="categoriesBySector" [name]="selectedType + 'categories-by-sector'"
                         categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
                         [showGridBorders]="true" [showHeatLegend]="false" initialColor="#fafafa">
                     </app-chart-heat-map>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -49,7 +49,8 @@
                     </div>
                     <app-chart-heat-map [data]="categoriesBySector" [name]="selectedType + 'categories-by-sector'"
                         categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false" initialColor="#fafafa">
+                        [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
+                        initialColor="#fafafa">
                     </app-chart-heat-map>
                 </div>
             </div>
@@ -105,7 +106,7 @@
                 </div>
                 <div class="card-body">
                     <app-chart-pictorial [data]="trafficAndSales.device" [name]="selectedType + 'devices'"
-                        category="name" iconType="monitor" height="280px">
+                        category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus" height="280px">
                     </app-chart-pictorial>
                 </div>
             </div>
@@ -119,7 +120,7 @@
                 </div>
                 <div class="card-body">
                     <app-chart-pictorial [data]="trafficAndSales.gender" [name]="selectedType + 'gender'"
-                        category="name" height="280px">
+                        category="name" [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                     </app-chart-pictorial>
                 </div>
             </div>
@@ -133,7 +134,7 @@
                 </div>
                 <div class="card-body">
                     <app-chart-lollipop [data]="trafficAndSales.age" [name]="selectedType + 'age'" category="age"
-                        value="visits" valueFormat="%" height="280px">
+                        value="visits" valueFormat="%" height="280px" [status]="trafficSalesReqStatus[2].reqStatus">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -147,7 +148,7 @@
                 </div>
                 <div class="card-body">
                     <app-chart-pyramid [data]="trafficAndSales.genderByAge" [name]="selectedType + 'age-and-gender'"
-                        height="280px">
+                        [status]="trafficSalesReqStatus[3].reqStatus" height="280px">
                     </app-chart-pyramid>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -14,15 +14,15 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="getCategoriesBySector('search', 1)">Search</a>
+                            (click)="getCategoriesBySector('Search', 1)">Search</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="getCategoriesBySector('marketing', 2)">Marketing</a>
+                            (click)="getCategoriesBySector('Marketing', 2)">Marketing</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                            (click)="getCategoriesBySector('sales', 3)">Ventas</a>
+                            (click)="getCategoriesBySector('Ventas', 3)">Ventas</a>
                     </li>
                 </ul>
             </div>
@@ -105,7 +105,7 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pictorial [data]="trafficAndSales.device" [name]="selectedType + 'devices'"
+                    <app-chart-pictorial [data]="trafficAndSales['device']" [name]="selectedType + 'devices'"
                         category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus" height="280px">
                     </app-chart-pictorial>
                 </div>
@@ -119,7 +119,7 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pictorial [data]="trafficAndSales.gender" [name]="selectedType + 'gender'"
+                    <app-chart-pictorial [data]="trafficAndSales['gender']" [name]="selectedType + 'gender'"
                         category="name" [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                     </app-chart-pictorial>
                 </div>
@@ -133,8 +133,9 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="trafficAndSales.age" [name]="selectedType + 'age'" category="age"
-                        value="visits" valueFormat="%" height="280px" [status]="trafficSalesReqStatus[2].reqStatus">
+                    <app-chart-lollipop [data]="trafficAndSales['age']" [name]="selectedType + 'age'" category="age"
+                        [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
+                        [status]="trafficSalesReqStatus[2].reqStatus">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -147,7 +148,7 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pyramid [data]="trafficAndSales.genderByAge" [name]="selectedType + 'age-and-gender'"
+                    <app-chart-pyramid [data]="trafficAndSales['genderByAge']" [name]="selectedType + 'age-and-gender'"
                         [status]="trafficSalesReqStatus[3].reqStatus" height="280px">
                     </app-chart-pyramid>
                 </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -50,7 +50,7 @@
                     <app-chart-heat-map [data]="categoriesBySector" [name]="selectedType + 'categories-by-sector'"
                         categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
                         [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
-                        initialColor="#fafafa">
+                        initialColor="#e9e9e9">
                     </app-chart-heat-map>
                 </div>
             </div>
@@ -76,7 +76,7 @@
                     </div>
                     <app-chart-heat-map [data]="categoriesXSector" [name]="selectedType + 'categories-by-sector'"
                         categoryX="sector" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false" initialColor="#fafafa">
+                        [showGridBorders]="true" [showHeatLegend]="false" initialColor="#e9e9e9">
                     </app-chart-heat-map>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -3,7 +3,7 @@
     <div class="row">
         <div class="col-12">
             <div class="stats-container">
-                <app-card-stat *ngFor="let stat of stats" [stat]="stat"></app-card-stat>
+                <app-card-stat *ngFor="let stat of kpis" [stat]="stat" [loader]="kpisReqStatus <= 1"></app-card-stat>
             </div>
         </div>
     </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -88,11 +88,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="changeDeviceGenderData('traffic', 1)">Tráfico</a>
+                            (click)="getDataByTrafficAndSales('traffic', 1)">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="changeDeviceGenderData('sales', 2)">Ventas</a>
+                            (click)="getDataByTrafficAndSales('sales', 2)">Ventas</a>
                     </li>
                 </ul>
             </div>
@@ -104,8 +104,8 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pictorial [data]="devices" [name]="selectedType + 'devices'" category="name"
-                        iconType="monitor" height="280px">
+                    <app-chart-pictorial [data]="trafficAndSales.device" [name]="selectedType + 'devices'"
+                        category="name" iconType="monitor" height="280px">
                     </app-chart-pictorial>
                 </div>
             </div>
@@ -118,8 +118,8 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pictorial [data]="gender" [name]="selectedType + 'gender'" category="name"
-                        height="280px">
+                    <app-chart-pictorial [data]="trafficAndSales.gender" [name]="selectedType + 'gender'"
+                        category="name" height="280px">
                     </app-chart-pictorial>
                 </div>
             </div>
@@ -132,8 +132,8 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="age" [name]="selectedType + 'age'" category="age" value="visits"
-                        valueFormat="%" height="280px">
+                    <app-chart-lollipop [data]="trafficAndSales.age" [name]="selectedType + 'age'" category="age"
+                        value="visits" valueFormat="%" height="280px">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -146,7 +146,8 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-pyramid [data]="ageByGender" [name]="selectedType + 'age-and-gender'" height="280px">
+                    <app-chart-pyramid [data]="trafficAndSales.genderByAge" [name]="selectedType + 'age-and-gender'"
+                        height="280px">
                     </app-chart-pyramid>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
@@ -57,7 +57,7 @@
             }
 
             &.off {
-                background-color: #F3F3F3;
+                background-color: #e9e9e9;
             }
         }
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -903,18 +903,14 @@ export class OverviewWrapperComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    console.log('INIT!!!')
-
     // tengo que partir de valores iniciales cuando se inicualiza el componente ya que en ese momento puede que no haya cambio
     this.userRole = this.userService.user.role_name;
 
     const selectedCountry = this.appStateService.selectedCountry;
-    console.log('selectedCountry', selectedCountry);
     this.countryID = selectedCountry?.id && selectedCountry?.id;
-    this.getAllData();
+    this.countryID && this.getAllData();
 
     this.appStateService.selectedCountry$.subscribe(country => {
-      console.log('countryID', this.countryID);
       if (this.userRole !== 'retailer' && country?.id !== this.countryID) {
         this.countryID = country?.id !== this.countryID && country?.id;
         this.getAllData();
@@ -923,7 +919,6 @@ export class OverviewWrapperComponent implements OnInit {
     });
 
     this.appStateService.selectedRetailer$.subscribe(retailer => {
-      console.log('retailer', this.retailerID);
       if (retailer?.id !== this.retailerID) {
         this.retailerID = retailer?.id !== this.retailerID && retailer?.id;
         this.getAllData();
@@ -933,9 +928,8 @@ export class OverviewWrapperComponent implements OnInit {
   }
 
   getAllData() {
-    console.log('getAllData')
     this.getKpis();
-    this.getCategoriesBySector('search', 1);
+    this.getCategoriesBySector('Search', 1);
     this.getDataByTrafficAndSales('traffic', 1);
   }
 
@@ -944,11 +938,8 @@ export class OverviewWrapperComponent implements OnInit {
     this.kpisReqStatus = 1;
     this.overviewService.getKpis(this.countryID).subscribe(
       (resp: any[]) => {
-        // console.log('resp', resp);
         const kpis1 = resp.filter(kpi => this.kpisLegends1.includes(kpi.string));
         const kpis2 = resp.filter(kpi => this.kpisLegends2.includes(kpi.string));
-        // console.log('kpis1', kpis1);
-        // console.log('kpis2', kpis2);
 
         for (let i = 0; i < this.kpis.length; i++) {
           const baseObj = this.kpis[i];
@@ -959,8 +950,6 @@ export class OverviewWrapperComponent implements OnInit {
           }
 
         }
-
-        // console.log('final kpis', this.kpis);
         this.kpisReqStatus = 2;
       },
       error => {
@@ -974,7 +963,6 @@ export class OverviewWrapperComponent implements OnInit {
     this.categoriesReqStatus = 1;
     this.overviewService.getCategoriesBySector(this.countryID, sector).subscribe(
       (resp: any[]) => {
-        // console.log('resp', resp);
         this.categoriesBySector = resp.sort((a, b) => (a.retailer < b.retailer ? -1 : 1));;
         this.categoriesReqStatus = 2;
       },
@@ -995,7 +983,6 @@ export class OverviewWrapperComponent implements OnInit {
       reqStatusObj.reqStatus = 1;
       this.overviewService.getTrafficAndSales(this.countryID, metricType, subMetricType).subscribe(
         (resp: any[]) => {
-          // console.log('resp', resp);
           if (subMetricType === 'gender-and-age') {
             this.trafficAndSales['genderByAge'] = resp;
           } else {
@@ -1013,8 +1000,6 @@ export class OverviewWrapperComponent implements OnInit {
 
       this.selectedTab2 = selectedTab;
     }
-    // console.log('trafficSalesReqStatus', this.trafficSalesReqStatus);
-    // console.log('trafficAndSales', this.trafficAndSales)
   }
 
   changeSectorData(category, selectedTab) {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -481,23 +481,23 @@ export class OverviewWrapperComponent implements OnInit {
   ]
 
   devicesByTraffic: any[] = [
-    { id: 1, name: 'Desktop', value: 2500 },
-    { id: 2, name: 'Mobile', value: 10500 },
+    { name: 'Desktop', value: 2500 },
+    { name: 'Mobile', value: 10500 },
   ]
 
   devicesBySales: any[] = [
-    { id: 1, name: 'Desktop', value: 300 },
-    { id: 2, name: 'Mobile', value: 450 },
+    { name: 'Desktop', value: 300 },
+    { name: 'Mobile', value: 450 },
   ]
 
   genderByTraffic: any[] = [
-    { id: 1, name: 'Hombre', value: 5500 },
-    { id: 2, name: 'Mujer', value: 7500 },
+    { name: 'Hombre', value: 5500 },
+    { name: 'Mujer', value: 7500 },
   ]
 
   genderBySales: any[] = [
-    { id: 1, name: 'Hombre', value: 1200 },
-    { id: 2, name: 'Mujer', value: 12800 },
+    { name: 'Hombre', value: 1200 },
+    { name: 'Mujer', value: 12800 },
   ]
 
   ageByTraffic: any[] = [
@@ -903,25 +903,37 @@ export class OverviewWrapperComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+    console.log('INIT!!!')
+
+    // tengo que partir de valores iniciales cuando se inicualiza el componente ya que en ese momento puede que no haya cambio
     this.userRole = this.userService.user.role_name;
 
+    const selectedCountry = this.appStateService.selectedCountry;
+    console.log('selectedCountry', selectedCountry);
+    this.countryID = selectedCountry?.id && selectedCountry?.id;
+    this.getAllData();
+
     this.appStateService.selectedCountry$.subscribe(country => {
-      if (this.userRole !== 'retailer' && country.id !== this.countryID) {
-        this.countryID = country.id !== this.countryID && country.id;
+      console.log('countryID', this.countryID);
+      if (this.userRole !== 'retailer' && country?.id !== this.countryID) {
+        this.countryID = country?.id !== this.countryID && country?.id;
         this.getAllData();
       }
-      console.log('countryID', this.countryID);
+
     });
 
     this.appStateService.selectedRetailer$.subscribe(retailer => {
-      if (retailer.id !== this.countryID) {
-        this.retailerID = retailer.id !== this.retailerID && retailer.id;
-      }
       console.log('retailer', this.retailerID);
+      if (retailer?.id !== this.retailerID) {
+        this.retailerID = retailer?.id !== this.retailerID && retailer?.id;
+        this.getAllData();
+      }
+
     });
   }
 
   getAllData() {
+    console.log('getAllData')
     this.getKpis();
     this.getCategoriesBySector('search', 1);
     this.getDataByTrafficAndSales('traffic', 1);
@@ -983,7 +995,7 @@ export class OverviewWrapperComponent implements OnInit {
       reqStatusObj.reqStatus = 1;
       this.overviewService.getTrafficAndSales(this.countryID, metricType, subMetricType).subscribe(
         (resp: any[]) => {
-          console.log('resp', resp);
+          // console.log('resp', resp);
           if (subMetricType === 'gender-and-age') {
             this.trafficAndSales['genderByAge'] = resp;
           } else {
@@ -991,6 +1003,7 @@ export class OverviewWrapperComponent implements OnInit {
           }
 
           reqStatusObj.reqStatus = 2;
+
         },
         error => {
           const errorMsg = error?.error?.message ? error.error.message : error?.message;
@@ -1000,8 +1013,8 @@ export class OverviewWrapperComponent implements OnInit {
 
       this.selectedTab2 = selectedTab;
     }
-    console.log('trafficSalesReqStatus', this.trafficSalesReqStatus);
-    console.log('trafficAndSales', this.trafficAndSales)
+    // console.log('trafficSalesReqStatus', this.trafficSalesReqStatus);
+    // console.log('trafficAndSales', this.trafficAndSales)
   }
 
   changeSectorData(category, selectedTab) {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -882,8 +882,10 @@ export class OverviewWrapperComponent implements OnInit {
     }
   ];
 
-  kpisReqStatus: number = 0;
+  categoriesBySector: any[];
 
+  kpisReqStatus: number = 0;
+  categoriesReqStatus: number = 0;
 
 
   constructor(
@@ -913,6 +915,7 @@ export class OverviewWrapperComponent implements OnInit {
 
   getAllData() {
     this.getKpis();
+    this.getCategoriesBySector('search', 1);
   }
 
 
@@ -945,6 +948,23 @@ export class OverviewWrapperComponent implements OnInit {
         console.error(`[overview-wrapper.component]: ${errorMsg}`);
         this.kpisReqStatus = 3;
       });
+  }
+
+  getCategoriesBySector(sector: string, selectedTab: number) {
+    this.categoriesReqStatus = 1;
+    this.overviewService.getCategoriesBySector(this.countryID, sector).subscribe(
+      (resp: any[]) => {
+        console.log('resp', resp);
+        this.categoriesBySector = resp;
+        this.categoriesReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.categoriesReqStatus = 3;
+      });
+
+    this.selectedTab1 = selectedTab;
   }
 
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -877,7 +877,7 @@ export class OverviewWrapperComponent implements OnInit {
       metricFormat: 'currency',
       subMetricTitle: 'roas',
       subMetricName: 'roas',
-      subMetricFormat: 'percentage',
+      subMetricFormat: 'decimals',
       icon: 'fas fa-hand-holding-usd',
       iconBg: '#fbc001'
     }

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -831,7 +831,7 @@ export class OverviewWrapperComponent implements OnInit {
   retailerID: number;
   userRole: string;
 
-  kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transaccions', 'revenue']
+  kpisLegends1 = ['inversion', 'clicks', 'bounce_rate', 'transactions', 'revenue']
   kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
 
   kpis: any[] = [
@@ -945,8 +945,8 @@ export class OverviewWrapperComponent implements OnInit {
     this.overviewService.getKpis(this.countryID).subscribe(
       (resp: any[]) => {
         // console.log('resp', resp);
-        const kpis1 = resp.filter(kpi => this.kpisLegends1.includes(kpi.name));
-        const kpis2 = resp.filter(kpi => this.kpisLegends2.includes(kpi.name));
+        const kpis1 = resp.filter(kpi => this.kpisLegends1.includes(kpi.string));
+        const kpis2 = resp.filter(kpi => this.kpisLegends2.includes(kpi.string));
         // console.log('kpis1', kpis1);
         // console.log('kpis2', kpis2);
 
@@ -975,7 +975,7 @@ export class OverviewWrapperComponent implements OnInit {
     this.overviewService.getCategoriesBySector(this.countryID, sector).subscribe(
       (resp: any[]) => {
         // console.log('resp', resp);
-        this.categoriesBySector = resp;
+        this.categoriesBySector = resp.sort((a, b) => (a.retailer < b.retailer ? -1 : 1));;
         this.categoriesReqStatus = 2;
       },
       error => {

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -20,6 +20,8 @@ import { RetailFiltersComponent } from './components/retail-filters/retail-filte
 import { CardStatComponent } from './components/card-stat/card-stat.component';
 import { CampaignsTablesComponent } from './components/campaigns-tables/campaigns-tables.component';
 import { GoogleBusinessComponent } from './components/google-business/google-business.component';
+import { CampaignComparatorComponent } from './pages/campaign-comparator/campaign-comparator.component';
+import { SentimentAnalysisComponent } from './pages/sentiment-analysis/sentiment-analysis.component';
 import { DashboardRoutes } from './dashboard.routing';
 
 // pages
@@ -79,6 +81,8 @@ import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loa
     GoogleBusinessComponent,
     ChartMultipleAxesComponent,
     ChartLoaderComponent,
+    CampaignComparatorComponent,
+    SentimentAnalysisComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -47,6 +47,7 @@ import { ChartColumnLineMixComponent } from './components/charts/chart-column-li
 import { ChartPictorialComponent } from './components/charts/chart-pictorial/chart-pictorial.component';
 import { ChartPyramidComponent } from './components/charts/chart-pyramid/chart-pyramid.component';
 import { ChartMultipleAxesComponent } from './components/charts/chart-multiple-axes/chart-multiple-axes.component';
+import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loader.component';
 
 
 @NgModule({
@@ -77,6 +78,7 @@ import { ChartMultipleAxesComponent } from './components/charts/chart-multiple-a
     ChartPyramidComponent,
     GoogleBusinessComponent,
     ChartMultipleAxesComponent,
+    ChartLoaderComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -1,11 +1,15 @@
 import { Routes } from '@angular/router';
+import { CampaignComparatorComponent } from './pages/campaign-comparator/campaign-comparator.component';
 
 import { CountryComponent } from './pages/country/country.component';
 import { OtherToolsComponent } from './pages/other-tools/other-tools.component';
 import { RetailerComponent } from './pages/retailer/retailer.component';
+import { SentimentAnalysisComponent } from './pages/sentiment-analysis/sentiment-analysis.component';
 
 export const DashboardRoutes: Routes = [
     { path: 'country', component: CountryComponent },
     { path: 'retailer', component: RetailerComponent },
     { path: 'tools', component: OtherToolsComponent },
+    { path: 'campaign-comparator', component: CampaignComparatorComponent },
+    { path: 'omnichat', component: SentimentAnalysisComponent },
 ];

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
@@ -1,0 +1,1 @@
+<p class="h3">Comparador de campaña</p>

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.spec.ts
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CampaignComparatorComponent } from './campaign-comparator.component';
+
+describe('CampaignComparatorComponent', () => {
+  let component: CampaignComparatorComponent;
+  let fixture: ComponentFixture<CampaignComparatorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CampaignComparatorComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CampaignComparatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.ts
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-campaign-comparator',
+  templateUrl: './campaign-comparator.component.html',
+  styleUrls: ['./campaign-comparator.component.scss']
+})
+export class CampaignComparatorComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.html
+++ b/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.html
@@ -1,0 +1,1 @@
+<p class="h3">Análisis de sentimientos OmniChat</p>

--- a/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.spec.ts
+++ b/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SentimentAnalysisComponent } from './sentiment-analysis.component';
+
+describe('SentimentAnalysisComponent', () => {
+  let component: SentimentAnalysisComponent;
+  let fixture: ComponentFixture<SentimentAnalysisComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SentimentAnalysisComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SentimentAnalysisComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.ts
+++ b/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-sentiment-analysis',
+  templateUrl: './sentiment-analysis.component.html',
+  styleUrls: ['./sentiment-analysis.component.scss']
+})
+export class SentimentAnalysisComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/dashboard/services/overview.service.spec.ts
+++ b/src/app/modules/dashboard/services/overview.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OverviewService } from './overview.service';
+
+describe('OverviewService', () => {
+  let service: OverviewService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OverviewService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -1,0 +1,52 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+import { Configuration } from 'src/app/app.constants';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OverviewService {
+  private baseUrl: string;
+
+  constructor(
+    private http: HttpClient,
+    private config: Configuration
+  ) {
+    this.baseUrl = this.config.endpoint;
+  }
+
+  // *** kpis ***
+  getKpis(countryID: number) {
+    if (!countryID) {
+      return throwError('[overview.service]: not countryID provided');
+    }
+    return this.http.get(`${this.baseUrl}/country/${countryID}/kpis`);
+  }
+
+  // *** categories by sector ***
+  getCategoriesBySector(countryID: number, sector: string) {
+    if (!countryID) {
+      return throwError('[overview.service]: not countryID provided');
+    }
+    if (!sector) {
+      return throwError('[overview.service]: not sector provided');
+    }
+    return this.http.get(`${this.baseUrl}/country/${countryID}/retailer/categories/sector`);
+    return this.http.get(`${this.baseUrl}/country/${countryID}/retailer/categories?sector=${sector}`);
+  }
+
+  // *** traffic and sales ***
+  getTrafficAndSales(countryID: number, metricType: string, subMetricType: string) {
+    if (!countryID) {
+      return throwError('[overview.service]: not countryID provided');
+    }
+    if (!metricType) {
+      return throwError('[overview.service]: not metricType provided');
+    }
+    if (!subMetricType) {
+      return throwError('[overview.service]: not subMetricType provided');
+    }
+    return this.http.get(`${this.baseUrl}/country${countryID}/${metricType}/${subMetricType}`);
+  }
+}

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -8,6 +8,7 @@ import { Configuration } from 'src/app/app.constants';
 })
 export class OverviewService {
   private baseUrl: string;
+  period = `start_date=2021-04-15&end_date=2021-04-30`
 
   constructor(
     private http: HttpClient,
@@ -21,7 +22,7 @@ export class OverviewService {
     if (!countryID) {
       return throwError('[overview.service]: not countryID provided');
     }
-    return this.http.get(`${this.baseUrl}/country/${countryID}/kpis`);
+    return this.http.get(`${this.baseUrl}/countries/${countryID}/kpis?sectors=1,2,3&categories=1,2,3,4&${this.period}`);
   }
 
   // *** categories by sector ***
@@ -32,8 +33,8 @@ export class OverviewService {
     if (!sector) {
       return throwError('[overview.service]: not sector provided');
     }
-    return this.http.get(`${this.baseUrl}/country/${countryID}/retailer/categories/sector`);
-    return this.http.get(`${this.baseUrl}/country/${countryID}/retailer/categories?sector=${sector}`);
+    // return this.http.get(`${this.baseUrl}/countries/${countryID}/retailer/categories/sector`);
+    return this.http.get(`${this.baseUrl}/countries/${countryID}/retailer/categories?sector=${sector}&${this.period}`);
   }
 
   // *** traffic and sales ***
@@ -47,6 +48,6 @@ export class OverviewService {
     if (!subMetricType) {
       return throwError('[overview.service]: not subMetricType provided');
     }
-    return this.http.get(`${this.baseUrl}/country/${countryID}/${metricType}/${subMetricType}`);
+    return this.http.get(`${this.baseUrl}/countries/${countryID}/${metricType}/${subMetricType}?${this.period}`);
   }
 }

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -47,6 +47,6 @@ export class OverviewService {
     if (!subMetricType) {
       return throwError('[overview.service]: not subMetricType provided');
     }
-    return this.http.get(`${this.baseUrl}/country${countryID}/${metricType}/${subMetricType}`);
+    return this.http.get(`${this.baseUrl}/country/${countryID}/${metricType}/${subMetricType}`);
   }
 }

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -13,26 +13,32 @@ export class AppStateService {
   // selected country
   private countrySource = new Subject<any>();
   selectedCountry$ = this.countrySource.asObservable();
+  selectedCountry;
 
   // selected retailer
   private retailerSource = new Subject<any>();
   selectedRetailer$ = this.retailerSource.asObservable();
+  selectedRetailer;
 
   constructor() { }
 
   selectCountry(country?) {
     if (country) {
       this.countrySource.next(country);
+      this.selectedCountry = country;
     } else {
       this.countrySource.next();
+      this.selectedCountry && delete this.selectedCountry;
     }
   }
 
   selectRetailer(retailer?) {
     if (retailer) {
       this.retailerSource.next(retailer);
+      this.selectedRetailer = retailer;
     } else {
       this.retailerSource.next();
+      this.selectedRetailer && delete this.selectedRetailer;
     }
 
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -293,3 +293,11 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
     width: 16px;
   }
 }
+
+.chart-error-container {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
# Problem Description
- In order to make a functional component is necessary add request to CO-OP API

# Features
- Add overview service to include enpoints used in overview-wrapper component
- Add GET requests to the following endpoints
  - /countries/{country_id}/kpis
  - /countries/{country_id}/retailer/categories?sector={sector_name}
  - /countries/{country_id}/{traffic or sale}/{device or gender or age or gender-and-age}
  
- Other implications:
   - Add chart-loader component
   - Update the following components components to show loader, success or error states:
      - card-stat
     - chart-heat-map
      - chart-pictorial
      - chart-lollipop
      - chart-pyramid
 - Update colors and borders in chart-heap-map instances from overview-wrapper component
 - Add new pages components to dashboard module
     - campaign-comparator component
     - sentimental-analysis component
  
# Bug Fixes
- Fix .ts errors in audiences-wrapper component

# Where this change will be used
- In country overview at `/dashboard/country?country={country_name}` path

# More details
![image](https://user-images.githubusercontent.com/38545126/116943074-740bab80-ac38-11eb-99b1-d72aefada1ac.png)
![image](https://user-images.githubusercontent.com/38545126/116943109-8259c780-ac38-11eb-9176-1d506d0ad0b4.png)
![image](https://user-images.githubusercontent.com/38545126/116943141-8f76b680-ac38-11eb-9924-487d869be883.png)
- Error state:
![image](https://user-images.githubusercontent.com/38545126/116943208-b6cd8380-ac38-11eb-98d8-bcb0f11aebde.png)

- Loading state:
![image](https://user-images.githubusercontent.com/38545126/116943264-d06ecb00-ac38-11eb-9944-f136d3e99011.png)

