### PR TITLE
update default end date in period filter in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -105,14 +105,16 @@ export class GeneralFiltersComponent implements OnInit {
 
   loadForm() {
     let today = new Date();
-    let previousDay = new Date();
+    let startDate = new Date();
+    let endDate = new Date();
     let daysAgo = 15;
 
-    previousDay.setDate(today.getDate() - daysAgo);
+    startDate.setDate(today.getDate() - daysAgo);
+    endDate.setDate(today.getDate() - 1);
 
     this.form = this.fb.group({
-      startDate: new FormControl(previousDay, [Validators.required]),
-      endDate: new FormControl(today, [Validators.required]),
+      startDate: new FormControl(startDate, [Validators.required]),
+      endDate: new FormControl(endDate, [Validators.required]),
       sectors: new FormControl(),
       categories: new FormControl(),
       campaigns: new FormControl()
@@ -124,7 +126,7 @@ export class GeneralFiltersComponent implements OnInit {
     this.categories = this.form.controls['categories'];
     this.campaigns = this.form.controls['campaigns'];
 
-    this.prevDate = { startDate: previousDay, endDate: today }
+    this.prevDate = { startDate: startDate, endDate: endDate }
 
     this.formSub = this.form.valueChanges
       .pipe(debounceTime(5))


### PR DESCRIPTION
# Problem Description
- API data is available a day before current day so is necessary update default end date in period filter inside general-filters component

# Features
- Use day before today to default end date in period filter

# Where this change will be used
- Where general-filter component will be used in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/118053129-8e850980-b349-11eb-9082-1fd40c06d1f0.png)
Note: Today is equals to 12-05-2021