### PR TITLE
show legend when data is empty in chart components used in overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
@@ -1,9 +1,14 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [id]="graphID" style="height: 100%"></div>
+    <div [hidden]="status !== 2 || data?.length < 1" [id]="graphID" style="height: 100%"></div>
+
+    <!-- empty data -->
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
+        <span>Sin datos disponibles</span>
+    </div>
 
     <!-- error -->
     <div [hidden]="status !== 3" class="chart-error-container text-muted">

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
@@ -1,9 +1,14 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
+    <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
+
+    <!-- empty data -->
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
+        <span>Sin datos disponibles</span>
+    </div>
 
     <!-- error -->
     <div [hidden]="status !== 3" class="chart-error-container text-muted">

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
@@ -1,9 +1,14 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
+    <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
+
+    <!-- empty data -->
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
+        <span>Sin datos disponibles</span>
+    </div>
 
     <!-- error -->
     <div [hidden]="status !== 3" class="chart-error-container text-muted">


### PR DESCRIPTION
# Problem Description
- Currently when a chart data is empty the charts components looks empty and they can confuse to the user, so is necessary show legends instead charts empty.

# Features
- show legend when data is empty in  the following components:
   - chart-lollipop
   - chart-pictorial
   - chart-pyramid

# Where this change will be used
- Where chart-lollipop, chart-pictorial and chart-pyramid components will be used, in this case in country and retailer overview at `/dashboard/country` and `/dashboard/retailer` paths

# More details
![image](https://user-images.githubusercontent.com/38545126/118320635-23ab0e00-b4c2-11eb-9406-5c7c86b6671d.png)