### PR TITLE
update number formatter in chart-line-comparison component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -87,11 +87,6 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
 
-    chart.legend = new am4charts.Legend();
-    chart.legend.position = 'bottom';
-    chart.legend.align = 'center';
-    chart.legend.contentAlign = 'center';
-
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
     dateAxis.renderer.minGridDistance = 50;
@@ -122,6 +117,17 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     chart.cursor = new am4charts.XYCursor();
     chart.cursor.xAxis = dateAxis;
     chart.responsive.enabled = true;
+
+    chart.legend = new am4charts.Legend();
+    chart.legend.position = 'bottom';
+    chart.legend.align = 'center';
+    chart.legend.contentAlign = 'center';
+
+    // two decimals
+    chart.numberFormatter.numberFormat = '#,###.##';
+
+    // no decimals
+    // chart.numberFormatter.numberFormat = '#,###.';
 
     this.series = { series1: series, series2: series2 };
 


### PR DESCRIPTION
# Problem Description
- Show only two decimals for values in chart-line-comparison component

# Features
-  Add numberFormatter property to chart instance in chart-line-comparison component

# Where this change will be used
- Where an instance of chart-line-comparison component will be used in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/118058095-fc81fe80-b352-11eb-9776-6a7316a2f0bd.png)

