### PR TITLE
manage request status of chart-pyramid from overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -144,6 +144,8 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     femaleRange.label.fontWeight = '600';
     femaleRange.grid.strokeOpacity = 1;
 
+    chart.zoomOutButton.disabled = true;
+
 
     this.labels = { labelLeft: maleLabel, labelRight: femaleLabel };
     this.loadValueFormat(this.valueFormat);

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -144,8 +144,6 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     femaleRange.label.fontWeight = '600';
     femaleRange.grid.strokeOpacity = 1;
 
-    chart.zoomOutButton.disabled = true;
-
 
     this.labels = { labelLeft: maleLabel, labelRight: femaleLabel };
     this.loadValueFormat(this.valueFormat);

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -68,15 +68,16 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="getDataByTrafficAndSales('traffic', 1)">Tráfico</a>
+                            (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="getDataByTrafficAndSales('sales', 2)">Ventas</a>
+                            (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
                     </li>
                 </ul>
             </div>
         </div>
+
         <!-- devices -->
         <div class="col-12 col-md-6 mt-4">
             <div class="card">
@@ -126,10 +127,28 @@
                 <div class="card-header">
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
                 </div>
-                <div class="card-body">
-                    <app-chart-pyramid [data]="trafficAndSales['genderByAge']" [name]="selectedType + 'age-and-gender'"
+                <div class="card-body" style="height: 328px">
+                    <!-- loader -->
+                    <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 1">
+                    </app-chart-loader>
+
+                    <!-- ready -->
+                    <app-chart-pyramid *ngIf="trafficAndSales['genderByAge']?.length > 0"
+                        [data]="trafficAndSales['genderByAge']" [name]="selectedType + 'age-and-gender'"
                         [status]="trafficSalesReqStatus[3].reqStatus" height="280px">
                     </app-chart-pyramid>
+
+                    <!-- empty data -->
+                    <div *ngIf="trafficSalesReqStatus[3].reqStatus === 2 && trafficAndSales['genderByAge']?.length === 0"
+                        class="chart-error-container text-muted">
+                        <span>Sin datos disponibles</span>
+                    </div>
+
+                    <!-- error -->
+                    <div *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 3"
+                        class="chart-error-container text-muted">
+                        <span>Error al consultar datos</span>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -90,6 +90,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   ];
 
   requestInfoSub: Subscription;
+  chartsInitLoad: boolean = true;
 
   constructor(
     private filtersStateService: FiltersStateService,
@@ -113,6 +114,8 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     this.getDataByTrafficAndSales('traffic', 1);
     this.getDataByUsersAndSales('users', 1);
     this.getInvestmentVsRevenue();
+
+    this.chartsInitLoad = true;
   }
 
   getKpis() {


### PR DESCRIPTION
# Problem Description
- In order to improve initial UX in chart-pyramid component is necessary manage requests status from overviwiew-wrapper component instead of chart-pyramid component because if they are handled in the chart, the data view is not loaded correctly and the chart is initialized with a wrongly positioned zoom by default.

# Features
-  Manage request state of chart-pyramid form overview-wrapper component

# Where this change will be used
- In chart-pyramid instance used in overview-wrapper component in `/dashboard/country` and `/dashboard/retailer`

# More details
- Before changes:
![image](https://user-images.githubusercontent.com/38545126/118529440-1fbcfd00-b709-11eb-87fb-13707da7c4a7.png)

- After changes:
![image](https://user-images.githubusercontent.com/38545126/118558287-05484b00-b72c-11eb-925e-060699db23e1.png)
