### PR TITLE
load countries options with other items as submenus in sidebar component

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -80,7 +80,7 @@
               <!-- custom icon -->
               <i *ngIf="menuItem.icon" class="{{ menuItem.icon }}"></i>
 
-              {{ menuItem.title | titlecase }}
+              {{ menuItem.title }}
             </a>
 
             <ul class="navbar-sub-nav" *ngIf="menuItem.submenu && menuItem.submenuOpen">
@@ -91,7 +91,7 @@
                   <!-- caret for submenus -->
                   <i [hidden]="!menuItemL2.submenu || menuItemL2.submenuOpen" class="menu-caret fas fa-caret-right"></i>
                   <i [hidden]="!menuItemL2.submenuOpen" class="menu-caret fas fa-caret-down"></i>
-                  {{ menuItemL2.title | titlecase }}
+                  {{ menuItemL2.title }}
                 </a>
 
                 <ul class="navbar-sub-nav" *ngIf="menuItemL2.submenu && menuItemL2.submenuOpen">


### PR DESCRIPTION
# Problem Description
- Is necessary change the behaviour in sidebar component for country items, now must be integrated two options apart of retailers list
  - a) Programa COOP -> redirects to country overview
  - b) Otras herramientas -> redirects to tools page

# Features
- Add two items more to submenu list of country element
- Update behaviour when a country is selected, deselected or there are other selections throw items or subitems of sidebar

# Where this change will be used
- In sidebar component used in dashboad module

# More details
![image](https://user-images.githubusercontent.com/38545126/117379325-dcf35d80-ae9c-11eb-9889-a4a7adbd6186.png)

