### PR TITLE
add basic template to latam-coop component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -1,5 +1,6 @@
 <form role="form" [formGroup]="form">
     <div class="row">
+        <!-- period -->
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <div class="date-picker">
                 <span class="mb-1 h4">Periodo</span>
@@ -19,6 +20,8 @@
                 </small>
             </div>
         </div>
+
+        <!-- sector -->
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Sector</span>
             <mat-select formControlName="sectors" multiple placeholder="Selecciona un Sector">
@@ -40,6 +43,8 @@
                 {{ sectorsErrorMsg }}
             </small>
         </div>
+
+        <!-- category -->
         <div class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Categoría</span>
             <mat-select formControlName="categories" multiple placeholder="Selecciona una Categoría">
@@ -61,6 +66,8 @@
                 {{ categoriesErrorMsg }}
             </small>
         </div>
+
+        <!-- campaign -->
         <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!retailerID">
             <span class="mb-1 h4">Campaña</span>
             <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña"
@@ -91,6 +98,23 @@
             <small class="text-danger" *ngIf="campaignsErrorMsg">
                 {{ campaignsErrorMsg }}
             </small>
+        </div>
+
+        <!-- medium -->
+        <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!isLatamSelected">
+            <span class="mb-1 h4">Fuente</span>
+            <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente">
+                <mat-select-trigger>
+                    <div class="select-value-container">
+                        <span class="select-value">{{sources.value ? sources.value[0]?.name : ''}}</span>
+                        <span *ngIf="sources.value?.length > 1" class="example-additional-selection ml-1">
+                            (+ {{sources.value?.length === 2 ? 'otro' : 'otros'}}
+                            {{ sources.value?.length === 2 ? '' : sources.value.length - 1}})
+                        </span>
+                    </div>
+                </mat-select-trigger>
+                <mat-option *ngFor="let source of sourceList" [value]="source">{{source.name}}</mat-option>
+            </mat-select>
         </div>
     </div>
 </form>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -33,7 +33,7 @@
         </div>
 
         <div class="row mt-5">
-            <div class="col-12">
+            <!-- <div class="col-12">
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
@@ -50,15 +50,16 @@
                         </li>
                     </ul>
                 </div>
-            </div>
+            </div> -->
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <ng-container [ngSwitch]="selectedTab1">
+                        <!-- <ng-container [ngSwitch]="selectedTab1">
                             <span *ngSwitchCase="1" class="h4">Categorías por Retailer - Search</span>
                             <span *ngSwitchCase="2" class="h4">Categorías por Retailer - Marketing</span>
                             <span *ngSwitchCase="3" class="h4">Categorías por Retailer - Ventas</span>
-                        </ng-container>
+                        </ng-container> -->
+                        <span class="h4">Categorías por sector y país</span>
                     </div>
                     <div class="card-body">
                         <div class="chart-legend mt-0 mb-2">
@@ -86,11 +87,11 @@
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
                                 (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
                                 (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
                         </li>
                     </ul>
@@ -101,7 +102,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
+                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['device']" name="latam-devices" category="name"
@@ -115,7 +116,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
+                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['gender']" name="latam-gender" category="name"
@@ -129,11 +130,11 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
+                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
                     </div>
                     <div class="card-body">
                         <app-chart-lollipop [data]="trafficAndSales['age']" name="latam-age" category="age"
-                            [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
+                            [value]="selectedTab1 === 1 ? 'visits' : 'sales'" height="280px"
                             [status]="trafficSalesReqStatus[2].reqStatus">
                         </app-chart-lollipop>
                     </div>
@@ -144,7 +145,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
+                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
@@ -178,26 +179,131 @@
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
                                 (click)="getDataByUsersAndSales('users', 1)">Usuarios</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
                                 (click)="getDataByUsersAndSales('sales', 2)">Ventas</a>
                         </li>
                     </ul>
                 </div>
             </div>
+
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4" [hidden]="selectedTab3 === 2">Usuarios por Sector</span>
-                        <span class="h4" [hidden]="selectedTab3 === 1">Ventas por Sector</span>
+                        <span class="h4">{{ selectedTab2 === 1 ? 'Usuarios' : 'Ventas'}} por </span>
+                        <ng-container [ngSwitch]="selectedTab3">
+                            <span *ngSwitchCase="1" class="h4">Sector</span>
+                            <span *ngSwitchCase="2" class="h4">Categoría</span>
+                            <span *ngSwitchCase="3" class="h4">Medio</span>
+                        </ng-container>
                     </div>
                     <div class="card-body">
+                        <div class="row">
+                            <div class="col-12 mb-4">
+                                <ul class="nav nav-tabs">
+                                    <li class="nav-item">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 1}"
+                                            (click)="selectedTab3 = 1; selectedTab4 = 1">
+                                            <span>Sector</span>
+                                        </a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 2}"
+                                            (click)="selectedTab3 = 2; selectedTab4 = 1">
+                                            <span>Categoría</span>
+                                        </a>
+                                    </li>
+                                    <li class="nav-item">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 3}"
+                                            (click)="selectedTab3 = 3; selectedTab4 = 1">
+                                            <span>Medio</span>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="col-12 mb-4">
+                                <div class="pills-container">
+                                    <!-- sector -->
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 1">
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
+                                                (click)="selectedTab4 = 1">Todo</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
+                                                (click)="selectedTab4 = 2">Search</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
+                                                (click)="selectedTab4 = 3">Marketing</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
+                                                (click)="selectedTab4 = 4">Ventas</a>
+                                        </li>
+                                    </ul>
+
+                                    <!-- categoria -->
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 2">
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
+                                                (click)="selectedTab4 = 1">Todo</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
+                                                (click)="selectedTab4 = 2">PS</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
+                                                (click)="selectedTab4 = 3">Print</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
+                                                (click)="selectedTab4 = 4">Supplies</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 5}"
+                                                (click)="selectedTab4 = 5">Accessories</a>
+                                        </li>
+                                    </ul>
+
+                                    <!-- medio -->
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 3">
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
+                                                (click)="selectedTab4 = 1">Todo</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
+                                                (click)="selectedTab4 = 2">Google</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
+                                                (click)="selectedTab4 = 3">Facebook</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
+                                                (click)="selectedTab4 = 4">Programmatic</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 5}"
+                                                (click)="selectedTab4 = 5">Institucional</a>
+                                        </li>
+                                        <li class="nav-item">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 6}"
+                                                (click)="selectedTab4 = 6">Otro</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+
                         <app-chart-line-series [series]="usersAndSalesBySector"
