### PR TITLE
adapt overview-wrapper to load data after emitted events from parents components 

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -513,6 +513,8 @@ export class SidebarComponent implements OnInit, OnDestroy {
     switch (item.paramName) {
       case 'country':
         if (this.userRole !== 'retailer') {
+          this.appStateService.selectRetailer();
+
           if (this.selectedItemL1.param && this.selectedItemL1.paramName !== 'region') {
             // When a country is selectedItemL1
             if (this.selectedCountryID !== this.selectedItemL1.id)
@@ -527,8 +529,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
                 this.appStateService.selectCountry({ id: this.selectedItemL2.id, name: this.selectedItemL2.title });
             }
           }
-
-          this.appStateService.selectRetailer();
         }
         break;
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -157,7 +157,8 @@
                     <span class="h4" [hidden]="selectedTab3 === 1">Ventas por Sector</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-line-series [series]="usersAndSalesBySector" [valueName]="valueName"
+                    <app-chart-line-series [series]="usersAndSalesBySector"
+                        [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
                         [valueFormat]="selectedTab3 === 2 && 'USD'" [name]="selectedType + 'sales-users-by-sector'"
                         [status]="usersAndSalesReqStatus">
                     </app-chart-line-series>

--- a/src/app/modules/dashboard/pages/country/country.component.html
+++ b/src/app/modules/dashboard/pages/country/country.component.html
@@ -1,1 +1,1 @@
-<app-overview-wrapper selectedType="country"></app-overview-wrapper>
+<app-overview-wrapper selectedType="country" [requestInfoChange]="requestInfoChange$"></app-overview-wrapper>

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -1,22 +1,65 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Params } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import { AppStateService } from 'src/app/services/app-state.service';
+import { FiltersStateService } from '../../services/filters-state.service';
 
 @Component({
   selector: 'app-country',
   templateUrl: './country.component.html',
   styleUrls: ['./country.component.scss']
 })
-export class CountryComponent implements OnInit {
+export class CountryComponent implements OnInit, OnDestroy {
 
-  countryName;
+  countryID: number;
+  retailerID: number;
+
+  countrySub: Subscription;
+  retailerSub: Subscription;
+  filtersSub: Subscription;
+
+  private requestInfoSource = new Subject<void>();
+  requestInfoChange$ = this.requestInfoSource.asObservable();
 
   constructor(
-    private route: ActivatedRoute
+    private appStateService: AppStateService,
+    private filtersStateService: FiltersStateService,
   ) { }
 
   ngOnInit(): void {
-    this.route.queryParams.subscribe((params: Params) => {
-      this.countryName = params['country'];
+    const selectedCountry = this.appStateService.selectedCountry;
+    const selectedRetailer = this.appStateService.selectedCountry;
+
+    this.countryID = selectedCountry?.id && selectedCountry?.id;
+    this.retailerID = selectedRetailer?.id && selectedRetailer?.id;
+
+    this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
+      this.requestInfoSource.next();
     });
+
+    this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
+      if (retailer?.id !== this.retailerID) {
+        this.retailerID = retailer?.id;
+      }
+    });
+
+    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
+      if (country?.id !== this.countryID) {
+        this.countryID = country?.id;
+
+        if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+
+          if (!this.retailerID) {
+            this.filtersStateService.clearCampaignsSelection();
+            this.requestInfoSource.next();
+          }
+        }
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.filtersSub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
+    this.countrySub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -23,7 +23,7 @@
     </ul>
 
     <ng-container *ngIf="activeTabView === 1">
-        <app-overview-wrapper selectedType="retailer"></app-overview-wrapper>
+        <app-overview-wrapper selectedType="retailer" [requestInfoChange]="requestInfoChange$"></app-overview-wrapper>
     </ng-container>
 
     <ng-container *ngIf="activeTabView === 2">


### PR DESCRIPTION
# Problem Description
- Refactor overview-wrapper component to load data after emitted events from parents components (country or retailer components)

# Features
- Use only one subscription in overview-wrapper component to get for all data after one observable change emitted from its parent (country or retailer component)
- Emit requestInfoChange event in country and retailers components

# Bug Fixes
- Emit retailer changes before country changes in sidebar component