### PR TITLE
restore filters after country and retailer changes in general-filters components

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -189,7 +189,7 @@
         (!endDate.valid && endDate.touched) ||
         (sectors?.value?.length < 1 && sectors.touched) ||
         (categories?.value?.length < 1 && categories.touched)
-        " (click)="applyFilters()">
+        " (click)="applyFilters(true)">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>


### PR DESCRIPTION
# Problem Description
- In order to improve UX is necessary restore filters (select all options for each filter by default) after country or retailer change

# Features
- Add restoreFilters method in general-filters-component
- Emit filters changes only for call from init and filter button
- For retailer and country changes only update filtered options and query params for requests 

# Where this change will be used
- In general-filters-components component shown in dashboard module at `/dashboard/*` path