-                            [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
-                            [valueFormat]="selectedTab3 === 2 && 'USD'" name="latam-sales-users-by-sector"
+                            [valueName]="selectedTab2 === 1 ? 'Usuarios' : 'Ventas'"
+                            [valueFormat]="selectedTab2 === 2 && 'USD'" name="latam-sales-users-by-sector"
                             [status]="usersAndSalesReqStatus">
                         </app-chart-line-series>
                     </div>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -258,7 +258,7 @@
                                         </li>
                                         <li class="nav-item">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
-                                                (click)="selectedTab4 = 3">Print</a>
+                                                (click)="selectedTab4 = 3">HW Print</a>
                                         </li>
                                         <li class="nav-item">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
@@ -266,7 +266,7 @@
                                         </li>
                                         <li class="nav-item">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 5}"
-                                                (click)="selectedTab4 = 5">Accessories</a>
+                                                (click)="selectedTab4 = 5">Accesorios</a>
                                         </li>
                                     </ul>
 
@@ -322,6 +322,80 @@
                             value1="investment" value2="revenue" valueName1="Inversión" valueName2="Revenue"
                             valueFormat="USD" [status]="invVsRevenueReqStatus">
                         </app-chart-line-comparison>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="pills-container mb-4">
+                    <ul class="nav nav-pills nav-fill">
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
+                                (click)="selectedTab5 = 1; showTopProducts('ps')">PS</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
+                                (click)="selectedTab5 = 2; showTopProducts('print')">HW Print</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
+                                (click)="selectedTab5 = 3; showTopProducts('supplies')">Supplies</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
+                                (click)="selectedTab5 = 4; showTopProducts('accesories')">Accesorios</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">Top Productos</span>
+                    </div>
+                    <div class="card-body">
+                        <div class="adaptable-container">
+                            <table mat-table [dataSource]="dataSource">
+                                <!-- category column -->
+                                <ng-container matColumnDef="rank">
+                                    <th mat-header-cell *matHeaderCellDef [style.width.px]="150">Rank</th>
+                                    <td mat-cell *matCellDef="let element"> {{element.rank}} </td>
+                                </ng-container>
+
+                                <!-- product column -->
+                                <ng-container matColumnDef="product">
+                                    <th mat-header-cell *matHeaderCellDef> Producto </th>
+                                    <td mat-cell *matCellDef="let element">
+                                        <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.product"
+                                            matTooltipPosition="right" matTooltipClass="custom-tooltip">
+                                            {{element.product}}
+                                        </span>
+                                    </td>
+                                </ng-container>
+
+                                <!-- amount -->
+                                <ng-container matColumnDef="amount">
+                                    <th mat-header-cell *matHeaderCellDef [style.width.px]="150">Cantidad</th>
+                                    <td mat-cell *matCellDef="let element"> {{element.amount}} </td>
+                                </ng-container>
+
+                                <!-- disclaimer column -->
+                                <ng-container matColumnDef="disclaimer">
+                                    <td mat-footer-cell *matFooterCellDef colspan="3">
+                                        <div class="text-danger text-center" *ngIf="getReqStatus === 3">
+                                            Ocurrió un error al consultar los usuarios
+                                        </div>
+                                    </td>
+                                </ng-container>
+
+                                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+                                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
+                                    [hidden]="getReqStatus !== 3"></tr>
+                            </table>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -1,23 +1,4 @@
 <div class="main-container mt-4">
-    <!-- <ul class="nav nav-tabs mb-4">
-        <li class="nav-item">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}" (click)="activeTabView = 1">
-                <span class="h2 py-2 ml-3 mr-3">Sector</span>
-            </a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}" (click)="activeTabView = 2">
-                <span class="h2 py-2 ml-3 mr-3">Categoría</span>
-            </a>
-        </li>
-        <li class="nav-item">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}" (click)="activeTabView = 3">
-                <span class="h2 py-2 ml-3 mr-3">Medio</span>
-            </a>
-        </li>
-    </ul> -->
-
-    <!-- <ng-container *ngIf="activeTabView === 1"> -->
     <div class="main-container mt-5">
         <!-- CARD STATS -->
         <div class="row">
@@ -33,36 +14,28 @@
         </div>
 
         <div class="row mt-5">
-            <!-- <div class="col-12">
+            <div class="col-12">
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                                (click)="getCategoriesBySector('Search', 1)">Search</a>
+                                (click)="getSectorsAndCategories('sectors', 1)">Sector</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                                (click)="getCategoriesBySector('Marketing', 2)">Marketing</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                                (click)="getCategoriesBySector('Ventas', 3)">Ventas</a>
+                                (click)="getSectorsAndCategories('categories', 2)">Categoría</a>
                         </li>
                     </ul>
                 </div>
-            </div> -->
+            </div>
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <!-- <ng-container [ngSwitch]="selectedTab1">
-                            <span *ngSwitchCase="1" class="h4">Categorías por Retailer - Search</span>
-                            <span *ngSwitchCase="2" class="h4">Categorías por Retailer - Marketing</span>
-                            <span *ngSwitchCase="3" class="h4">Categorías por Retailer - Ventas</span>
-                        </ng-container> -->
-                        <span class="h4">Categorías por sector y país</span>
+                        <span class="h4">Inversión en {{ selectedTab1 === 1 ? 'Sectores' : 'Categorías' }} por
+                            País</span>
                     </div>
                     <div class="card-body">
