### PR TITLE
add 'select all' option in filters shown in general-filter component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -22,7 +22,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let country of countryList" [value]="country">{{country.name}}</mat-option>
+                <mat-option #allSelectedCountries
+                    (click)="toggleAllSelection('allSelectedCountries','countries', 'countryList')" [value]="0"
+                    class="font-weight-bold">
+                    Todos
+                </mat-option>
+                <mat-option *ngFor="let country of countryList" [value]="country"
+                    (click)="tosslePerOne('allSelectedCountries', 'countries', 'countryList')">
+                    {{country.name}}
+                </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="countries?.value?.length < 1 && countries.touched">
                 Selecciona al menos un País
@@ -53,7 +61,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let retailer of retailerList" [value]="retailer">{{retailer.name}}</mat-option>
+                <mat-option #allSelectedRetailers
+                    (click)="toggleAllSelection('allSelectedRetailers','retailers', 'retailerList')" [value]="0"
+                    class="font-weight-bold">
+                    Todos
+                </mat-option>
+                <mat-option *ngFor="let retailer of retailerList" [value]="retailer"
+                    (click)="tosslePerOne('allSelectedRetailers', 'retailers', 'retailerList')">
+                    {{retailer.name}}
+                </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="retailers?.value?.length < 1 && retailers.touched">
                 Selecciona al menos un Retailer
@@ -97,7 +113,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let sector of sectorList" [value]="sector">{{sector.name}}</mat-option>
+                <mat-option #allSelectedSectors
+                    (click)="toggleAllSelection('allSelectedSectors','sectors', 'sectorList')" [value]="0"
+                    class="font-weight-bold">
+                    Todos
+                </mat-option>
+                <mat-option *ngFor="let sector of sectorList" [value]="sector"
+                    (click)="tosslePerOne('allSelectedSectors', 'sectors', 'sectorList')">
+                    {{sector.name}}
+                </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
                 Selecciona al menos un Sector
@@ -120,7 +144,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let category of categoryList" [value]="category">{{category.name}}</mat-option>
+                <mat-option #allSelectedCategories
+                    (click)="toggleAllSelection('allSelectedCategories','categories', 'categoryList')" [value]="0"
+                    class="font-weight-bold">
+                    Todas
+                </mat-option>
+                <mat-option *ngFor="let category of categoryList" [value]="category"
+                    (click)="tosslePerOne('allSelectedCategories', 'categories', 'categoryList')">
+                    {{category.name}}
+                </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
                 Selecciona al menos una Categoría
@@ -153,7 +185,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let campaign of campaignList" [value]="campaign">{{campaign.name}}</mat-option>
+                <mat-option #allSelectedCampaigns
+                    (click)="toggleAllSelection('allSelectedCampaigns','campaigns', 'campaignList')" [value]="0"
+                    class="font-weight-bold">
+                    Todas
+                </mat-option>
+                <mat-option *ngFor="let campaign of campaignList" [value]="campaign"
+                    (click)="tosslePerOne('allSelectedCampaigns', 'campaigns', 'campaignList')">
+                    {{campaign.name}}
+                </mat-option>
             </mat-select>
             <small class="text-muted mt-1" *ngIf="campaignList?.length < 1 && campaignsReqStatus === 2">
                 No existen campañas para el Periodo, Sectores y Categorías seleccionados
@@ -163,7 +203,7 @@
             </small>
         </div>
 
-        <!-- medium -->
+        <!-- source -->
         <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
             <span class="mb-1 h4">Fuente</span>
             <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente">
@@ -176,7 +216,15 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option *ngFor="let source of sourceList" [value]="source">{{source.name}}</mat-option>
+                <mat-option #allSelectedSources
+                    (click)="toggleAllSelection('allSelectedSources','sources', 'sourceList')" [value]="0"
+                    class="font-weight-bold">
+                    Todas
+                </mat-option>
+                <mat-option *ngFor="let source of sourceList" [value]="source"
+                    (click)="tosslePerOne('allSelectedSources', 'sources', 'sourceList')">
+                    {{source.name}}
+                </mat-option>
             </mat-select>
         </div>
     </div>
@@ -189,7 +237,7 @@
         (!endDate.valid && endDate.touched) ||
         (sectors?.value?.length < 1 && sectors.touched) ||
         (categories?.value?.length < 1 && categories.touched)
