### PR TITLE
update general-filters component used in overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -64,7 +64,7 @@
         <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!retailerID">
             <span class="mb-1 h4">Campaña</span>
             <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña"
-                [disabled]="campaignList?.length < 1 && campaignsReqStatus === 2">
+                [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsErrorMsg">
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{campaigns.value ? campaigns.value[0]?.name : ''}}</span>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -36,6 +36,9 @@
             <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
                 Selecciona al menos un sector
             </small>
+            <small class="text-danger" *ngIf="sectorsErrorMsg">
+                {{ sectorsErrorMsg }}
+            </small>
         </div>
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Categoría</span>
@@ -54,10 +57,14 @@
             <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
                 Selecciona al menos una categoría
             </small>
+            <small class="text-danger" *ngIf="categoriesErrorMsg">
+                {{ categoriesErrorMsg }}
+            </small>
         </div>
-        <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!retailerID">
             <span class="mb-1 h4">Campaña</span>
-            <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña">
+            <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña"
+                [disabled]="campaignList?.length < 1 && campaignsReqStatus === 2">
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{campaigns.value ? campaigns.value[0]?.name : ''}}</span>
@@ -69,8 +76,11 @@
                 </mat-select-trigger>
                 <mat-option *ngFor="let campaign of campaignList" [value]="campaign">{{campaign.name}}</mat-option>
             </mat-select>
-            <small class="text-danger" *ngIf="campaigns?.value?.length < 1 && campaigns.touched">
-                Selecciona al menos una campaña
+            <small class="text-muted mt-1" *ngIf="campaignList?.length < 1 && campaignsReqStatus === 2">
+                No existen campañas para el Periodo, Sectores y Categorías seleccionados
+            </small>
+            <small class="text-danger" *ngIf="campaignsErrorMsg">
+                {{ campaignsErrorMsg }}
             </small>
         </div>
     </div>
@@ -82,8 +92,7 @@
         (!startDate.valid && startDate.touched) || 
         (!endDate.valid && endDate.touched) ||
         (sectors?.value?.length < 1 && sectors.touched) ||
-        (categories?.value?.length < 1 && categories.touched) ||
-        (campaigns?.value?.length < 1 && campaigns.touched)
+        (categories?.value?.length < 1 && categories.touched)
         ">
             <i class="fas fa-filter mr-2"></i>
             Filtrar

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
@@ -10,3 +10,8 @@
     align-items: center;
     display: flex;
 }
