### PR TITLE
initialize kpis data to zero in overview components

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -26,6 +26,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'inversión',
       metricName: 'investment',
+      metricValue: 0,
       metricFormat: 'currency',
       metricSymbol: 'USD',
       icon: 'fas fa-wallet',
@@ -34,8 +35,10 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'clicks',
       metricName: 'clicks',
+      metricValue: 0,
       subMetricTitle: 'ctr',
       subMetricName: 'ctr',
+      subMetricValue: 0,
       subMetricFormat: 'percentage',
       icon: 'fas fa-hand-pointer',
       iconBg: '#2f9998'
@@ -44,17 +47,21 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'bounce rate',
       metricName: 'bounce_rate',
+      metricValue: 0,
       metricFormat: 'percentage',
       subMetricTitle: 'usuarios',
       subMetricName: 'users',
+      subMetricValue: 0,
       icon: 'fas fa-stopwatch',
       iconBg: '#a77dcc'
     },
     {
       metricTitle: 'transacciones',
       metricName: 'transactions',
+      metricValue: 0,
       subMetricTitle: 'CR',
       subMetricName: 'cr',
+      subMetricValue: 0,
       subMetricFormat: 'percentage',
       icon: 'fas fa-shopping-basket',
       iconBg: '#f89934'
@@ -62,9 +69,11 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'revenue',
       metricName: 'revenue',
+      metricValue: 0,
       metricFormat: 'currency',
       subMetricTitle: 'roas',
       subMetricName: 'roas',
+      subMetricValue: 0,
       subMetricFormat: 'decimals',
       icon: 'fas fa-hand-holding-usd',
       iconBg: '#fbc001'

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -26,6 +26,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'inversión',
       metricName: 'investment',
+      metricValue: 0,
       metricFormat: 'currency',
       metricSymbol: 'USD',
       icon: 'fas fa-wallet',
@@ -34,8 +35,10 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'clicks',
       metricName: 'clicks',
+      metricValue: 0,
       subMetricTitle: 'ctr',
       subMetricName: 'ctr',
+      subMetricValue: 0,
       subMetricFormat: 'percentage',
       icon: 'fas fa-hand-pointer',
       iconBg: '#2f9998'
@@ -44,17 +47,21 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'bounce rate',
       metricName: 'bounce_rate',
+      metricValue: 0,
       metricFormat: 'percentage',
       subMetricTitle: 'usuarios',
       subMetricName: 'users',
+      subMetricValue: 0,
       icon: 'fas fa-stopwatch',
       iconBg: '#a77dcc'
     },
     {
       metricTitle: 'transacciones',
       metricName: 'transactions',
+      metricValue: 0,
       subMetricTitle: 'CR',
       subMetricName: 'cr',
+      subMetricValue: 0,
       subMetricFormat: 'percentage',
       icon: 'fas fa-shopping-basket',
       iconBg: '#f89934'
@@ -62,9 +69,11 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     {
       metricTitle: 'revenue',
       metricName: 'revenue',
+      metricValue: 0,
       metricFormat: 'currency',
       subMetricTitle: 'roas',
       subMetricName: 'roas',
+      subMetricValue: 0,
       subMetricFormat: 'decimals',
       icon: 'fas fa-hand-holding-usd',
       iconBg: '#fbc001'


### PR DESCRIPTION
# Problem Description
- When there is an error in GET /kpis request response the values in KPI's cards aren't show and this might confuse to the users

# Features
- Initialize kpis data to zero in overview components

# Where this change will be used
- In overview components at `/dashboard/coop` `/dashboard/country` or `/dashboard/retailer` paths

# More details
![image](https://user-images.githubusercontent.com/38545126/118824715-b0b5e480-b87f-11eb-9ff9-8731593d411a.png)