-                        <div class="chart-legend mt-0 mb-2">
+                        <!-- <div class="chart-legend mt-0 mb-2">
                             <div class="legend-container">
                                 <div class="legend-square on"></div>
                                 <div class="legend-label">Activas</div>
@@ -71,11 +44,11 @@
                                 <div class="legend-square off"></div>
                                 <div class="legend-label">Inactivas</div>
                             </div>
-                        </div>
+                        </div> -->
                         <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
-                            categoryX="country" categoryY="sector" height="250px" [showTooltipValue]="false"
+                            categoryX="country" [categoryY]="selectedTab1 === 1 ? 'sector' : 'category'" height="250px"
                             [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
-                            [minValue]="0" [maxValue]="1" initialColor="#e9e9e9">
+                            gridBordersColor="#f7f7f7">
                         </app-chart-heat-map>
                     </div>
                 </div>
@@ -87,11 +60,11 @@
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
                                 (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
                                 (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
                         </li>
                     </ul>
@@ -102,7 +75,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['device']" name="latam-devices" category="name"
@@ -116,7 +89,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['gender']" name="latam-gender" category="name"
@@ -130,11 +103,11 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
                     </div>
                     <div class="card-body">
                         <app-chart-lollipop [data]="trafficAndSales['age']" name="latam-age" category="age"
-                            [value]="selectedTab1 === 1 ? 'visits' : 'sales'" height="280px"
+                            [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
                             [status]="trafficSalesReqStatus[2].reqStatus">
                         </app-chart-lollipop>
                     </div>
@@ -145,7 +118,7 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab1 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
@@ -179,11 +152,11 @@
                 <div class="pills-container">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
                                 (click)="getDataByUsersAndSales('users', 1)">Usuarios</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
                                 (click)="getDataByUsersAndSales('sales', 2)">Ventas</a>
                         </li>
                     </ul>
@@ -193,8 +166,8 @@
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{ selectedTab2 === 1 ? 'Usuarios' : 'Ventas'}} por </span>
-                        <ng-container [ngSwitch]="selectedTab3">
+                        <span class="h4">{{ selectedTab3 === 1 ? 'Usuarios' : 'Ventas'}} por </span>
+                        <ng-container [ngSwitch]="selectedTab4">
                             <span *ngSwitchCase="1" class="h4">Sector</span>
                             <span *ngSwitchCase="2" class="h4">Categoría</span>
                             <span *ngSwitchCase="3" class="h4">Medio</span>
@@ -205,20 +178,20 @@
                             <div class="col-12 mb-4">
                                 <ul class="nav nav-tabs">
                                     <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 1}"
-                                            (click)="selectedTab3 = 1; selectedTab4 = 1">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 1}"
+                                            (click)="selectedTab4 = 1; selectedTab5 = 1">
                                             <span>Sector</span>
                                         </a>
                                     </li>
                                     <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 2}"
-                                            (click)="selectedTab3 = 2; selectedTab4 = 1">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 2}"
+                                            (click)="selectedTab4 = 2; selectedTab5 = 1">
                                             <span>Categoría</span>
                                         </a>
                                     </li>
                                     <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab3 === 3}"
-                                            (click)="selectedTab3 = 3; selectedTab4 = 1">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 3}"
+                                            (click)="selectedTab4 = 3; selectedTab5 = 1">
                                             <span>Medio</span>
                                         </a>
                                     </li>
@@ -227,74 +200,74 @@
                             <div class="col-12 mb-4">
                                 <div class="pills-container">
                                     <!-- sector -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 1">
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 1">
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
-                                                (click)="selectedTab4 = 1">Todo</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
+                                                (click)="selectedTab5 = 1">Todo</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
-                                                (click)="selectedTab4 = 2">Search</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
+                                                (click)="selectedTab5 = 2">Search</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
-                                                (click)="selectedTab4 = 3">Marketing</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
+                                                (click)="selectedTab5 = 3">Marketing</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
-                                                (click)="selectedTab4 = 4">Ventas</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
+                                                (click)="selectedTab5 = 4">Ventas</a>
                                         </li>
                                     </ul>
 
                                     <!-- categoria -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 2">
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 2">
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
-                                                (click)="selectedTab4 = 1">Todo</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
+                                                (click)="selectedTab5 = 1">Todo</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
-                                                (click)="selectedTab4 = 2">PS</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
+                                                (click)="selectedTab5 = 2">PS</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
-                                                (click)="selectedTab4 = 3">HW Print</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
+                                                (click)="selectedTab5 = 3">HW Print</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
-                                                (click)="selectedTab4 = 4">Supplies</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
+                                                (click)="selectedTab5 = 4">Supplies</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 5}"
-                                                (click)="selectedTab4 = 5">Accesorios</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 5}"
+                                                (click)="selectedTab5 = 5">Accesorios</a>
                                         </li>
                                     </ul>
 
                                     <!-- medio -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab3 === 3">
+                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 3">
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
-                                                (click)="selectedTab4 = 1">Todo</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
+                                                (click)="selectedTab5 = 1">Todo</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
-                                                (click)="selectedTab4 = 2">Google</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
+                                                (click)="selectedTab5 = 2">Google</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 3}"
-                                                (click)="selectedTab4 = 3">Facebook</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
+                                                (click)="selectedTab5 = 3">Facebook</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 4}"
-                                                (click)="selectedTab4 = 4">Programmatic</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
+                                                (click)="selectedTab5 = 4">Programmatic</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 5}"
-                                                (click)="selectedTab4 = 5">Institucional</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 5}"
+                                                (click)="selectedTab5 = 5">Institucional</a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 6}"
-                                                (click)="selectedTab4 = 6">Otro</a>
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 6}"
+                                                (click)="selectedTab5 = 6">Otro</a>
                                         </li>
                                     </ul>
                                 </div>
@@ -302,8 +275,8 @@
                         </div>
 
                         <app-chart-line-series [series]="usersAndSalesBySector"
