### PR TITLE
add states to chart-line-comparison and chart-line-series components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.html
@@ -1,3 +1,13 @@
 <div class="chart">
-    <div [id]="chartID" style="height: 100%"></div>
+    <!-- loader -->
+    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+
+    <!-- ready -->
+    <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.scss
@@ -1,0 +1,4 @@
+.chart-hidden {
+    opacity: 0;
+    height: 0;
+}

--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -11,6 +11,8 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
   @Input() category: string = 'date';
   @Input() value1: string = 'value1';
   @Input() value2: string = 'value2';
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   chart;
   chartID;
@@ -85,6 +87,10 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
 
+    chart.legend = new am4charts.Legend();
+    chart.legend.position = 'bottom';
+    chart.legend.align = 'center';
+    chart.legend.contentAlign = 'center';
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
@@ -116,9 +122,6 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     chart.cursor = new am4charts.XYCursor();
     chart.cursor.xAxis = dateAxis;
     chart.responsive.enabled = true;
-
-    chart.legend = new am4charts.Legend();
-    chart.legend.position = 'bottom';
 
     this.series = { series1: series, series2: series2 };
 

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
@@ -1,3 +1,13 @@
 <div class="chart">
-    <div [id]="chartID" style="height: 100%"></div>
+    <!-- loader -->
+    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+
+    <!-- ready -->
+    <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%"></div>
+
+    <!-- error -->
+    <div [hidden]="status !== 3" class="chart-error-container text-muted">
+        <span [hidden]="!errorLegend">{{ errorLegend }}</span>
+        <span [hidden]="errorLegend">Error al consultar datos</span>
+    </div>
 </div>

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.scss
@@ -1,0 +1,4 @@
+.chart-hidden {
+    opacity: 0;
+    height: 0;
+}

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -13,6 +13,8 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
   @Input() value = 'value'; // property name in the object to show in valueAxis
   @Input() valueName; // property to show in tooltips
   @Input() valueFormat; // USD MXN Copy shown in tooltip
+  @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
+  @Input() errorLegend: string;
 
   chartID;
   loadStatus: number = 0;
@@ -65,6 +67,9 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
 
     chart.legend = new am4charts.Legend();
     chart.legend.position = 'bottom';
+    chart.legend.align = 'center';
+    chart.legend.contentAlign = 'center';
+
     chart.legend.scrollable = true;
 
     chart.legend.itemContainers.template.events.on('over', function (event) {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -179,8 +179,9 @@
                     <span class="h4" [hidden]="selectedTab3 === 1">Ventas por Sector</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-line-series [valueName]="valueName" [valueFormat]="selectedTab3 === 2 && 'USD'"
-                        [series]="usersAndSalesBySector" [name]="selectedType + 'sales-users-by-sector'">
+                    <app-chart-line-series [series]="usersAndSalesBySector" [valueName]="valueName"
+                        [valueFormat]="selectedTab3 === 2 && 'USD'" [name]="selectedType + 'sales-users-by-sector'"
+                        [status]="usersAndSalesReqStatus">
                     </app-chart-line-series>
                 </div>
             </div>
@@ -196,7 +197,7 @@
                 <div class="card-body">
                     <app-chart-line-comparison [data]="investmentVsRevenue"
                         [name]="selectedType + 'investment-vs-revenue'" value1="investment" value2="revenue"
-                        valueName1="Inversión" valueName2="Revenue" valueFormat="USD">
+                        valueName1="Inversión" valueName2="Revenue" valueFormat="USD" [status]="invVsRevenueReqStatus">
                     </app-chart-line-comparison>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -132,6 +132,8 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   kpisReqStatus: number = 0;
   categoriesReqStatus: number = 0;
+  usersAndSalesReqStatus: number = 0;
+  invVsRevenueReqStatus: number = 0;
   trafficSalesReqStatus = [
     { name: 'device', reqStatus: 0 },
     { name: 'gender', reqStatus: 0 },
@@ -260,13 +262,16 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   }
 
   getDataByUsersAndSales(metricType: string, selectedTab: number) {
+    this.usersAndSalesReqStatus = 1;
     this.overviewService.getUsersAndSales(metricType).subscribe(
       (resp: any[]) => {
         this.usersAndSalesBySector = resp;
+        this.usersAndSalesReqStatus = 2;
       },
       error => {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.usersAndSalesReqStatus = 3;
       }
     )
 
@@ -274,13 +279,16 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   }
 
   getInvestmentVsRevenue() {
+    this.invVsRevenueReqStatus = 1;
     this.overviewService.getInvestmentVsRevenue().subscribe(
       (resp: any[]) => {
         this.investmentVsRevenue = resp;
+        this.invVsRevenueReqStatus = 2;
       },
       error => {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.invVsRevenueReqStatus = 3;
       }
     )
   }


### PR DESCRIPTION
# Problem Description
- Add states to chart components used in overview-wrapper component in order to show a loader or an error message after request response

# Features
- Add states to chart-line-comparison and chart-line-series components
- Add request states to chart-line-comparison and chart-line-series instances in overview-wrapper component

# Where this change will be used
- Where chart-line-comparison and chart-line-series will be used in dashboard module at `/dashboard/*` path
- In overview-wrapper component