### PR TITLE
add functionality to overview-wrapper component for countries and retailers

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -114,8 +114,8 @@ export class NavbarComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.sidebarSub.unsubscribe();
-    this.countrySub.unsubscribe();
-    this.retailerSub.unsubscribe();
+    this.sidebarSub?.unsubscribe();
+    this.countrySub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
   }
 }

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -515,13 +515,16 @@ export class SidebarComponent implements OnInit, OnDestroy {
         if (this.userRole !== 'retailer') {
           if (this.selectedItemL1.param && this.selectedItemL1.paramName !== 'region') {
             // When a country is selectedItemL1
-            this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
+            if (this.selectedCountryID !== this.selectedItemL1.id)
+              this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
           } else if (this.selectedItemL2.param) {
             // When a country is selectedItemL2 (There is a region value in selectedItemL1)
             if (item.param === 'latam') {
-              this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
+              if (this.selectedCountryID !== this.selectedItemL1.id)
+                this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
             } else {
-              this.appStateService.selectCountry({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
+              if (this.selectedCountryID !== this.selectedItemL2.id)
+                this.appStateService.selectCountry({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
             }
           }
 
@@ -531,24 +534,37 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
       case 'retailer':
         if (this.userRole === 'retailer') {
+          if (this.selectedRetailerID !== this.selectedItemL1.id) {
+            this.appStateService.selectRetailer({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
+          }
           this.appStateService.selectCountry();
-          this.appStateService.selectRetailer({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
+
         } else {
           if (this.selectedItemL1.param && this.selectedItemL1.paramName !== 'region') {
             // When a country is selectedItemL1
-            this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
-            this.appStateService.selectRetailer({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
+            if (this.selectedRetailerID !== this.selectedItemL2.id) {
+              this.appStateService.selectRetailer({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
+            }
+
+            if (this.selectedCountryID !== this.selectedItemL1.id) {
+              this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
+            }
           } else if (this.selectedItemL2.param) {
+            if (this.selectedRetailerID !== this.selectedItemL3.id) {
+              this.appStateService.selectRetailer({ id: this.selectedItemL3.id, name: this.selectedItemL3.title });
+            }
+
             // When a country is selectedItemL2 (There is a region value in selectedItemL1)
-            this.appStateService.selectCountry({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
-            this.appStateService.selectRetailer({ id: this.selectedItemL3.id, name: this.selectedItemL3.title });
+            if (this.selectedCountryID !== this.selectedItemL2.id) {
+              this.appStateService.selectCountry({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
+            }
           }
         }
         break;
 
       default:
-        this.appStateService.selectCountry();
         this.appStateService.selectRetailer();
+        this.appStateService.selectCountry();
     }
   }
 
@@ -563,8 +579,8 @@ export class SidebarComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.countrySub.unsubscribe();
-    this.retailerSub.unsubscribe();
+    this.countrySub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
     this.appStateService.selectCountry();
     this.appStateService.selectRetailer();
   }

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -92,13 +92,22 @@ export class GeneralFiltersComponent implements OnInit {
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
       this.countryID = country?.id;
+
+      if (this.campaigns.value) {
+        this.clearCampaignsSelection();
+      }
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;
+
+      if (this.campaigns.value) {
+        this.clearCampaignsSelection();
+      }
+
       if (this.retailerID) {
         this.getCampaigns();
-        this.applyFilters();
+        // this.applyFilters();
       }
     });
   }
@@ -193,6 +202,8 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   getCampaigns() {
+    this.campaigns.setValue([]);
+
     this.campaignsReqStatus = 1;
     const sectorsStrList = this.convertArrayToString(this.sectors.value, 'id');
     const categoriesStrList = this.convertArrayToString(this.categories.value, 'id');
@@ -226,6 +237,12 @@ export class GeneralFiltersComponent implements OnInit {
     return JSON.stringify(this.campaignList) == JSON.stringify(this.campaigns.value) ? true : false;
   }
 
+  clearCampaignsSelection() {
+    this.campaigns.setValue([]);
+    this.filtersStateService.selectCampaigns(this.campaigns.value);
+    this.filtersStateService.convertFiltersToQueryParams();
+  }
+
   applyFilters() {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value);
@@ -236,8 +253,8 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    this.formSub && this.formSub.unsubscribe();
-    this.countrySub && this.countrySub.unsubscribe();
-    this.retailerSub && this.retailerSub.unsubscribe();
+    this.formSub?.unsubscribe();
+    this.countrySub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -90,25 +90,17 @@ export class GeneralFiltersComponent implements OnInit {
       this.retailerID = selectedRetailer?.id ? selectedRetailer.id : undefined;
     }
 
-    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
-      this.countryID = country?.id;
-
-      if (this.campaigns.value) {
-        this.clearCampaignsSelection();
-      }
-    });
-
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;
-
-      if (this.campaigns.value) {
-        this.clearCampaignsSelection();
-      }
 
       if (this.retailerID) {
         this.getCampaigns();
         // this.applyFilters();
       }
+    });
+
+    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
+      this.countryID = country?.id;
     });
   }
 
@@ -163,8 +155,7 @@ export class GeneralFiltersComponent implements OnInit {
             this.prevDate = { startDate: this.startDate.value._d, endDate: this.endDate.value._d }
           } else if (this.prevCamps !== this.campaigns.value) {
             // change in campaign selection
-            console.log('different campaigns')
-            const areAll = this.areAllCampaignsSelected();
+            // console.log('different campaigns')
             this.prevCamps = this.campaigns.value;
           }
         }
@@ -237,17 +228,13 @@ export class GeneralFiltersComponent implements OnInit {
     return JSON.stringify(this.campaignList) == JSON.stringify(this.campaigns.value) ? true : false;
   }
 
-  clearCampaignsSelection() {
-    this.campaigns.setValue([]);
-    this.filtersStateService.selectCampaigns(this.campaigns.value);
-    this.filtersStateService.convertFiltersToQueryParams();
-  }
-
   applyFilters() {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value);
     this.filtersStateService.selectCategories(this.categories.value);
-    this.filtersStateService.selectCampaigns(this.campaigns.value);
+
+    const areAllCampsSelected = this.areAllCampaignsSelected();
+    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value);
 
     this.filtersStateService.filtersChange();
   }

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -11,8 +11,8 @@
         </div>
     </div>
 
-    <div class="row mt-5" *ngIf="selectedType === 'country'">
-        <div class="col-12">
+    <div class="row mt-5">
+        <div class="col-12" *ngIf="selectedType === 'country'">
             <div class="pills-container">
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
@@ -33,11 +33,13 @@
         <div class="col-12 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <ng-container [ngSwitch]="selectedTab1">
+                    <ng-container *ngIf="selectedType === 'country'" [ngSwitch]="selectedTab1">
                         <span *ngSwitchCase="1" class="h4">Categorías por Retailer - Search</span>
                         <span *ngSwitchCase="2" class="h4">Categorías por Retailer - Marketing</span>
                         <span *ngSwitchCase="3" class="h4">Categorías por Retailer - Ventas</span>
                     </ng-container>
+
+                    <span *ngIf="selectedType === 'retailer'" class="h4">Categorías por Sector</span>
                 </div>
                 <div class="card-body">
                     <div class="chart-legend mt-0 mb-2">
@@ -51,36 +53,9 @@
                         </div>
                     </div>
                     <app-chart-heat-map [data]="categoriesBySector" [name]="selectedType + 'categories-by-sector'"
-                        categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus" [minValue]="0"
-                        [maxValue]="1" initialColor="#e9e9e9">
-                    </app-chart-heat-map>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row mt-5" *ngIf="selectedType === 'retailer'">
-        <div class="col-12 mt-4">
-            <div class="card">
-                <div class="card-header">
-                    <span class="h4">Categorías por Sector</span>
-                </div>
-                <div class="card-body">
-                    <div class="chart-legend mt-0 mb-2">
-                        <div class="legend-container">
-                            <div class="legend-square on"></div>
-                            <div class="legend-label">Activas</div>
-                        </div>
-                        <div class="legend-container ml-3">
-                            <div class="legend-square off"></div>
-                            <div class="legend-label">Inactivas</div>
-                        </div>
-                    </div>
-                    <app-chart-heat-map [data]="categoriesXSector" [name]="selectedType + 'categories-by-sector'"
-                        categoryX="sector" categoryY="category" height="250px" [showTooltipValue]="false"
-                        [showGridBorders]="true" [showHeatLegend]="false" [minValue]="0" [maxValue]="1"
-                        initialColor="#e9e9e9">
+                        [categoryX]="selectedType === 'country' ? 'retailer' : 'sector'" categoryY="category"
+                        height="250px" [showTooltipValue]="false" [showGridBorders]="true" [showHeatLegend]="false"
+                        [status]="categoriesReqStatus" [minValue]="0" [maxValue]="1" initialColor="#e9e9e9">
                     </app-chart-heat-map>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -141,7 +141,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     }
 
     if (this.selectedType === 'country') {
-      this.appStateService.selectedCountry$.subscribe(country => {
+      this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
         if (country?.id !== this.countryID) {
           this.countryID = country?.id;
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -114,6 +114,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
     if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
       console.log('getAllData init')
+      this.filtersStateService.clearCampaignsSelection();
       this.getAllData();
     }
 
@@ -130,6 +131,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
             if (this.retailerID) {
               console.log('getAllData retailer subs')
+              this.filtersStateService.clearCampaignsSelection();
               this.getAllData();
             }
 
@@ -137,7 +139,6 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         }
       });
     }
-
 
     if (this.selectedType === 'country') {
       this.appStateService.selectedCountry$.subscribe(country => {
@@ -147,6 +148,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
           if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
 
             if (!this.retailerID) {
+              this.filtersStateService.clearCampaignsSelection();
               console.log('getAllData country subs')
               this.getAllData();
             }

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { AppStateService } from 'src/app/services/app-state.service';
 import { UserService } from 'src/app/services/user.service';
@@ -13,57 +13,8 @@ import { OverviewService } from '../../services/overview.service';
 export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   @Input() selectedType: string; // country or retailer
-  @Input() selectedID: number; // country or retailer id
 
   countryName: string;
-
-  categoriesXSector: any[] = [
-    {
-      category: 'PS',
-      sector: 'Search',
-      value: 1
-    },
-    {
-      category: 'Print',
-      sector: 'Search',
-      value: 0
-    },
-    {
-      category: 'Supplies',
-      sector: 'Search',
-      value: 1
-    },
-    {
-      category: 'PS',
-      sector: 'Marketing',
-      value: 0
-    },
-    {
-      category: 'Print',
-      sector: 'Marketing',
-      value: 1
-    },
-    {
-      category: 'Supplies',
-      sector: 'Marketing',
-      value: 0
-    },
-    {
-      category: 'PS',
-      sector: 'Ventas',
-      value: 1
-    },
-    {
-      category: 'Print',
-      sector: 'Ventas',
-      value: 0
-    },
-    {
-      category: 'Supplies',
-      sector: 'Ventas',
-      value: 0
-    }
-  ]
 
   selectedTab1: number = 1;
   selectedTab2: number = 1;
@@ -161,28 +112,49 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     const selectedCountry = this.appStateService.selectedCountry;
     this.countryID = selectedCountry?.id && selectedCountry?.id;
 
+    if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+      console.log('getAllData init')
+      this.getAllData();
+    }
+
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
+      console.log('getAllData filtersChange subs')
       this.getAllData();
     });
 
-    this.appStateService.selectedCountry$.subscribe(country => {
-      if (this.userRole !== 'retailer' && country?.id !== this.countryID) {
-        this.countryID = country?.id !== this.countryID && country?.id;
+    if (this.selectedType === 'retailer') {
+      this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
+        if (retailer?.id !== this.retailerID) {
+          this.retailerID = retailer?.id !== this.retailerID && retailer?.id;
+          if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
 
-        if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
-          this.getAllData();
-        }
-      }
+            if (this.retailerID) {
+              console.log('getAllData retailer subs')
+              this.getAllData();
+            }
 
-    });
-    this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
-      if (retailer?.id !== this.retailerID) {
-        this.retailerID = retailer?.id !== this.retailerID && retailer?.id;
-        if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
-          // this.getAllData();
+          }
         }
-      }
-    });
+      });
+    }
+
+
+    if (this.selectedType === 'country') {
+      this.appStateService.selectedCountry$.subscribe(country => {
+        if (country?.id !== this.countryID) {
+          this.countryID = country?.id;
+
+          if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+
+            if (!this.retailerID) {
+              console.log('getAllData country subs')
+              this.getAllData();
+            }
+
+          }
+        }
+      });
+    }
   }
 
   getAllData() {
@@ -294,8 +266,8 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.countrySub && this.countrySub.unsubscribe();
-    this.retailerSub && this.retailerSub.unsubscribe();
-    this.filtersSub && this.filtersSub.unsubscribe();
+    this.countrySub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
+    this.filtersSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,1 +1,1 @@
-<app-overview-wrapper selectedType="country" [selectedID]="countryID"></app-overview-wrapper>
+<app-overview-wrapper selectedType="country"></app-overview-wrapper>

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
-import { AppStateService } from 'src/app/services/app-state.service';
 
 @Component({
   selector: 'app-country',
@@ -10,26 +9,14 @@ import { AppStateService } from 'src/app/services/app-state.service';
 export class CountryComponent implements OnInit {
 
   countryName;
-  countryID: number;
 
   constructor(
-    private route: ActivatedRoute,
-    private appStateServ: AppStateService,
+    private route: ActivatedRoute
   ) { }
 
   ngOnInit(): void {
     this.route.queryParams.subscribe((params: Params) => {
       this.countryName = params['country'];
     });
-
-    this.appStateServ.selectedCountry$
-      .subscribe(
-        country => {
-          this.countryID = country?.id;
-        },
-        error => {
-          console.error(`[country.component]: ${error}`);
-        }
-      )
   }
 }

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -1,9 +1,10 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
+import { AfterViewInit, Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 import { ActivatedRoute, Params } from '@angular/router';
 import { MatFormFieldControl } from '@angular/material/form-field';
 import { AppStateService } from 'src/app/services/app-state.service';
+import { Subscription } from 'rxjs';
 
 
 @Component({
@@ -14,7 +15,7 @@ import { AppStateService } from 'src/app/services/app-state.service';
     { provide: MatFormFieldControl, useExisting: RetailerComponent }
   ]
 })
-export class RetailerComponent implements OnInit, AfterViewInit {
+export class RetailerComponent implements OnInit, AfterViewInit, OnDestroy {
   countryName;
   retailerName;
   retailerID: number;
@@ -128,6 +129,8 @@ export class RetailerComponent implements OnInit, AfterViewInit {
     panel4: false
   }
 
+  retailerSub: Subscription;
+
   constructor(
     private route: ActivatedRoute,
     private appStateServ: AppStateService
@@ -139,7 +142,7 @@ export class RetailerComponent implements OnInit, AfterViewInit {
       this.retailerName = params['retailer']
     });
 
-    this.appStateServ.selectedRetailer$
+    this.retailerSub = this.appStateServ.selectedRetailer$
       .subscribe(
         retailer => {
           this.retailerID = retailer?.id;
@@ -157,5 +160,9 @@ export class RetailerComponent implements OnInit, AfterViewInit {
 
   panelChange(panel, value) {
     this.extPanelIsOpen[panel] = value
+  }
+
+  ngOnDestroy() {
+    this.retailerSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -73,6 +73,11 @@ export class FiltersStateService {
     return stringArray.substring(1);
   }
 
+  clearCampaignsSelection() {
+    this.selectCampaigns([]);
+    delete this.campaignsQParams;
+  }
+
   filtersChange() {
     this.convertFiltersToQueryParams();
     this.filtersSource.next();

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -35,15 +35,11 @@ export class OverviewService {
     }
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
-      this.countryID = country?.id !== this.countryID
-        ? country?.id
-        : undefined;
+      this.countryID = country?.id;
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
-      this.retailerID = retailer?.id !== this.retailerID
-        ? retailer?.id
-        : undefined;
+      this.retailerID = retailer?.id;
     });
   }
 
@@ -69,32 +65,36 @@ export class OverviewService {
 
   // *** kpis ***
   getKpis() {
-    if (!this.countryID) {
-      return throwError('[overview.service]: not countryID provided');
-    }
-
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/${this.countryID}/kpis?${queryParams}`);
+
+    if (this.retailerID) {
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/kpis?${queryParams}`);
+    } else if (this.countryID) {
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/kpis?${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
   }
 
   // *** categories by sector ***
   getCategoriesBySector(sector: string) {
-    if (!this.countryID) {
-      return throwError('[overview.service]: not countryID provided');
-    }
     if (!sector) {
       return throwError('[overview.service]: not sector provided');
     }
 
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/${this.countryID}/retailer/categories?sector=${sector}&${queryParams}`);
+
+    if (this.retailerID) {
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/categories?sector=${sector}&${queryParams}`);
+    } else if (this.countryID) {
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/retailer/categories?sector=${sector}&${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
   }
 
   // *** traffic and sales ***
   getTrafficAndSales(metricType: string, subMetricType: string) {
-    if (!this.countryID) {
-      return throwError('[overview.service]: not countryID provided');
-    }
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
     }
@@ -103,24 +103,41 @@ export class OverviewService {
     }
 
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/${this.countryID}/${metricType}/${subMetricType}?${queryParams}`);
+
+    if (this.retailerID) {
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/${metricType}/${subMetricType}?${queryParams}`);
+    } else if (this.countryID) {
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/${metricType}/${subMetricType}?${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
   }
 
   getUsersAndSales(metricType: string) {
-    if (!this.countryID) {
-      return throwError('[overview.service]: not countryID provided');
+    if (!metricType) {
+      return throwError('[overview.service]: not metricType provided');
     }
 
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/${this.countryID}/${metricType}?${queryParams}`);
+
+    if (this.retailerID) {
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/${metricType}?${queryParams}`);
+    } else if (this.countryID) {
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/${metricType}?${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
   }
 
   getInvestmentVsRevenue() {
-    if (!this.countryID) {
-      return throwError('[overview.service]: not countryID provided');
-    }
-
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/${this.countryID}/investment-vs-revenue?${queryParams}`);
+
+    if (this.retailerID) {
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/investment-vs-revenue?${queryParams}`);
+    } else if (this.countryID) {
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/investment-vs-revenue?${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
   }
 }


### PR DESCRIPTION
# Problem Description
- Is necessary show real data from API requests in overview-wrapper component which shows country or retailer overview based on sidebar selection
- Is necessary applies filters to request and preserve it in each selection with the exception of the campaign filter

# Features
- Adapt chart-heat-map instance to show retailer info in overview-wrapper component template
- Get data after changes in country, retailer and filters observables in overview-wrapper component
- Avoid sending campaigns values in request when all campaigns are selected in general-filter component
- Add clearCampaignSelection in filters-state component
- Clear campaigns selection after retailer or country changes in overview-wrapper component

# Bug Fixes
- Unsubscribe from subscriptions in ngOnDestroy method in all components which there are subscriptions of selected country and retailer
- Update emitNewSelection method in sidebar component in order to avoid repetead emissions

# Where this change will be used
- In country and retailer overview at `/dashboard/country` and `/dashboard/retailer` paths

# More details
- Overview requests in country selection
![image](https://user-images.githubusercontent.com/38545126/118309655-2f430880-b4b3-11eb-8664-1fb06e42258f.png)

- Overview requests in retailer selection
![image](https://user-images.githubusercontent.com/38545126/118309744-4eda3100-b4b3-11eb-8731-03836089f54d.png)