-                            [valueName]="selectedTab2 === 1 ? 'Usuarios' : 'Ventas'"
-                            [valueFormat]="selectedTab2 === 2 && 'USD'" name="latam-sales-users-by-sector"
+                            [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
+                            [valueFormat]="selectedTab3 === 2 && 'USD'" name="latam-sales-users-by-sector"
                             [status]="usersAndSalesReqStatus">
                         </app-chart-line-series>
                     </div>
@@ -401,13 +374,4 @@
             </div>
         </div>
     </div>
-    <!-- </ng-container> -->
-
-    <!-- <ng-container *ngIf="activeTabView === 2">
-        <p class="text-muted">Categoría</p>
-    </ng-container>
-
-    <ng-container *ngIf="activeTabView === 3">
-        <p class="text-muted">Medio</p>
-    </ng-container> -->
 </div>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -73,7 +73,7 @@
                             </div>
                         </div>
                         <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
-                            categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
+                            categoryX="country" categoryY="sector" height="250px" [showTooltipValue]="false"
                             [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
                             [minValue]="0" [maxValue]="1" initialColor="#e9e9e9">
                         </app-chart-heat-map>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.html
@@ -1,5 +1,5 @@
 <div class="main-container mt-4">
-    <ul class="nav nav-tabs mb-4">
+    <!-- <ul class="nav nav-tabs mb-4">
         <li class="nav-item">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}" (click)="activeTabView = 1">
                 <span class="h2 py-2 ml-3 mr-3">Sector</span>
@@ -15,17 +15,219 @@
                 <span class="h2 py-2 ml-3 mr-3">Medio</span>
             </a>
         </li>
-    </ul>
+    </ul> -->
 
-    <ng-container *ngIf="activeTabView === 1">
-        <p class="text-muted">Sector</p>
-    </ng-container>
+    <!-- <ng-container *ngIf="activeTabView === 1"> -->
+    <div class="main-container mt-5">
+        <!-- CARD STATS -->
+        <div class="row">
+            <div class="col-12">
+                <div class="stats-container">
+                    <app-card-stat *ngFor="let stat of kpis" [stat]="stat" [loader]="kpisReqStatus <= 1">
+                    </app-card-stat>
+                </div>
+                <p class="text-center text-muted mt-3 mb-0" [hidden]="kpisReqStatus !== 3">
+                    Error al consultar datos
+                </p>
+            </div>
+        </div>
 
-    <ng-container *ngIf="activeTabView === 2">
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="pills-container">
+                    <ul class="nav nav-pills nav-fill">
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
+                                (click)="getCategoriesBySector('Search', 1)">Search</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
+                                (click)="getCategoriesBySector('Marketing', 2)">Marketing</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
+                                (click)="getCategoriesBySector('Ventas', 3)">Ventas</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-12 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <ng-container [ngSwitch]="selectedTab1">
+                            <span *ngSwitchCase="1" class="h4">Categorías por Retailer - Search</span>
+                            <span *ngSwitchCase="2" class="h4">Categorías por Retailer - Marketing</span>
+                            <span *ngSwitchCase="3" class="h4">Categorías por Retailer - Ventas</span>
+                        </ng-container>
+                    </div>
+                    <div class="card-body">
+                        <div class="chart-legend mt-0 mb-2">
+                            <div class="legend-container">
+                                <div class="legend-square on"></div>
+                                <div class="legend-label">Activas</div>
+                            </div>
+                            <div class="legend-container ml-3">
+                                <div class="legend-square off"></div>
+                                <div class="legend-label">Inactivas</div>
+                            </div>
+                        </div>
+                        <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
+                            categoryX="retailer" categoryY="category" height="250px" [showTooltipValue]="false"
+                            [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
+                            [minValue]="0" [maxValue]="1" initialColor="#e9e9e9">
+                        </app-chart-heat-map>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="pills-container">
+                    <ul class="nav nav-pills nav-fill">
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
+                                (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
+                                (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- devices -->
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-pictorial [data]="trafficAndSales['device']" name="latam-devices" category="name"
+                            iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus" height="280px">
+                        </app-chart-pictorial>
+                    </div>
+                </div>
+            </div>
+
+            <!-- gender -->
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-pictorial [data]="trafficAndSales['gender']" name="latam-gender" category="name"
+                            iconType="man" [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
+                        </app-chart-pictorial>
+                    </div>
+                </div>
+            </div>
+
+            <!-- age -->
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-lollipop [data]="trafficAndSales['age']" name="latam-age" category="age"
+                            [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
+                            [status]="trafficSalesReqStatus[2].reqStatus">
+                        </app-chart-lollipop>
+                    </div>
+                </div>
+            </div>
+
+            <!-- age and gender -->
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
+                    </div>
+                    <div class="card-body" style="height: 328px">
+                        <!-- loader -->
+                        <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 1">
+                        </app-chart-loader>
+
+                        <!-- ready -->
+                        <app-chart-pyramid *ngIf="trafficAndSales['genderByAge']?.length > 0"
+                            [data]="trafficAndSales['genderByAge']" name="latam-age-and-gender"
+                            [status]="trafficSalesReqStatus[3].reqStatus" height="280px">
+                        </app-chart-pyramid>
+
+                        <!-- empty data -->
+                        <div *ngIf="trafficSalesReqStatus[3].reqStatus === 2 && trafficAndSales['genderByAge']?.length === 0"
+                            class="chart-error-container text-muted">
+                            <span>Sin datos disponibles</span>
+                        </div>
+
+                        <!-- error -->
+                        <div *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 3"
+                            class="chart-error-container text-muted">
+                            <span>Error al consultar datos</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="pills-container">
+                    <ul class="nav nav-pills nav-fill">
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
+                                (click)="getDataByUsersAndSales('users', 1)">Usuarios</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
+                                (click)="getDataByUsersAndSales('sales', 2)">Ventas</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+            <div class="col-12 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4" [hidden]="selectedTab3 === 2">Usuarios por Sector</span>
+                        <span class="h4" [hidden]="selectedTab3 === 1">Ventas por Sector</span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-line-series [series]="usersAndSalesBySector"
+                            [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
+                            [valueFormat]="selectedTab3 === 2 && 'USD'" name="latam-sales-users-by-sector"
+                            [status]="usersAndSalesReqStatus">
+                        </app-chart-line-series>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">Inversión vs Revenue</span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-line-comparison [data]="investmentVsRevenue" name="latam-investment-vs-revenue"
+                            value1="investment" value2="revenue" valueName1="Inversión" valueName2="Revenue"
+                            valueFormat="USD" [status]="invVsRevenueReqStatus">
+                        </app-chart-line-comparison>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- </ng-container> -->
+
+    <!-- <ng-container *ngIf="activeTabView === 2">
         <p class="text-muted">Categoría</p>
     </ng-container>
 
     <ng-container *ngIf="activeTabView === 3">
         <p class="text-muted">Medio</p>
-    </ng-container>
+    </ng-container> -->
 </div>

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
@@ -1,0 +1,69 @@
+.stats-container {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 20px;
+
+    @media screen and (max-width: 1200px) {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    @media screen and (max-width: 1000px) {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    @media screen and (max-width: 480px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.card-header {
+    padding: 0.5rem 1.5rem;
+}
+
+.header {
+   border-radius: 0.375rem;;
+}
+
+.pills-container {
+    width: 60%;
+
+    .nav-item .nav-link {
+        cursor: pointer;
+    }
+
+    @media screen and (max-width: 820px) {
+        width: 100%;
+    }
+}
+
+.chart-legend {
+    align-items: center;
+    display: flex;
+    justify-content: flex-end;
+    padding: 0 15px;
+
+    .legend-container {
+        align-items: center;
+        display: flex;
+       
+        .legend-square {
+            border-radius: 4px;
+            height: 25px;
+            margin-right: 4px;
+            width: 25px;
+
+            &.on {
+                background-color: #67B6DC;
+            }
+
+            &.off {
+                background-color: #e9e9e9;
+            }
+        }
+
+        .legend-label {
+            color: #000000;
+            font-size: 12px;
+        }
+    }
+}

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
@@ -36,6 +36,25 @@
     }
 }
 
+.card-body {
+    .nav-tabs {
+        .nav-link {
+            cursor: pointer;
+            color:rgba(0, 0, 0, 0.5);
+    
+            &.active {
+                color: rgba(0, 0, 0, 0.9);
+            }
+        }
+    }
+
+    .pills-container {
+        .nav-link {
+            box-shadow: 0 2px 3px rgb(50 50 93 / 11%), 0 1px 3px rgb(0 0 0 / 8%);
+        } 
+    }
+}
+
 .chart-legend {
     align-items: center;
     display: flex;

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.scss
@@ -86,3 +86,27 @@
         }
     }
 }
+
+.adaptable-container {
+    overflow: auto;
+
+    table {
+        width: 100%;
+    
+        th:nth-of-type(n + 3),
+        td:nth-of-type(n + 3) {
+            text-align: center;
+        }
+    }
+
+    .lg-container {
+        max-width: 27rem;
+        span {
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
+            max-width: inherit;
+            display: inline-block;
+        }
+    }
+}

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -15,6 +15,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
   selectedTab1: number = 1;
   selectedTab2: number = 1;
   selectedTab3: number = 1;
+  selectedTab4: number = 1;
 
   kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
   kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
@@ -177,7 +178,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
           reqStatusObj.reqStatus = 3;
         });
 
-      this.selectedTab2 = selectedTab;
+      this.selectedTab1 = selectedTab;
     }
   }
 
@@ -187,21 +188,6 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
       (resp: any[]) => {
         this.usersAndSalesBySector = resp;
         this.usersAndSalesReqStatus = 2;
-
-        this.usersAndSalesBySector[0].customLineColor = '#67B6DC';
-        this.usersAndSalesBySector[1].customLineColor = '#67B6DC';
-
-        this.usersAndSalesBySector[2].customLineColor = '#A367DC';
-        this.usersAndSalesBySector[3].customLineColor = '#A367DC';
-
-        this.usersAndSalesBySector[4].customLineColor = '#DC67CE';
-        this.usersAndSalesBySector[5].customLineColor = '#DC67CE';
-
-
-
-        this.usersAndSalesBySector[1].customLineStye = 'dashed';
-        this.usersAndSalesBySector[3].customLineStye = 'dashed';
-        this.usersAndSalesBySector[5].customLineStye = 'dashed';
       },
       error => {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
@@ -210,7 +196,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
       }
     )
 
-    this.selectedTab3 = selectedTab;
+    this.selectedTab2 = selectedTab;
   }
 
   getInvestmentVsRevenue() {

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -18,6 +18,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
   selectedTab3: number = 1;
   selectedTab4: number = 1;
   selectedTab5: number = 1;
+  selectedTab6: number = 1;
 
   kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
   kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
@@ -117,7 +118,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
 
   getAllData() {
     this.getKpis();
-    this.getCategoriesBySector('Search', 1);
+    this.getSectorsAndCategories('sectors', 1);
     this.getDataByTrafficAndSales('sales', 2);
     this.getDataByUsersAndSales('sales', 2);
     this.getInvestmentVsRevenue();
@@ -150,9 +151,9 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
       });
   }
 
