### PR TITLE
clear campaigns value after retailer or country change in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -93,14 +93,20 @@ export class GeneralFiltersComponent implements OnInit {
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;
 
+      if (this.campaigns.value) {
+        this.campaigns.setValue([]);
+      }
+
       if (this.retailerID) {
         this.getCampaigns();
-        // this.applyFilters();
       }
     });
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
       this.countryID = country?.id;
+      if (this.campaigns.value) {
+        this.campaigns.setValue([]);
+      }
     });
   }
 


### PR DESCRIPTION
# Problem Description
- After select some campaigns in campaign filter, change of country or retailer and filter again the previous campaigns selections appear in query params of the http requests, so is necessary clear campaigns value after a country or retailer change in general-filters components

# Bug Fixes
- Clear campaigns value after retailer or country change (observable subscribtions) in general-filters component

# Where this change will be used
- Where a campaign filter will be used in dashboard module at `/dashboard/* `path