+
+.text-muted {
+    line-height: 18px;
+    display: inline-block;
+}

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -60,13 +60,11 @@ export class GeneralFiltersComponent implements OnInit {
   prevDate: any = {};
   prevCamps: any[];
 
-  viewType: string; // country, retailer
+  campaignsReqStatus: number = 0;
 
   sectorsErrorMsg: string;
   categoriesErrorMsg: string;
   campaignsErrorMsg: string;
-
-  campaignsReqStatus: number = 0;
 
   constructor(
     private fb: FormBuilder,
@@ -202,6 +200,7 @@ export class GeneralFiltersComponent implements OnInit {
           this.campaignsReqStatus = 2;
         },
         error => {
+          this.campaignList = [];
           this.campaignsErrorMsg = 'Error al consultar campañas';
           console.error(`[general-filers.component]: ${error}`);
           this.campaignsReqStatus = 3;

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -42,6 +42,7 @@ export class GeneralFiltersComponent implements OnInit {
   campaignList: any[];
 
   countryID: number;
+  retailerID: number;
 
   form: FormGroup;
   startDate: AbstractControl;
@@ -49,13 +50,23 @@ export class GeneralFiltersComponent implements OnInit {
   sectors: AbstractControl;
   categories: AbstractControl;
   campaigns: AbstractControl;
+
   formSub: Subscription;
   countrySub: Subscription;
+  retailerSub: Subscription;
 
   prevSectors: any[];
   prevCategories: any[];
   prevDate: any = {};
   prevCamps: any[];
+
+  viewType: string; // country, retailer
+
+  sectorsErrorMsg: string;
+  categoriesErrorMsg: string;
+  campaignsErrorMsg: string;
+
+  campaignsReqStatus: number = 0;
 
   constructor(
     private fb: FormBuilder,
@@ -66,17 +77,23 @@ export class GeneralFiltersComponent implements OnInit {
 
   ngOnInit() {
     this.loadForm();
+    this.fillFilters();
+
     const selectedCountry = this.appStateService.selectedCountry;
-    if (selectedCountry?.id) {
-      this.countryID = selectedCountry.id;
-      this.fillFilters();
+    const selectedRetailer = this.appStateService.selectedRetailer;
+
+    if (selectedCountry?.id || selectedRetailer?.id) {
+      this.countryID = selectedCountry?.id ? selectedCountry.id : undefined;
+      this.retailerID = selectedRetailer?.id ? selectedRetailer.id : undefined;
     }
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
-      if (country?.id !== this.countryID) {
-        this.countryID = country.id;
-        this.fillFilters();
-      }
+      this.countryID = country?.id;
+    });
+
+    this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
+      this.retailerID = retailer?.id;
+      this.getCampaigns();
     });
   }
 
@@ -106,6 +123,8 @@ export class GeneralFiltersComponent implements OnInit {
     this.formSub = this.form.valueChanges
       .pipe(debounceTime(5))
       .subscribe(form => {
+        if (!this.retailerID) return;
+
         if (this.sectors.value && this.categories.value && !this.campaigns.value && this.countryID) {
           // initial campaigns load
           this.getCampaigns();
@@ -147,8 +166,10 @@ export class GeneralFiltersComponent implements OnInit {
         this.sectorList = res;
         this.sectors.patchValue([...this.sectorList.map(item => item)]);
         this.prevSectors = this.sectors.value;
+        this.sectorsErrorMsg && delete this.sectorsErrorMsg;
       })
       .catch((error) => {
+        this.sectorsErrorMsg = 'Error al consultar sectores';
         console.error(`[general-filers.component]: ${error}`);
       });
   }
@@ -160,25 +181,30 @@ export class GeneralFiltersComponent implements OnInit {
         this.categoryList = res;
         this.categories.patchValue([...this.categoryList.map(item => item)]);
         this.prevCategories = this.categories.value;
+        this.categoriesErrorMsg && delete this.categoriesErrorMsg;
       })
       .catch((error) => {
+        this.categoriesErrorMsg = 'Error al consultar categorías';
         console.error(`[general-filers.component]: ${error}`);
       });
   }
 
   getCampaigns() {
-    console.log('getCampaigns')
+    this.campaignsReqStatus = 1;
     const sectorsStrList = this.convertArrayToString(this.sectors.value, 'id');
     const categoriesStrList = this.convertArrayToString(this.categories.value, 'id');
 
-    this.overviewService.getCampaigns(this.countryID, sectorsStrList, categoriesStrList)
+    this.overviewService.getCampaigns(this.retailerID, sectorsStrList, categoriesStrList)
       .subscribe(
         (res: any[]) => {
           this.campaignList = res;
-          this.campaigns.patchValue([...this.campaignList.map(item => item)]);
+          this.campaignsErrorMsg && delete this.campaignsErrorMsg;
+          this.campaignsReqStatus = 2;
         },
         error => {
+          this.campaignsErrorMsg = 'Error al consultar campañas';
           console.error(`[general-filers.component]: ${error}`);
+          this.campaignsReqStatus = 3;
         }
       );
   }
@@ -199,5 +225,6 @@ export class GeneralFiltersComponent implements OnInit {
   ngOnDestroy() {
     this.formSub && this.formSub.unsubscribe();
     this.countrySub && this.countrySub.unsubscribe();
+    this.retailerSub && this.retailerSub.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -18,12 +18,12 @@ export class OverviewService {
   }
 
   // *** filters ***
-  getCampaigns(countryID, sectorsStrList?: string, categoriesStrList?: string) {
-    if (!countryID) {
+  getCampaigns(retailerID, sectorsStrList?: string, categoriesStrList?: string) {
+    if (!retailerID) {
       return throwError('[overview.service]: not countryID provided');
     }
 
-    return this.http.get(`${this.baseUrl}/countries/${countryID}/campaigns?sectors=${sectorsStrList}&categories=${categoriesStrList}&${this.period}`);
+    return this.http.get(`${this.baseUrl}/retailers/${retailerID}/campaigns?sectors=${sectorsStrList}&categories=${categoriesStrList}&${this.period}`);
   }
 
   // *** kpis ***

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -94,6 +94,10 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
     }
 }
 
+.mat-select-disabled .mat-select-trigger {
+  background-color: rgba(0,0,0,.02) !important;
+}
+
 .mat-select-panel:not([class*=mat-elevation-z]){
   box-shadow: 0 1px 3px rgba(50, 50, 93, 0.15), 0 1px 0 rgba(0, 0, 0, 0.02);
   border-radius: 0.375rem;


### PR DESCRIPTION
# Problem Description
- Is necessary adapt general-filters component behaviour to only show campaigns filter in retailer view
- Use error mesages when when a request fails or when campaigns request response is empty

# Features
- Show campaigns filter only in retailer view and hide it in country view
- Remove preselection for campaigns filter
- Show error messages and disable select when sector, categories and campaigns request response fails
- Show a messageand disable select when campaign request response is an empty array
- Update general styles for disabled mat-select 
- Update getCampaigns method in overview service

# Where this change will be used
- When general-filters components will be used in dashboard components

# More details
- View in country selection 
![image](https://user-images.githubusercontent.com/38545126/117901231-861cc800-b290-11eb-82b9-5bd5f1ae436c.png)

- View in retailer selection
![image](https://user-images.githubusercontent.com/38545126/117901201-7604e880-b290-11eb-9a5e-20e7d7ef3905.png)
![image](https://user-images.githubusercontent.com/38545126/117901216-7dc48d00-b290-11eb-8ac9-9b96051dafc5.png)