-        " (click)="applyFilters(true)">
+        " (click)="applyFilters()">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -378,7 +378,6 @@ export class GeneralFiltersComponent implements OnInit {
   }
 
   applyFilters(emitChange?: boolean) {
-    console.log('applyFilters')
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value);
     this.filtersStateService.selectCategories(this.categories.value);
@@ -388,7 +387,6 @@ export class GeneralFiltersComponent implements OnInit {
 
     // in init or when Filter button is clicked
     if (emitChange) {
-      console.log('emit change')
       this.filtersStateService.filtersChange();
     }
   }

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -106,7 +106,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
-      this.filtersStateService.clearCampaignsSelection();
+      this.filtersStateService.restoreFilters();
       this.getAllData();
     }
 

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -49,7 +49,7 @@ export class CountryComponent implements OnInit, OnDestroy {
         if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
 
           if (!this.retailerID) {
-            this.filtersStateService.clearCampaignsSelection();
+            this.filtersStateService.restoreFilters();
             this.requestInfoSource.next();
           }
         }

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -116,7 +116,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
-      this.filtersStateService.clearCampaignsSelection();
+      this.filtersStateService.restoreFilters();
       this.getAllData();
     }
 

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -151,7 +151,7 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
         if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
           if (this.retailerID) {
-            this.filtersStateService.clearCampaignsSelection();
+            this.filtersStateService.restoreFilters();
             this.requestInfoSource.next();
           }
         }

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -11,24 +11,28 @@ export class FiltersStateService {
   private periodSource = new Subject<Period>();
   period$ = this.periodSource.asObservable();
   period: Period;
+  periodInitial: Period;
   periodQParams;
 
   // selected sectors
   private sectorsSource = new Subject<any[]>();
   sectors$ = this.sectorsSource.asObservable();
   sectors: any[];
+  sectorsInitial: any[];
   sectorsQParams;
 
   // selected categories
   private categoriesSource = new Subject<any[]>();
   categories$ = this.categoriesSource.asObservable();
   categories: any[];
+  categoriesInitial: any[];
   categoriesQParams;
 
   // selected campaigns
   private cammpaignsSource = new Subject<any[]>();
   campaigns$ = this.cammpaignsSource.asObservable();
   campaigns: any[];
+  campaignsInitial: any[];
   campaignsQParams;
 
   // filtersChange
@@ -67,15 +71,18 @@ export class FiltersStateService {
   convertArrayToQueryParams(array, param: string): string {
     let stringArray = '';
     for (let i = 0; i < array.length; i++) {
-      stringArray = stringArray.concat(',', array[i][param]);
+      stringArray = array[i][param] ? stringArray.concat(',', array[i][param]) : stringArray;
     }
 
     return stringArray.substring(1);
   }
 
-  clearCampaignsSelection() {
+  restoreFilters() {
+    this.period = this.periodInitial;
+    this.sectors = this.sectorsInitial;
+    this.categories = this.categoriesInitial;
     this.selectCampaigns([]);
-    delete this.campaignsQParams;
+    this.convertFiltersToQueryParams();
   }
 
   filtersChange() {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -94,6 +94,12 @@ th.mat-header-cell, td.mat-cell, td.mat-footer-cell {
     }
 }
 
+.mat-select-panel {
+  &::-webkit-scrollbar {
+    width: 6px !important;
+  }
+}
+
 .mat-select-disabled .mat-select-trigger {
   background-color: rgba(0,0,0,.02) !important;
 }


### PR DESCRIPTION
# Problem Description
- In order to improve UX is necessary add a 'select all / deselect all" option in all used filters 

# Features
- Declare initial values in filters and add restoreFilters method in filter-state service
- Assign initial values in filters from general-filters components
- Add selectAll options in general-filters component
- Update scrollbar styles for mat-selects

# Bug Fixes
- Replace clearCampaignSelection method by restoreFilters method

# Where this change will be used
- In general-filters-components component shown in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/119064504-1bab0c80-b9a1-11eb-8be8-e095e539cef2.png)
![image](https://user-images.githubusercontent.com/38545126/119064529-236ab100-b9a1-11eb-9d61-0d35db5cfd5d.png)