### PR TITLE
add select all and filter behaviour in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -15,10 +15,16 @@
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{countries.value ? countries.value[0]?.name : ''}}</span>
-                        <span *ngIf="countries.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{countries.value?.length === 2 ? 'otro' : 'otros'}}
-                            {{ countries.value?.length === 2 ? '' : countries.value.length - 1}})
+                        <span class="select-value">
+                            {{countries.value
+                            ? countries.value[0]?.name
+                            ? countries.value[0]?.name
+                            : countries.value[1]?.name
+                            : ''}}
+                        </span>
+                        <span *ngIf="countriesCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{countriesCounter === 2 ? 'otro' : 'otros'}}
+                            {{ countriesCounter === 2 ? '' : countriesCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -56,10 +62,18 @@
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{retailers.value ? retailers.value[0]?.name : ''}}</span>
+                        <span class="select-value">
+                            {{
+                            retailers.value
+                            ? retailers.value[0]?.name
+                            ? retailers.value[0]?.name
+                            : retailers.value[1]?.name
+                            : ''
+                            }}
+                        </span>
                         <span *ngIf="retailers.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{retailers.value?.length === 2 ? 'otro' : 'otros'}}
-                            {{ retailers.value?.length === 2 ? '' : retailers.value.length - 1}})
+                            (+ {{retailersCounter === 2 ? 'otro' : 'otros'}}
+                            {{ retailersCounter === 2 ? '' : retailersCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -110,15 +124,22 @@
             <mat-select formControlName="sectors" multiple placeholder="Selecciona un Sector">
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{sectors.value ? sectors.value[0]?.name : ''}}</span>
+                        <span class="select-value">
+                            {{
+                            sectors.value
+                            ? sectors.value[0]?.name
+                            ? sectors.value[0]?.name
+                            : sectors.value[1]?.name
+                            : ''
+                            }}
+                        </span>
                         <span *ngIf="sectors.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{sectors.value?.length === 2 ? 'otro' : 'otros'}}
-                            {{ sectors.value?.length === 2 ? '' : sectors.value.length - 1}})
+                            (+ {{sectorsCounter ? 'otro' : 'otros'}}
+                            {{ sectorsCounter === 2 ? '' : sectorsCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedSectors
-                    (click)="toggleAllSelection('allSelectedSectors','sectors', 'sectorList')" [value]="0"
+                <mat-option #allSelectedSectors (click)="toggleAllSelection('sectors','sector')" [value]="0"
                     class="font-weight-bold">
                     Todos
                 </mat-option>
@@ -141,15 +162,22 @@
             <mat-select formControlName="categories" multiple placeholder="Selecciona una Categoría">
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{categories.value ? categories.value[0]?.name : ''}}</span>
+                        <span class="select-value">
+                            {{
+                            categories.value
+                            ? categories.value[0]?.name
+                            ? categories.value[0]?.name
+                            : categories.value[1]?.name
+                            : ''
+                            }}
+                        </span>
                         <span *ngIf="categories.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{categories.value?.length === 2 ? 'otra' : 'otras'}}
-                            {{ categories.value?.length === 2 ? '' : categories.value.length - 1}})
+                            (+ {{categoriesCounter === 2 ? 'otra' : 'otras'}}
+                            {{ categoriesCounter === 2 ? '' : categoriesCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedCategories
-                    (click)="toggleAllSelection('allSelectedCategories','categories', 'categoryList')" [value]="0"
+                <mat-option #allSelectedCategories (click)="toggleAllSelection('categories', 'category')" [value]="0"
                     class="font-weight-bold">
                     Todas
                 </mat-option>
@@ -182,14 +210,21 @@
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{campaigns.value ? campaigns.value[0]?.name : ''}}</span>
+                        <span class="select-value">
+                            {{
+                            campaigns.value
+                            ? campaigns.value[0]?.name
+                            ? campaigns.value[0]?.name
+                            : campaigns.value[1]?.name
+                            : ''
+                            }}
+                        </span>
                         <span *ngIf="campaigns.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{campaigns.value?.length === 2 ? 'otra' : 'otras'}}
-                            {{ campaigns.value?.length === 2 ? '' : campaigns.value.length - 1}})
+                            (+ {{campaignsCounter === 2 ? 'otra' : 'otras'}}
+                            {{ campaignsCounter === 2 ? '' : campaignsCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
-                <!-- (click)="toggleAllSelection('allSelectedCampaigns','campaigns', 'campaignList')" -->
                 <mat-option #allSelectedCampaigns (click)="toggleAllSelection('campaigns', 'campaign')" [value]="0"
                     class="font-weight-bold">
                     Todas
@@ -216,15 +251,22 @@
             <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente">
                 <mat-select-trigger>
                     <div class="select-value-container">
-                        <span class="select-value">{{sources.value ? sources.value[0]?.name : ''}}</span>
+                        <span class="select-value">
+                            {{
+                            sources.value
+                            ? sources.value[0]?.name
+                            ? sources.value[0]?.name
+                            : sources.value[1]?.name
+                            : ''
+                            }}
+                        </span>
                         <span *ngIf="sources.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{sources.value?.length === 2 ? 'otro' : 'otros'}}
-                            {{ sources.value?.length === 2 ? '' : sources.value.length - 1}})
+                            (+ {{sourcesCounter === 2 ? 'otra' : 'otras'}}
+                            {{ sourcesCounter === 2 ? '' : sourcesCounter - 1}})
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedSources
-                    (click)="toggleAllSelection('allSelectedSources','sources', 'sourceList')" [value]="0"
+                <mat-option #allSelectedSources (click)="toggleAllSelection('sources', 'source')" [value]="0"
                     class="font-weight-bold">
                     Todas
                 </mat-option>
@@ -240,7 +282,10 @@
 <div class="row">
     <div class="col-12 text-right">
         <button type="button" class="btn btn-primary" [disabled]="
-        (!startDate.valid && startDate.touched) || 
+        (isLatamSelected && this.countries?.value?.length < 1) ||
+        (isLatamSelected && this.retailers?.value?.length < 1) ||
+        (isLatamSelected && this.sources?.value?.length < 1) ||
+        (!startDate.valid && startDate.touched) ||
         (!endDate.valid && endDate.touched) ||
         (sectors?.value?.length < 1 && sectors.touched) ||
         (categories?.value?.length < 1 && categories.touched)

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -63,15 +63,17 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedRetailers
-                    (click)="toggleAllSelection('allSelectedRetailers','retailers', 'retailerList')" [value]="0"
+                <mat-option #allSelectedRetailers (click)="toggleAllSelection('retailers', 'retailer')" [value]="0"
                     class="font-weight-bold">
                     Todos
                 </mat-option>
-                <mat-option *ngFor="let retailer of retailerList" [value]="retailer"
-                    (click)="tosslePerOne('allSelectedRetailers', 'retailers', 'retailerList')">
-                    {{retailer.name}}
-                </mat-option>
+                <ng-container *ngFor="let retailer of retailerList">
+                    <mat-option [hidden]="retailer.hidden" [value]="retailer"
+                        (click)="tosslePerOne('allSelectedRetailers', 'retailers', 'retailerList')">
+                        {{retailer.name}}
+                    </mat-option>
+                </ng-container>
+
             </mat-select>
             <small class="text-danger" *ngIf="retailers?.value?.length < 1 && retailers.touched">
                 Selecciona al menos un Retailer

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -10,7 +10,7 @@
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
                     <input class="form-control" [(ngModel)]="countryFilter" matInput type="text"
-                        (keyup)="filterFromList('country', $event.target.value)" placeholder="Buscar País"
+                        (keyup)="filterFromList('countries', 'country', $event.target.value)" placeholder="Buscar País"
                         [ngModelOptions]="{standalone: true}">
                 </div>
                 <mat-select-trigger>
@@ -22,15 +22,17 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedCountries
-                    (click)="toggleAllSelection('allSelectedCountries','countries', 'countryList')" [value]="0"
-                    class="font-weight-bold">
+                <mat-option #allSelectedCountries [value]="0" class="font-weight-bold"
+                    (click)="toggleAllSelection('countries', 'country')">
                     Todos
                 </mat-option>
-                <mat-option *ngFor="let country of countryList" [value]="country"
-                    (click)="tosslePerOne('allSelectedCountries', 'countries', 'countryList')">
-                    {{country.name}}
-                </mat-option>
+                <ng-container *ngFor="let country of countryList">
+                    <mat-option [hidden]="country.hidden" [value]="country"
+                        (click)="tosslePerOne('allSelectedCountries', 'countries', 'countryList')">
+                        {{country.name}}
+                    </mat-option>
+                </ng-container>
+
             </mat-select>
             <small class="text-danger" *ngIf="countries?.value?.length < 1 && countries.touched">
                 Selecciona al menos un País
@@ -49,8 +51,8 @@
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
                     <input class="form-control" [(ngModel)]="retailerFilter" matInput type="text"
-                        (keyup)="filterFromList('retailer', $event.target.value)" placeholder="Buscar Retailer"
-                        [ngModelOptions]="{standalone: true}">
+                        (keyup)="filterFromList('retailers', 'retailer', $event.target.value)"
+                        placeholder="Buscar Retailer" [ngModelOptions]="{standalone: true}">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -173,8 +175,8 @@
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
                     <input class="form-control" [(ngModel)]="campaignFilter" matInput type="text"
-                        (keyup)="filterFromList('campaign', $event.target.value)" placeholder="Buscar Campaña"
-                        [ngModelOptions]="{standalone: true}">
+                        (keyup)="filterFromList('campaigns', 'campaign', $event.target.value)"
+                        placeholder="Buscar Campaña" [ngModelOptions]="{standalone: true}">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -185,15 +187,18 @@
                         </span>
                     </div>
                 </mat-select-trigger>
-                <mat-option #allSelectedCampaigns
-                    (click)="toggleAllSelection('allSelectedCampaigns','campaigns', 'campaignList')" [value]="0"
+                <!-- (click)="toggleAllSelection('allSelectedCampaigns','campaigns', 'campaignList')" -->
+                <mat-option #allSelectedCampaigns (click)="toggleAllSelection('campaigns', 'campaign')" [value]="0"
                     class="font-weight-bold">
                     Todas
                 </mat-option>
-                <mat-option *ngFor="let campaign of campaignList" [value]="campaign"
-                    (click)="tosslePerOne('allSelectedCampaigns', 'campaigns', 'campaignList')">
-                    {{campaign.name}}
-                </mat-option>
+                <ng-container *ngFor="let campaign of campaignList">
+                    <mat-option [hidden]="campaign.hidden" [value]="campaign"
+                        (click)="tosslePerOne('allSelectedCampaigns', 'campaigns', 'campaignList')">
+                        {{campaign.name}}
+                    </mat-option>
+                </ng-container>
+
             </mat-select>
             <small class="text-muted mt-1" *ngIf="campaignList?.length < 1 && campaignsReqStatus === 2">
                 No existen campañas para el Periodo, Sectores y Categorías seleccionados

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -101,6 +101,13 @@ export class GeneralFiltersComponent implements OnInit {
   categoriesErrorMsg: string;
   campaignsErrorMsg: string;
 
+  countriesCounter: number;
+  retailersCounter: number;
+  sectorsCounter: number;
+  categoriesCounter: number;
+  campaignsCounter: number = 0;
+  sourcesCounter: number = this.sourceList.length;
+
   @ViewChild('allSelectedCountries') private allSelectedCountries: MatOption;
   @ViewChild('allSelectedRetailers') private allSelectedRetailers: MatOption;
   @ViewChild('allSelectedSectors') private allSelectedSectors: MatOption;
@@ -175,6 +182,13 @@ export class GeneralFiltersComponent implements OnInit {
     this.countryFilter && delete this.countryFilter;
     this.retailerFilter && delete this.retailerFilter;
     this.campaignFilter && delete this.campaignFilter;
+
+    this.countriesCounter = this.filtersStateService.countriesInitial?.length;
+    this.retailersCounter = this.filtersStateService.retailersInitial?.length;
+    this.sectorsCounter = this.filtersStateService.sectorsInitial?.length;
+    this.categoriesCounter = this.filtersStateService.categoriesInitial?.length;
+    this.campaignsCounter = 0;
+    this.sourcesCounter = this.sourceList.length;
   }
 
   loadForm() {
@@ -258,6 +272,8 @@ export class GeneralFiltersComponent implements OnInit {
       .then((res: any[]) => {
         this.countryList = res;
         this.filteredCountryList = res;
+        this.countriesCounter = res.length;
+        this.filtersStateService.countriesInitial = res;
 
         this.countries.patchValue([...this.countryList.map(item => item), 0]);
         this.prevCountries = this.countries.value;
@@ -282,6 +298,8 @@ export class GeneralFiltersComponent implements OnInit {
 
         this.retailerList = retailers;
         this.filteredRetailerList = retailers;
+        this.retailersCounter = retailers.length;
+        this.filtersStateService.retailersInitial = res;
 
         this.retailers.patchValue([...this.retailerList.map(item => item), 0]);
         this.prevRetailers = this.retailers.value;
@@ -299,10 +317,11 @@ export class GeneralFiltersComponent implements OnInit {
       .toPromise()
       .then((res: any[]) => {
         this.sectorList = res;
+        this.sectorsCounter = res.length;
+        this.filtersStateService.sectorsInitial = res;
 
         this.sectors.patchValue([...this.sectorList.map(item => item), 0]);
         this.prevSectors = this.sectors.value;
-        this.filtersStateService.sectorsInitial = this.sectors.value;
 
         this.sectorsErrorMsg && delete this.sectorsErrorMsg;
       })
@@ -317,10 +336,11 @@ export class GeneralFiltersComponent implements OnInit {
       .toPromise()
       .then((res: any[]) => {
         this.categoryList = res;
+        this.categoriesCounter = res.length;
+        this.filtersStateService.categoriesInitial = res;
 
         this.categories.patchValue([...this.categoryList.map(item => item), 0]);
         this.prevCategories = this.categories.value;
-        this.filtersStateService.categoriesInitial = this.categories.value;
 
         this.categoriesErrorMsg && delete this.categoriesErrorMsg;
       })
@@ -376,7 +396,7 @@ export class GeneralFiltersComponent implements OnInit {
 
   /**
   * filterFromList
-  * Generic function to be used for sarch filter when all options in filters are selected by default
+  * Generic function to be used for sarch filter
   * @param controlRef // associated form control name
   * @param listRef // associated elementList name
   * @param value // filtered value
@@ -440,11 +460,11 @@ export class GeneralFiltersComponent implements OnInit {
     const filteredArrayRef = `filtered${listRefPascalCase}List`;
     const matOptionRef = `allSelected${controlRefPascalCase}`;
 
-
     const allSelected = this[matOptionRef].selected;
     const shownElements = this[arrayReference].filter(item => !item.hidden);
 
-    this[controlRef].patchValue(this[filteredArrayRef].filter(item => {
+    const initialArrayRef = this[filteredArrayRef] ? filteredArrayRef : arrayReference;
+    this[controlRef].patchValue(this[initialArrayRef].filter(item => {
       const isSelectedElement = this[controlRef].value.includes(item);
       const isShownElement = shownElements.includes(item);
 
@@ -468,9 +488,12 @@ export class GeneralFiltersComponent implements OnInit {
     }));
 
     this.allAreItemsSelected(controlRef, arrayReference, matOptionRef);
+    this.updateSelectionCounter(controlRef);
   }
 
   tosslePerOne(matOptionRef: string, controlRef: string, listRef: string) {
+    this.updateSelectionCounter(controlRef);
+
     if (this[matOptionRef].selected) {
       this[matOptionRef].deselect();
       return false;
@@ -481,10 +504,14 @@ export class GeneralFiltersComponent implements OnInit {
     }
   }
 
+  updateSelectionCounter(controlRef: string) {
+    const counterRef = `${controlRef}Counter`;
+
+    const selectionCounter = this[controlRef].value.filter(item => item.id);
+    this[counterRef] = selectionCounter.length;
+  }
+
   applyFilters() {
-    console.log('countries.value', this.countries.value)
-    console.log('retailers.value', this.retailers.value)
-    console.log('campaigns.value', this.campaigns.value)
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value);
     this.filtersStateService.selectCategories(this.categories.value);

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -7,6 +7,20 @@ import * as moment from 'moment';
 })
 export class FiltersStateService {
 
+  // selected countries
+  private countriesSource = new Subject<any[]>();
+  countries$ = this.countriesSource.asObservable();
+  countries: any[];
+  countriesInitial: any[];
+  countriesQParams;
+
+  // selected retailers
+  private retailersSource = new Subject<any[]>();
+  retailers$ = this.retailersSource.asObservable();
+  retailers: any[];
+  retailersInitial: any[];
+  retailersQParams;
+
   // selected period
   private periodSource = new Subject<Period>();
   period$ = this.periodSource.asObservable();
@@ -40,6 +54,16 @@ export class FiltersStateService {
   filtersChange$ = this.filtersSource.asObservable();
 
   constructor() { }
+
+  selectCountries(countries: any[]) {
+    this.countriesSource.next(countries);
+    this.countries = countries;
+  }
+
+  selectRetailers(retailers: any[]) {
+    this.retailersSource.next(retailers);
+    this.retailers = retailers;
+  }
 
   selectPeriod(period: Period) {
     this.periodSource.next(period);
@@ -78,6 +102,8 @@ export class FiltersStateService {
   }
 
   restoreFilters() {
+    this.countries = this.countriesInitial;
+    this.retailers = this.retailersInitial;
     this.period = this.periodInitial;
     this.sectors = this.sectorsInitial;
     this.categories = this.categoriesInitial;


### PR DESCRIPTION
# Problem Description
- When search is made in a filter and "select all" option is selected and deselected the selection must be only for filtered elements and for the rest of elements is necessary preserve the previous selection
- Is necessary add this functionality for all filters (included countries and retailers filters)

# Features
- Update filter and all selection behaviour in general-filters component
- Add functionality to retailer filter in general-filter component
- Add coountries and retailers in filter-state service
- Use counters variables select triggers from general-filters component

# Where this change will be used
- Where general-filters component will be used in dashboard module at `/dashboard/*` path

# More details
- Filter and deselect some elements
![image](https://user-images.githubusercontent.com/38545126/119209984-888cd800-ba6f-11eb-8022-b73c4cd5a88c.png)


- After deselect some elements and clear search 
![image](https://user-images.githubusercontent.com/38545126/119210002-a0fcf280-ba6f-11eb-883c-0a22e104780a.png)
![image](https://user-images.githubusercontent.com/38545126/119210014-af4b0e80-ba6f-11eb-98b8-c217fd0dab31.png)
