### PR TITLE
fix state directive in chart-line-comparison and chart-line-series component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.scss
@@ -1,4 +1,8 @@
 .chart-hidden {
     opacity: 0;
-    height: 0;
+}
+
+.chart-error-container {
+    position: absolute;
+    top: 0
 }

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.scss
@@ -1,4 +1,8 @@
 .chart-hidden {
     opacity: 0;
-    height: 0;
+}
+
+.chart-error-container {
+    position: absolute;
+    top: 0
 }


### PR DESCRIPTION
# Problem Description
- When directive _hidden_ or css property _hidden_ is used for the **div** which show chart the chart not respect some properties in shown legends. So, in order to avoid using this property is necessary update some styles to show correctly loader and error chart states.

# Bug Fixes
- Remove height property for charts
- Add styles to position chart-error-container correctly (inside card)

# Where this change will be used
- Where  chart-line-comparison and chart-line-series will be used in dashboard module at` /dashboard/*` path

# More details
- Loader state
![image](https://user-images.githubusercontent.com/38545126/118146864-a35aaf00-b3d4-11eb-8274-5c3a41c546e2.png)

- Error state
![image](https://user-images.githubusercontent.com/38545126/118146199-fa13b900-b3d3-11eb-8ab9-5bbd0d425ba2.png)

- Ready state
![image](https://user-images.githubusercontent.com/38545126/118146995-c2f1d780-b3d4-11eb-9ec7-8d867eb6e2eb.png)