-  getCategoriesBySector(sector: string, selectedTab: number) {
+  getSectorsAndCategories(metricType: string, selectedTab: number) {
     this.categoriesReqStatus = 1;
-    this.overviewService.getSectorsByCountryLatam(sector).subscribe(
+    this.overviewService.getSectorsAndCategoriesLatam(metricType).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
         this.categoriesReqStatus = 2;
@@ -189,7 +190,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
           reqStatusObj.reqStatus = 3;
         });
 
-      this.selectedTab1 = selectedTab;
+      this.selectedTab2 = selectedTab;
     }
   }
 
@@ -207,7 +208,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
       }
     )
 
-    this.selectedTab2 = selectedTab;
+    this.selectedTab3 = selectedTab;
   }
 
   getInvestmentVsRevenue() {

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -141,7 +141,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
 
   getCategoriesBySector(sector: string, selectedTab: number) {
     this.categoriesReqStatus = 1;
-    this.overviewService.getCategoriesBySectorLatam(sector).subscribe(
+    this.overviewService.getSectorsByCountryLatam(sector).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
         this.categoriesReqStatus = 2;

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatTableDataSource } from '@angular/material/table';
 import { Subscription } from 'rxjs';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { OverviewService } from '../../services/overview.service';
@@ -16,6 +17,7 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
   selectedTab2: number = 1;
   selectedTab3: number = 1;
   selectedTab4: number = 1;
+  selectedTab5: number = 1;
 
   kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
   kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
@@ -88,6 +90,15 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
 
   filtersSub: Subscription;
   chartsInitLoad: boolean = true;
+
+  displayedColumns: string[] = ['rank', 'product', 'amount'];
+  private products = [
+    { rank: 1, product: 'Laptop HP 15-EF1005LA 15.6" AMD 3020e 4 GB RAM 128 SSD Negra', amount: 22 },
+    { rank: 2, product: 'Laptop HP 15-GW0012LA 15.6" AMD Ryzen 5 12 GB RAM 256 GB Roja', amount: 20 },
+    { rank: 3, product: 'Laptop HP 14-DK1013LA 14" AMD Athlon Silver 4 GB RAM 500 GB Gris', amount: 19 },
+    { rank: 4, product: 'Laptop HP 15-EF1007LA 15.6" AMD Ryzen 3 12 GB RAM 256 GB SSD Azul', amount: 15 }
+  ]
+  dataSource = new MatTableDataSource<any>(this.products);
 
   constructor(
     private filtersStateService: FiltersStateService,
@@ -212,6 +223,48 @@ export class LatamCoopComponent implements OnInit, OnDestroy {
         this.invVsRevenueReqStatus = 3;
       }
     )
+  }
+
+  showTopProducts(category: string) {
+    switch (category) {
+      case 'ps':
+        this.products = [
+          { rank: 1, product: 'Laptop HP 15-EF1005LA 15.6" AMD 3020e 4 GB RAM 128 SSD Negra', amount: 22 },
+          { rank: 2, product: 'Laptop HP 15-GW0012LA 15.6" AMD Ryzen 5 12 GB RAM 256 GB Roja', amount: 20 },
+          { rank: 3, product: 'Laptop HP 14-DK1013LA 14" AMD Athlon Silver 4 GB RAM 500 GB Gris', amount: 19 },
+          { rank: 4, product: 'Laptop HP 15-EF1007LA 15.6" AMD Ryzen 3 12 GB RAM 256 GB SSD Azul', amount: 15 }
+        ]
+        break;
+
+      case 'print':
+        this.products = [
+          { rank: 1, product: 'Impresora Multifunción HP INK TANK 415 - HP', amount: 10 },
+          { rank: 2, product: 'Impresora HP Deskjet Ink Advantage 1275 - HP', amount: 8 },
+          { rank: 3, product: 'Impresora HP INK TANK 115 - HP', amount: 7 },
+          { rank: 4, product: 'Impresora Multifunción HP Deskjet INK Advantage 2375 - HP', amount: 5 }
+        ]
+        break;
+
+      case 'supplies':
+        this.products = [
+          { rank: 1, product: 'Cartucho de tinta HP 664 Negra - HP', amount: 60 },
+          { rank: 2, product: 'Cartucho de tinta HP 662 Negra - HP', amount: 56 },
+          { rank: 3, product: 'Cartucho HP 122 CH561HL Negro - HP', amount: 45 },
+          { rank: 4, product: 'Cartucho HP 10 C48444A Negro - HP', amount: 35 }
+        ]
+        break;
+
+      case 'accesories':
+        this.products = [
+          { rank: 1, product: 'Funda HP Carry de 13"', amount: 32 },
+          { rank: 2, product: 'Teclado HP Pavilion Gaming 500', amount: 25 },
+          { rank: 3, product: 'Teclado y Mouse HP 320MK', amount: 13 },
+          { rank: 4, product: 'Estación de acomplamiento mini HP USB-C', amount: 15 }
+        ]
+        break;
+    }
+
+    this.dataSource = new MatTableDataSource<any>(this.products);
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
+++ b/src/app/modules/dashboard/pages/latam-coop/latam-coop.component.ts
@@ -1,17 +1,234 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { FiltersStateService } from '../../services/filters-state.service';
+import { OverviewService } from '../../services/overview.service';
 
 @Component({
   selector: 'app-latam-coop',
   templateUrl: './latam-coop.component.html',
   styleUrls: ['./latam-coop.component.scss']
 })
-export class LatamCoopComponent implements OnInit {
+export class LatamCoopComponent implements OnInit, OnDestroy {
 
   activeTabView = 1;
 
-  constructor() { }
+  selectedTab1: number = 1;
+  selectedTab2: number = 1;
+  selectedTab3: number = 1;
+
+  kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
+  kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
+  kpis: any[] = [
+    {
+      metricTitle: 'inversión',
+      metricName: 'investment',
+      metricFormat: 'currency',
+      metricSymbol: 'USD',
+      icon: 'fas fa-wallet',
+      iconBg: '#172b4d'
+    },
+    {
+      metricTitle: 'clicks',
+      metricName: 'clicks',
+      subMetricTitle: 'ctr',
+      subMetricName: 'ctr',
+      subMetricFormat: 'percentage',
+      icon: 'fas fa-hand-pointer',
+      iconBg: '#2f9998'
+
+    },
+    {
+      metricTitle: 'bounce rate',
+      metricName: 'bounce_rate',
+      metricFormat: 'percentage',
+      subMetricTitle: 'usuarios',
+      subMetricName: 'users',
+      icon: 'fas fa-stopwatch',
+      iconBg: '#a77dcc'
+    },
+    {
+      metricTitle: 'transacciones',
+      metricName: 'transactions',
+      subMetricTitle: 'CR',
+      subMetricName: 'cr',
+      subMetricFormat: 'percentage',
+      icon: 'fas fa-shopping-basket',
+      iconBg: '#f89934'
+    },
+    {
+      metricTitle: 'revenue',
+      metricName: 'revenue',
+      metricFormat: 'currency',
+      subMetricTitle: 'roas',
+      subMetricName: 'roas',
+      subMetricFormat: 'decimals',
+      icon: 'fas fa-hand-holding-usd',
+      iconBg: '#fbc001'
+    }
+  ];
+
+  categoriesBySector: any[] = [];
+  trafficAndSales = {};
+
+  usersAndSalesBySector: any[] = [];
+  investmentVsRevenue: any[] = [];
+
+  // requests status
+  kpisReqStatus: number = 0;
+  categoriesReqStatus: number = 0;
+  usersAndSalesReqStatus: number = 0;
+  invVsRevenueReqStatus: number = 0;
+  trafficSalesReqStatus = [
+    { name: 'device', reqStatus: 0 },
+    { name: 'gender', reqStatus: 0 },
+    { name: 'age', reqStatus: 0 },
+    { name: 'gender-and-age', reqStatus: 0 }
+  ];
+
+  filtersSub: Subscription;
+  chartsInitLoad: boolean = true;
+
+  constructor(
+    private filtersStateService: FiltersStateService,
+    private overviewService: OverviewService) { }
 
   ngOnInit(): void {
+    if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+      this.filtersStateService.clearCampaignsSelection();
+      this.getAllData();
+    }
+
+    this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
+      this.getAllData();
+    });
   }
 
+  getAllData() {
+    this.getKpis();
+    this.getCategoriesBySector('Search', 1);
+    this.getDataByTrafficAndSales('sales', 2);
+    this.getDataByUsersAndSales('sales', 2);
+    this.getInvestmentVsRevenue();
+
+    this.chartsInitLoad = true;
+  }
+
+  getKpis() {
+    this.kpisReqStatus = 1;
+    this.overviewService.getKpisLatam().subscribe(
+      (resp: any[]) => {
+        const kpis1 = resp.filter(kpi => this.kpisLegends1.includes(kpi.string));
+        const kpis2 = resp.filter(kpi => this.kpisLegends2.includes(kpi.string));
+
+        for (let i = 0; i < this.kpis.length; i++) {
+          const baseObj = this.kpis[i];
+          baseObj.metricValue = kpis1[i]['value'];
+
+          if (i !== 0 && kpis2[i - 1]) {
+            baseObj.subMetricValue = kpis2[i - 1]['value'];
+          }
+
+        }
+        this.kpisReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.kpisReqStatus = 3;
+      });
+  }
+
+  getCategoriesBySector(sector: string, selectedTab: number) {
+    this.categoriesReqStatus = 1;
+    this.overviewService.getCategoriesBySectorLatam(sector).subscribe(
+      (resp: any[]) => {
+        this.categoriesBySector = resp;
+        this.categoriesReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.categoriesReqStatus = 3;
+      });
+
+    this.selectedTab1 = selectedTab;
+  }
+
+  getDataByTrafficAndSales(metricType: string, selectedTab: number) {
+    const requiredData = ['device', 'gender', 'age', 'gender-and-age']
+
+    for (let subMetricType of requiredData) {
+      const reqStatusObj = this.trafficSalesReqStatus.find(item => item.name === subMetricType);
+      reqStatusObj.reqStatus = 1;
+      this.overviewService.getTrafficAndSalesLatam(metricType, subMetricType).subscribe(
+        (resp: any[]) => {
+          if (subMetricType === 'gender-and-age') {
+            this.trafficAndSales['genderByAge'] = resp;
+          } else {
+            this.trafficAndSales[subMetricType] = resp;
+          }
+
+          reqStatusObj.reqStatus = 2;
+
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[overview-wrapper.component]: ${errorMsg}`);
+          reqStatusObj.reqStatus = 3;
+        });
+
+      this.selectedTab2 = selectedTab;
+    }
+  }
+
+  getDataByUsersAndSales(metricType: string, selectedTab: number) {
+    this.usersAndSalesReqStatus = 1;
+    this.overviewService.getUsersAndSalesLatam(metricType).subscribe(
+      (resp: any[]) => {
+        this.usersAndSalesBySector = resp;
+        this.usersAndSalesReqStatus = 2;
+
+        this.usersAndSalesBySector[0].customLineColor = '#67B6DC';
+        this.usersAndSalesBySector[1].customLineColor = '#67B6DC';
+
+        this.usersAndSalesBySector[2].customLineColor = '#A367DC';
+        this.usersAndSalesBySector[3].customLineColor = '#A367DC';
+
+        this.usersAndSalesBySector[4].customLineColor = '#DC67CE';
+        this.usersAndSalesBySector[5].customLineColor = '#DC67CE';
+
+
+
+        this.usersAndSalesBySector[1].customLineStye = 'dashed';
+        this.usersAndSalesBySector[3].customLineStye = 'dashed';
+        this.usersAndSalesBySector[5].customLineStye = 'dashed';
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.usersAndSalesReqStatus = 3;
+      }
+    )
+
+    this.selectedTab3 = selectedTab;
+  }
+
+  getInvestmentVsRevenue() {
+    this.invVsRevenueReqStatus = 1;
+    this.overviewService.getInvestmentVsRevenueLatam().subscribe(
+      (resp: any[]) => {
+        this.investmentVsRevenue = resp;
+        this.invVsRevenueReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+        this.invVsRevenueReqStatus = 3;
+      }
+    )
+  }
+
+  ngOnDestroy() {
+    this.filtersSub?.unsubscribe();
+  }
 }

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -159,14 +159,14 @@ export class OverviewService {
   }
 
   // *** sectors by country ***
-  getSectorsByCountryLatam(sector: string) {
-    if (!sector) {
-      return throwError('[overview.service]: not sector provided');
+  getSectorsAndCategoriesLatam(metricType: string) {
+    if (!metricType) {
+      return throwError('[overview.service]: not metricType provided');
     }
 
     let queryParams = this.concatedQueryParams();
     // return this.http.get(`${this.baseUrl}/countries/1/retailer/categories?sector=${sector}&${queryParams}`);
-    return this.http.get(`http://localhost:3000/api/v1/latam/categories?sector=${sector}&${queryParams}`);
+    return this.http.get(`http://localhost:3000/api/v1/latam/categories/${metricType}?${queryParams}`);
   }
 
   // *** traffic and sales ***

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -53,8 +53,11 @@ export class OverviewService {
     return `start_date=${startDate}&end_date=${endDate}&sectors=${sectors}&categories=${categories}${campaigns ? `&campaigns=${campaigns}` : ''}`;
   }
 
+  /**** COUNTRIES AND RETAILERS
+  * Overview endpoints for Countries and Retailers
+  * ****/
+
   // *** filters ***
-  // solo para este caso es una exepcion y si trabaja con sus query params
   getCampaigns(sectorsStrList?: string, categoriesStrList?: string) {
     if (!this.retailerID) {
       return throwError('[overview.service]: not countryID provided');
@@ -113,6 +116,7 @@ export class OverviewService {
     }
   }
 
+  // *** users and sales ***
   getUsersAndSales(metricType: string) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
@@ -129,6 +133,7 @@ export class OverviewService {
     }
   }
 
+  // *** investment vs revenue ***
   getInvestmentVsRevenue() {
     let queryParams = this.concatedQueryParams();
 
@@ -139,5 +144,60 @@ export class OverviewService {
     } else {
       return throwError('[overview.service]: not retailerID or countryID provided');
     }
+  }
+
+
+  /**** LATAM
+  * Overview endpoints for LATAM
+  * ****/
+
+  // *** kpis ***
+  getKpisLatam() {
+    let queryParams = this.concatedQueryParams();
+    return this.http.get(`${this.baseUrl}/countries/1/kpis?${queryParams}`);
+    return this.http.get(`${this.baseUrl}/latam/kpis?${queryParams}`);
+  }
+
+  // *** categories by sector ***
+  getCategoriesBySectorLatam(sector: string) {
+    if (!sector) {
+      return throwError('[overview.service]: not sector provided');
+    }
+
+    let queryParams = this.concatedQueryParams();
+    return this.http.get(`${this.baseUrl}/countries/1/retailer/categories?sector=${sector}&${queryParams}`);
+    return this.http.get(`${this.baseUrl}/latam/categories?sector=${sector}&${queryParams}`);
+  }
+
+  // *** traffic and sales ***
+  getTrafficAndSalesLatam(metricType: string, subMetricType: string) {
+    if (!metricType) {
+      return throwError('[overview.service]: not metricType provided');
+    }
+    if (!subMetricType) {
+      return throwError('[overview.service]: not subMetricType provided');
+    }
+
+    let queryParams = this.concatedQueryParams();
+    return this.http.get(`${this.baseUrl}/countries/1/${metricType}/${subMetricType}?${queryParams}`);
+
+  }
+
+  // *** users and sales ***
+  getUsersAndSalesLatam(metricType: string) {
+    if (!metricType) {
+      return throwError('[overview.service]: not metricType provided');
+    }
+
+    let queryParams = this.concatedQueryParams();
+    // return this.http.get(`${this.baseUrl}/countries/1/${metricType}?${queryParams}`);
+    return this.http.get(`http://localhost:3000/api/v1/latam/${metricType}?${queryParams}`);
+  }
+
+  // *** investment vs revenue ***
+  getInvestmentVsRevenueLatam() {
+    let queryParams = this.concatedQueryParams();
+    return this.http.get(`${this.baseUrl}/countries/1/investment-vs-revenue?${queryParams}`);
+    return this.http.get(`${this.baseUrl}/latam/investment-vs-revenue?${queryParams}`);
   }
 }

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -158,15 +158,15 @@ export class OverviewService {
     return this.http.get(`${this.baseUrl}/latam/kpis?${queryParams}`);
   }
 
-  // *** categories by sector ***
-  getCategoriesBySectorLatam(sector: string) {
+  // *** sectors by country ***
+  getSectorsByCountryLatam(sector: string) {
     if (!sector) {
       return throwError('[overview.service]: not sector provided');
     }
 
     let queryParams = this.concatedQueryParams();
-    return this.http.get(`${this.baseUrl}/countries/1/retailer/categories?sector=${sector}&${queryParams}`);
-    return this.http.get(`${this.baseUrl}/latam/categories?sector=${sector}&${queryParams}`);
+    // return this.http.get(`${this.baseUrl}/countries/1/retailer/categories?sector=${sector}&${queryParams}`);
+    return this.http.get(`http://localhost:3000/api/v1/latam/categories?sector=${sector}&${queryParams}`);
   }
 
   // *** traffic and sales ***


### PR DESCRIPTION
# Problem Description
- Is necessary create a basic template in latam-coop component to show LATAM overview data

# Features
- Add LATAM provisional endpoints to overview-service
- Add basic template to latam-coop component
- Other implications:
   - Adapt chart-line-template behaviour in latam-coop component
   - Show source filter in general-filters when latam is selected
   - Update chart-heat-map to change categories inputs dynamically

# Where this change will be used
- In LATAM overview template at `/dashboard/coop?country=latam` path

# More details
![image](https://user-images.githubusercontent.com/38545126/118747126-0c03ba80-b81f-11eb-9074-f96ff4cabfbf.png)
![image](https://user-images.githubusercontent.com/38545126/118747133-16be4f80-b81f-11eb-84b5-80d82d67120b.png)
![image](https://user-images.githubusercontent.com/38545126/118747155-1e7df400-b81f-11eb-98e2-b081f7097d0b.png)
![image](https://user-images.githubusercontent.com/38545126/118747174-289ff280-b81f-11eb-8ea0-8ef2bd8e8c16.png)

