### PR TITLE
show country and retailer filters in general-filters component for latam view

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -1,7 +1,70 @@
 <form role="form" [formGroup]="form">
     <div class="row">
+
+        <!-- country -->
+        <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
+            <span class="mb-1 h4">País</span>
+            <mat-select formControlName="countries" multiple placeholder="Selecciona un País">
+                <div class="input-group input-group-alternative mb-1">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="fas fa-search"></i></span>
+                    </div>
+                    <input class="form-control" [(ngModel)]="countryFilter" matInput type="text"
+                        (keyup)="filterFromList('country', $event.target.value)" placeholder="Buscar País"
+                        [ngModelOptions]="{standalone: true}">
+                </div>
+                <mat-select-trigger>
+                    <div class="select-value-container">
+                        <span class="select-value">{{countries.value ? countries.value[0]?.name : ''}}</span>
+                        <span *ngIf="countries.value?.length > 1" class="example-additional-selection ml-1">
+                            (+ {{countries.value?.length === 2 ? 'otro' : 'otros'}}
+                            {{ countries.value?.length === 2 ? '' : countries.value.length - 1}})
+                        </span>
+                    </div>
+                </mat-select-trigger>
+                <mat-option *ngFor="let country of countryList" [value]="country">{{country.name}}</mat-option>
+            </mat-select>
+            <small class="text-danger" *ngIf="countries?.value?.length < 1 && countries.touched">
+                Selecciona al menos un País
+            </small>
+            <small class="text-danger" *ngIf="countriesErrorMsg">
+                {{ countriesErrorMsg }}
+            </small>
+        </div>
+
+        <!-- retailer -->
+        <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
+            <span class="mb-1 h4">Retailer</span>
+            <mat-select formControlName="retailers" multiple placeholder="Selecciona un Retailer">
+                <div class="input-group input-group-alternative mb-1">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text"><i class="fas fa-search"></i></span>
+                    </div>
+                    <input class="form-control" [(ngModel)]="retailerFilter" matInput type="text"
+                        (keyup)="filterFromList('retailer', $event.target.value)" placeholder="Buscar Retailer"
+                        [ngModelOptions]="{standalone: true}">
+                </div>
+                <mat-select-trigger>
+                    <div class="select-value-container">
+                        <span class="select-value">{{retailers.value ? retailers.value[0]?.name : ''}}</span>
+                        <span *ngIf="retailers.value?.length > 1" class="example-additional-selection ml-1">
+                            (+ {{retailers.value?.length === 2 ? 'otro' : 'otros'}}
+                            {{ retailers.value?.length === 2 ? '' : retailers.value.length - 1}})
+                        </span>
+                    </div>
+                </mat-select-trigger>
+                <mat-option *ngFor="let retailer of retailerList" [value]="retailer">{{retailer.name}}</mat-option>
+            </mat-select>
+            <small class="text-danger" *ngIf="retailers?.value?.length < 1 && retailers.touched">
+                Selecciona al menos un Retailer
+            </small>
+            <small class="text-danger" *ngIf="retailersErrorMsg">
+                {{ retailersErrorMsg }}
+            </small>
+        </div>
+
         <!-- period -->
-        <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <div class="date-picker">
                 <span class="mb-1 h4">Periodo</span>
                 <mat-form-field appearance="fill">
@@ -22,14 +85,14 @@
         </div>
 
         <!-- sector -->
-        <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <span class="mb-1 h4">Sector</span>
             <mat-select formControlName="sectors" multiple placeholder="Selecciona un Sector">
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">{{sectors.value ? sectors.value[0]?.name : ''}}</span>
                         <span *ngIf="sectors.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{sectors.value?.length === 2 ? 'otra' : 'otras'}}
+                            (+ {{sectors.value?.length === 2 ? 'otro' : 'otros'}}
                             {{ sectors.value?.length === 2 ? '' : sectors.value.length - 1}})
                         </span>
                     </div>
@@ -37,7 +100,7 @@
                 <mat-option *ngFor="let sector of sectorList" [value]="sector">{{sector.name}}</mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
-                Selecciona al menos un sector
+                Selecciona al menos un Sector
             </small>
             <small class="text-danger" *ngIf="sectorsErrorMsg">
                 {{ sectorsErrorMsg }}
@@ -45,7 +108,7 @@
         </div>
 
         <!-- category -->
-        <div class="col-12 col-sm-6 col-lg-3 mb-4">
+        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <span class="mb-1 h4">Categoría</span>
             <mat-select formControlName="categories" multiple placeholder="Selecciona una Categoría">
                 <mat-select-trigger>
@@ -60,7 +123,7 @@
                 <mat-option *ngFor="let category of categoryList" [value]="category">{{category.name}}</mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
-                Selecciona al menos una categoría
+                Selecciona al menos una Categoría
             </small>
             <small class="text-danger" *ngIf="categoriesErrorMsg">
                 {{ categoriesErrorMsg }}
@@ -68,7 +131,7 @@
         </div>
 
         <!-- campaign -->
-        <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!retailerID">
+        <div [hidden]="!retailerID" class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Campaña</span>
             <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña"
                 [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsErrorMsg">
@@ -77,8 +140,8 @@
                     <div class="input-group-prepend">
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
-                    <input class="form-control" [(ngModel)]="campaignsFilter" matInput type="text"
-                        (keyup)="filterCampaigns($event.target.value)" placeholder="Buscar campaña"
+                    <input class="form-control" [(ngModel)]="campaignFilter" matInput type="text"
+                        (keyup)="filterFromList('campaign', $event.target.value)" placeholder="Buscar Campaña"
                         [ngModelOptions]="{standalone: true}">
                 </div>
                 <mat-select-trigger>
@@ -101,7 +164,7 @@
         </div>
 
         <!-- medium -->
-        <div class="col-12 col-sm-6 col-lg-3 mb-4" [hidden]="!isLatamSelected">
+        <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
             <span class="mb-1 h4">Fuente</span>
             <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente">
                 <mat-select-trigger>


### PR DESCRIPTION
# Problem Description
- Is necessary to show country and retailer filters for LATAM view

# Features
- Add countries and retailers filters
- Create a generic method to apply search filter in countries, retailers and campaigns filters (or others if its necessary)
- Use dynamic classes in filters columns to adapt the content dependig if general-filters components are used from LATAM, Country or Retailer view

# Where this change will be used
- Where general-filters component will be use 
   - LATAM view -> `/dashboard/coop`
   - Country view -> `/dashboard/country`
   - Retailer view -> `/dashboard/retailer`

# More details
- LATAM view
![image](https://user-images.githubusercontent.com/38545126/118884673-6737ba80-b8bc-11eb-9687-008da7033629.png)

- Country view
![image](https://user-images.githubusercontent.com/38545126/118884800-89c9d380-b8bc-11eb-9907-27c8adca77f0.png)

- Retailer view
![image](https://user-images.githubusercontent.com/38545126/118884847-98b08600-b8bc-11eb-959e-85b5e12ae7e0.png)
