### PR TITLE
add basic funcionality to general-filters component in country

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -119,10 +119,7 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
   }
 
   loadChartData(chart) {
-    console.log('loadChartData')
     chart.data = this.data;
-
-    console.log('chart.data', chart.data)
     this.chart = chart;
   }
 

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -25,7 +25,7 @@
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{sectors.value ? sectors.value[0]?.name : ''}}</span>
-                        <span *ngIf="sectors.value?.length > 1" class="example-additional-selection">
+                        <span *ngIf="sectors.value?.length > 1" class="example-additional-selection ml-1">
                             (+ {{sectors.value?.length === 2 ? 'otra' : 'otras'}}
                             {{ sectors.value?.length === 2 ? '' : sectors.value.length - 1}})
                         </span>
@@ -33,6 +33,9 @@
                 </mat-select-trigger>
                 <mat-option *ngFor="let sector of sectorList" [value]="sector">{{sector.name}}</mat-option>
             </mat-select>
+            <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
+                Selecciona al menos un sector
+            </small>
         </div>
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Categoría</span>
@@ -40,7 +43,7 @@
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{categories.value ? categories.value[0]?.name : ''}}</span>
-                        <span *ngIf="categories.value?.length > 1" class="example-additional-selection">
+                        <span *ngIf="categories.value?.length > 1" class="example-additional-selection ml-1">
                             (+ {{categories.value?.length === 2 ? 'otra' : 'otras'}}
                             {{ categories.value?.length === 2 ? '' : categories.value.length - 1}})
                         </span>
@@ -48,6 +51,9 @@
                 </mat-select-trigger>
                 <mat-option *ngFor="let category of categoryList" [value]="category">{{category.name}}</mat-option>
             </mat-select>
+            <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
+                Selecciona al menos una categoría
+            </small>
         </div>
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Campaña</span>
@@ -55,7 +61,7 @@
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{campaigns.value ? campaigns.value[0]?.name : ''}}</span>
-                        <span *ngIf="campaigns.value?.length > 1" class="example-additional-selection">
+                        <span *ngIf="campaigns.value?.length > 1" class="example-additional-selection ml-1">
                             (+ {{campaigns.value?.length === 2 ? 'otra' : 'otras'}}
                             {{ campaigns.value?.length === 2 ? '' : campaigns.value.length - 1}})
                         </span>
@@ -63,13 +69,22 @@
                 </mat-select-trigger>
                 <mat-option *ngFor="let campaign of campaignList" [value]="campaign">{{campaign.name}}</mat-option>
             </mat-select>
+            <small class="text-danger" *ngIf="campaigns?.value?.length < 1 && campaigns.touched">
+                Selecciona al menos una campaña
+            </small>
         </div>
     </div>
 </form>
 
 <div class="row">
     <div class="col-12 text-right">
-        <button type="button" class="btn btn-primary">
+        <button type="button" class="btn btn-primary" [disabled]="
+        (!startDate.valid && startDate.touched) || 
+        (!endDate.valid && endDate.touched) ||
+        (sectors?.value?.length < 1 && sectors.touched) ||
+        (categories?.value?.length < 1 && categories.touched) ||
+        (campaigns?.value?.length < 1 && campaigns.touched)
+        ">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -18,11 +18,12 @@ export class OverviewService {
   }
 
   // *** filters ***
-  getCampaigns(countryID) {
+  getCampaigns(countryID, sectorsStrList?: string, categoriesStrList?: string) {
     if (!countryID) {
       return throwError('[overview.service]: not countryID provided');
     }
-    return this.http.get(`${this.baseUrl}/countries/${countryID}/campaigns`);
+
+    return this.http.get(`${this.baseUrl}/countries/${countryID}/campaigns?sectors=${sectorsStrList}&categories=${categoriesStrList}&${this.period}`);
   }
 
   // *** kpis ***


### PR DESCRIPTION
# Problem Description
- Is necessary to load general filters with the information which the user has access (sectors, categories and campaigns) and show selection by default
- Create a request to campaigns depending on sectors and categories selection

# Features
- Update getCampaigns method in overview service
- Add required validators to filters form
- Show default selection (select all options which the user has access)
- Add selected sectors and categories query params to campaigns request 

# Bug Fixes
- Reemove unecessary lines in chart-lollipop component

# Where this change will be used
- In country overview at `/dashboard/country` path

# More details
![image](https://user-images.githubusercontent.com/38545126/117222788-ee236800-add1-11eb-8c96-d1f37db07088.png)
