### PR TITLE
add search filter to campaigns filter in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -65,6 +65,15 @@
             <span class="mb-1 h4">Campaña</span>
             <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña"
                 [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsErrorMsg">
+
+                <div class="input-group input-group-alternative mb-1">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="fas fa-search"></i></span>
+                    </div>
+                    <input class="form-control" [(ngModel)]="campaignsFilter" matInput type="text"
+                        (keyup)="filterCampaigns($event.target.value)" placeholder="Buscar campaña"
+                        [ngModelOptions]="{standalone: true}">
+                </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{campaigns.value ? campaigns.value[0]?.name : ''}}</span>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -42,7 +42,7 @@ export class GeneralFiltersComponent implements OnInit {
   categoryList: any[];
   campaignList: any[];
   filteredCampaignList: any[];
-  filteredCampaigns: boolean; // flag to kwnow is campaignsList is te result of a search filter
+  filteredCampaigns: boolean; // flag to know is campaignsList is the result of a search filter
   campaignsFilter: string; // filtered value in campaignsList
 
   countryID: number;

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -41,6 +41,9 @@ export class GeneralFiltersComponent implements OnInit {
   sectorList: any[];
   categoryList: any[];
   campaignList: any[];
+  filteredCampaignList: any[];
+  filteredCampaigns: boolean; // flag to kwnow is campaignsList is te result of a search filter
+  campaignsFilter: string; // filtered value in campaignsList
 
   countryID: number;
   retailerID: number;
@@ -95,6 +98,7 @@ export class GeneralFiltersComponent implements OnInit {
 
       if (this.campaigns.value) {
         this.campaigns.setValue([]);
+        this.campaignsFilter = '';
       }
 
       if (this.retailerID) {
@@ -106,6 +110,7 @@ export class GeneralFiltersComponent implements OnInit {
       this.countryID = country?.id;
       if (this.campaigns.value) {
         this.campaigns.setValue([]);
+        this.campaignsFilter = '';
       }
     });
   }
@@ -146,17 +151,17 @@ export class GeneralFiltersComponent implements OnInit {
         } else if (this.sectors.value?.length > 0 && this.categories.value?.length > 0 && this.form.valid) {
           if (this.prevSectors !== this.sectors.value) {
             // change in sectors selection
-            console.log('diffrentent sectors')
+            // console.log('diffrentent sectors')
             this.getCampaigns();
             this.prevSectors = this.sectors.value;
           } else if (this.prevCategories !== this.categories.value) {
             // change in categories selection
-            console.log('different categories')
+            // console.log('different categories')
             this.getCampaigns();
             this.prevCategories = this.categories.value;
           } else if (this.prevDate.startDate.getTime() !== this.startDate.value._d.getTime() || this.prevDate.endDate.getTime() !== this.endDate.value._d.getTime()) {
             // change in date selection
-            console.log('different date')
+            // console.log('different date')
             this.getCampaigns();
             this.prevDate = { startDate: this.startDate.value._d, endDate: this.endDate.value._d }
           } else if (this.prevCamps !== this.campaigns.value) {
@@ -200,6 +205,8 @@ export class GeneralFiltersComponent implements OnInit {
 
   getCampaigns() {
     this.campaigns.setValue([]);
+    this.campaignsFilter = '';
+    this.filteredCampaigns = false;
 
     this.campaignsReqStatus = 1;
     const sectorsStrList = this.convertArrayToString(this.sectors.value, 'id');
@@ -209,6 +216,7 @@ export class GeneralFiltersComponent implements OnInit {
       .subscribe(
         (res: any[]) => {
           this.campaignList = res;
+          this.filteredCampaignList = res;
           this.campaignsErrorMsg && delete this.campaignsErrorMsg;
           this.campaignsReqStatus = 2;
         },
@@ -231,7 +239,16 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   areAllCampaignsSelected(): boolean {
+    if (this.filteredCampaigns) {
+      return false;
+    }
     return JSON.stringify(this.campaignList) == JSON.stringify(this.campaigns.value) ? true : false;
+  }
+
+  filterCampaigns(value) {
+    this.campaignList = this.filteredCampaignList.filter(camp => camp.name.toLowerCase().includes(value.toLowerCase()));
+
+    this.filteredCampaigns = value.length > 0 ? true : false;
   }
 
   applyFilters() {

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 // **** Angular Material ****
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
@@ -89,6 +89,7 @@ import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loa
   imports: [
     CommonModule,
     RouterModule.forChild(DashboardRoutes),
+    FormsModule,
     ReactiveFormsModule,
     MatNativeDateModule,
     MatRippleModule,


### PR DESCRIPTION
# Problem Description
- In order to improve UX with campaigns filters, is necessary add a search input filter because campaigns filter could show a large number of options.

# Features
- Add formsModule to dashboard module imports
- Add search input to campaigns filter in general-filters component

# Where this change will be used
- Where general-filter component will be use and campaigns filter will be enable in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/118522010-2fd0de80-b701-11eb-9424-624831dd2752.png)
