### PR TITLE
add latam-coop component with basic template

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -118,7 +118,7 @@ export class SidebarComponent implements OnInit {
       submenu: [
         {
           title: 'Programa COOP',
-          path: '/dashboard/country',
+          path: '/dashboard/coop',
           paramName: 'country',
           param: 'latam'
         },

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -23,10 +23,12 @@ export class DashboardComponent implements OnInit {
   }
 
   loadTitle(route: string) {
-    if (route.includes('/dashboard/retailer')) {
-      this.title = 'Retailer'
+    if (route.includes('/dashboard/coop')) {
+      this.title = 'Programa COOP';
     } else if (route.includes('/dashboard/country')) {
       this.title = 'Visión general del país';
+    } else if (route.includes('/dashboard/retailer')) {
+      this.title = 'Retailer'
     } else if (route.includes('/dashboard/tools')) {
       this.title = 'Otras herramientas';
     } else if (route.includes('/dashboard/omnichat')) {

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -28,6 +28,7 @@ import { DashboardRoutes } from './dashboard.routing';
 import { CountryComponent } from './pages/country/country.component';
 import { RetailerComponent } from './pages/retailer/retailer.component';
 import { OtherToolsComponent } from './pages/other-tools/other-tools.component';
+import { LatamCoopComponent } from './pages/latam-coop/latam-coop.component';
 
 // wrappers
 import { OverviewWrapperComponent } from './components/overview-wrapper/overview-wrapper.component';
@@ -83,6 +84,7 @@ import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loa
     ChartLoaderComponent,
     CampaignComparatorComponent,
     SentimentAnalysisComponent,
+    LatamCoopComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { CampaignComparatorComponent } from './pages/campaign-comparator/campaign-comparator.component';
 
 import { CountryComponent } from './pages/country/country.component';
+import { LatamCoopComponent } from './pages/latam-coop/latam-coop.component';
 import { OtherToolsComponent } from './pages/other-tools/other-tools.component';
 import { RetailerComponent } from './pages/retailer/retailer.component';
 import { SentimentAnalysisComponent } from './pages/sentiment-analysis/sentiment-analysis.component';
@@ -12,4 +13,5 @@ export const DashboardRoutes: Routes = [
     { path: 'tools', component: OtherToolsComponent },
     { path: 'campaign-comparator', component: CampaignComparatorComponent },
     { path: 'omnichat', component: SentimentAnalysisComponent },
+    { path: 'coop', component: LatamCoopComponent },
 ];

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -1,0 +1,31 @@
+<div class="main-container mt-4">
+    <ul class="nav nav-tabs mb-4">
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}" (click)="activeTabView = 1">
+                <span class="h2 py-2 ml-3 mr-3">Sector</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}" (click)="activeTabView = 2">
+                <span class="h2 py-2 ml-3 mr-3">Categoría</span>
+            </a>
+        </li>
+        <li class="nav-item">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}" (click)="activeTabView = 3">
+                <span class="h2 py-2 ml-3 mr-3">Medio</span>
+            </a>
+        </li>
+    </ul>
+
+    <ng-container *ngIf="activeTabView === 1">
+        <p class="text-muted">Sector</p>
+    </ng-container>
+
+    <ng-container *ngIf="activeTabView === 2">
+        <p class="text-muted">Categoría</p>
+    </ng-container>
+
+    <ng-container *ngIf="activeTabView === 3">
+        <p class="text-muted">Medio</p>
+    </ng-container>
+</div>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.spec.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LatamCoopComponent } from './latam-coop.component';
+
+describe('LatamCoopComponent', () => {
+  let component: LatamCoopComponent;
+  let fixture: ComponentFixture<LatamCoopComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ LatamCoopComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LatamCoopComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-latam-coop',
+  templateUrl: './latam-coop.component.html',
+  styleUrls: ['./latam-coop.component.scss']
+})
+export class LatamCoopComponent implements OnInit {
+
+  activeTabView = 1;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}


### PR DESCRIPTION
# Problem Description
- Is necessary to add a special page to show content of "Programa COOP" in LATAM option

# Features
- Add latam-coop component in dashboard module with the route /dashboard/coop
- Add basic template to latam-coop component
- Update path to redirect from latam options in sidebar component
- Update title shown of header in dashboard component

# Where this change will be used
- In` /dashboard/coop` path

# More details
![image](https://user-images.githubusercontent.com/38545126/117729885-1d125300-b1b1-11eb-8f96-a6573634b877.png)
