### PR TITLE
add functionality to general-filters component in requests made in overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -93,7 +93,7 @@
         (!endDate.valid && endDate.touched) ||
         (sectors?.value?.length < 1 && sectors.touched) ||
         (categories?.value?.length < 1 && categories.touched)
-        ">
+        " (click)="applyFilters()">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -7,6 +7,7 @@ import { OverviewService } from '../../services/overview.service';
 import { AppStateService } from 'src/app/services/app-state.service';
 import { Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
+import { FiltersStateService } from '../../services/filters-state.service';
 
 export const MY_FORMATS = {
   parse: {
@@ -71,6 +72,7 @@ export class GeneralFiltersComponent implements OnInit {
     private appStateService: AppStateService,
     private usersMngmtService: UsersMngmtService,
     private overviewService: OverviewService,
+    private filtersStateService: FiltersStateService
   ) { }
 
   ngOnInit() {
@@ -219,6 +221,15 @@ export class GeneralFiltersComponent implements OnInit {
 
   areAllCampaignsSelected(): boolean {
     return JSON.stringify(this.campaignList) == JSON.stringify(this.campaigns.value) ? true : false;
+  }
+
+  applyFilters() {
+    this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
+    this.filtersStateService.selectSectors(this.sectors.value);
+    this.filtersStateService.selectCategories(this.categories.value);
+    this.filtersStateService.selectCampaigns(this.campaigns.value);
+
+    this.filtersStateService.convertFiltersToQueryParams();
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -75,9 +75,12 @@ export class GeneralFiltersComponent implements OnInit {
     private filtersStateService: FiltersStateService
   ) { }
 
-  ngOnInit() {
+  async ngOnInit() {
     this.loadForm();
-    this.fillFilters();
+
+    await this.getSectors();
+    await this.getCategories();
+    this.applyFilters();
 
     const selectedCountry = this.appStateService.selectedCountry;
     const selectedRetailer = this.appStateService.selectedRetailer;
@@ -93,7 +96,10 @@ export class GeneralFiltersComponent implements OnInit {
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;
-      this.getCampaigns();
+      if (this.retailerID) {
+        this.getCampaigns();
+        this.applyFilters();
+      }
     });
   }
 
@@ -154,13 +160,8 @@ export class GeneralFiltersComponent implements OnInit {
       });
   }
 
-  async fillFilters() {
-    await this.getSectors();
-    await this.getCategories();
-  }
-
   getSectors() {
-    this.usersMngmtService.getSectors()
+    return this.usersMngmtService.getSectors()
       .toPromise()
       .then((res: any[]) => {
         this.sectorList = res;
@@ -175,7 +176,7 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   getCategories() {
-    this.usersMngmtService.getCategories()
+    return this.usersMngmtService.getCategories()
       .toPromise()
       .then((res: any[]) => {
         this.categoryList = res;
@@ -194,7 +195,7 @@ export class GeneralFiltersComponent implements OnInit {
     const sectorsStrList = this.convertArrayToString(this.sectors.value, 'id');
     const categoriesStrList = this.convertArrayToString(this.categories.value, 'id');
 
-    this.overviewService.getCampaigns(this.retailerID, sectorsStrList, categoriesStrList)
+    this.overviewService.getCampaigns(sectorsStrList, categoriesStrList)
       .subscribe(
         (res: any[]) => {
           this.campaignList = res;
@@ -229,7 +230,7 @@ export class GeneralFiltersComponent implements OnInit {
     this.filtersStateService.selectCategories(this.categories.value);
     this.filtersStateService.selectCampaigns(this.campaigns.value);
 
-    this.filtersStateService.convertFiltersToQueryParams();
+    this.filtersStateService.filtersChange();
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/services/filters-state.service.spec.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FiltersStateService } from './filters-state.service';
+
+describe('FiltersStateService', () => {
+  let service: FiltersStateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FiltersStateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import * as moment from 'moment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FiltersStateService {
+
+  // selected period
+  private periodSource = new Subject<Period>();
+  period$ = this.periodSource.asObservable();
+  period: Period;
+  periodQParams;
+
+  // selected sectors
+  private sectorsSource = new Subject<any[]>();
+  sectors$ = this.sectorsSource.asObservable();
+  sectors: any[];
+  sectorsQParams;
+
+  // selected categories
+  private categoriesSource = new Subject<any[]>();
+  categories$ = this.categoriesSource.asObservable();
+  categories: any[];
+  categoriesQParams;
+
+  // selected campaigns
+  private cammpaignsSource = new Subject<any[]>();
+  campaigns$ = this.cammpaignsSource.asObservable();
+  campaigns: any[];
+  campaignsQParams;
+
+
+  constructor() { }
+
+  selectPeriod(period: Period) {
+    this.periodSource.next(period);
+    this.period = period;
+    console.log('new Period', period)
+  }
+
+  selectSectors(sectors: any[]) {
+    this.sectorsSource.next(sectors);
+    this.sectors = sectors;
+    console.log('new sectors', sectors)
+  }
+
+  selectCategories(categories: any[]) {
+    this.categoriesSource.next(categories);
+    this.categories = categories;
+    console.log('new categories', categories)
+  }
+
+  selectCampaigns(campaigns: any[]) {
+    this.cammpaignsSource.next(campaigns);
+    this.campaigns = campaigns;
+    console.log('new campaigns', campaigns)
+  }
+
+  convertFiltersToQueryParams() {
+    this.periodQParams = { startDate: moment(this.period.startDate).format('YYYY-MM-DD'), endDate: moment(this.period.endDate).format('YYYY-MM-DD') }
+    this.sectorsQParams = this.sectors && this.convertArrayToQueryParams(this.sectors, 'id');
+    this.categoriesQParams = this.categories && this.convertArrayToQueryParams(this.categories, 'id');
+    this.campaignsQParams = this.campaigns && this.convertArrayToQueryParams(this.campaigns, 'id');
+
+    console.log('periodParams', this.periodQParams)
+    console.log('sectorsQParams', this.sectorsQParams)
+    console.log('categoriesQParams', this.categoriesQParams)
+    console.log('campaignsQParams', this.campaignsQParams)
+  }
+
+  // boton de filtrar
+  convertArrayToQueryParams(array, param: string): string {
+    let stringArray = '';
+    for (let i = 0; i < array.length; i++) {
+      stringArray = stringArray.concat(',', array[i][param]);
+    }
+
+    return stringArray.substring(1);
+  }
+}
+
+interface Period {
+  startDate: Date,
+  endDate: Date
+}
+

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -31,31 +31,30 @@ export class FiltersStateService {
   campaigns: any[];
   campaignsQParams;
 
+  // filtersChange
+  private filtersSource = new Subject<any>();
+  filtersChange$ = this.filtersSource.asObservable();
 
   constructor() { }
 
   selectPeriod(period: Period) {
     this.periodSource.next(period);
     this.period = period;
-    console.log('new Period', period)
   }
 
   selectSectors(sectors: any[]) {
     this.sectorsSource.next(sectors);
     this.sectors = sectors;
-    console.log('new sectors', sectors)
   }
 
   selectCategories(categories: any[]) {
     this.categoriesSource.next(categories);
     this.categories = categories;
-    console.log('new categories', categories)
   }
 
   selectCampaigns(campaigns: any[]) {
     this.cammpaignsSource.next(campaigns);
     this.campaigns = campaigns;
-    console.log('new campaigns', campaigns)
   }
 
   convertFiltersToQueryParams() {
@@ -63,14 +62,8 @@ export class FiltersStateService {
     this.sectorsQParams = this.sectors && this.convertArrayToQueryParams(this.sectors, 'id');
     this.categoriesQParams = this.categories && this.convertArrayToQueryParams(this.categories, 'id');
     this.campaignsQParams = this.campaigns && this.convertArrayToQueryParams(this.campaigns, 'id');
-
-    console.log('periodParams', this.periodQParams)
-    console.log('sectorsQParams', this.sectorsQParams)
-    console.log('categoriesQParams', this.categoriesQParams)
-    console.log('campaignsQParams', this.campaignsQParams)
   }
 
-  // boton de filtrar
   convertArrayToQueryParams(array, param: string): string {
     let stringArray = '';
     for (let i = 0; i < array.length; i++) {
@@ -78,6 +71,11 @@ export class FiltersStateService {
     }
 
     return stringArray.substring(1);
+  }
+
+  filtersChange() {
+    this.convertFiltersToQueryParams();
+    this.filtersSource.next();
   }
 }
 

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -2,23 +2,38 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { throwError } from 'rxjs';
 import { Configuration } from 'src/app/app.constants';
+import { FiltersStateService } from './filters-state.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class OverviewService {
   private baseUrl: string;
-  period = `start_date=2021-04-15&end_date=2021-04-30`
+  period = `start_date=2021-04-15&end_date=2021-04-30`;
 
   constructor(
     private http: HttpClient,
-    private config: Configuration
+    private config: Configuration,
+    private filtersStateService: FiltersStateService
   ) {
     this.baseUrl = this.config.endpoint;
   }
 
+
+  concatedQueryParams(): string {
+    let startDate = this.filtersStateService.periodQParams.startDate;
+    let endDate = this.filtersStateService.periodQParams.endDate;
+    let sectors = this.filtersStateService.sectorsQParams;
+    let categories = this.filtersStateService.categoriesQParams;
+    let campaigns = this.filtersStateService.campaignsQParams;
+
+
+    return `?start_date=${startDate}&end_date=${endDate}&sectors=${sectors}&categories=${categories}${campaigns ? `&campaigns=${campaigns}` : ''}`;
+  }
   // *** filters ***
+  // solo para este caso es una exepcion y si trabaja con sus query params
   getCampaigns(retailerID, sectorsStrList?: string, categoriesStrList?: string) {
+    let queryParams = this.concatedQueryParams();
     if (!retailerID) {
       return throwError('[overview.service]: not countryID provided');
     }


### PR DESCRIPTION
# Problem Description
-  Is necessary use selections in filters to make requests in overview-wrapper component
- Add functionality for selected countries 

# Features
- Add filters-state service to: 
    - save selected options in filters
    - add a variable to know when a filter from filter button is made
    - convert filters selections in query params to add them in http requests
- Emit selected filters in general-filters component
- Update overview service to get countryID and retailerID from service constructor instead to add them as a param in each requests

# Where this change will be used
- In country view at /dashboard/country?country={country_name}

# More details
![image](https://user-images.githubusercontent.com/38545126/118029558-e6137d00-b329-11eb-8b48-ba6654af2280.png)

