### PR TITLE
add unique selection functionality to filters in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -35,7 +35,13 @@
                 <ng-container *ngFor="let country of countryList">
                     <mat-option [hidden]="country.hidden" [value]="country"
                         (click)="tosslePerOne('allSelectedCountries', 'countries', 'countryList')">
-                        {{country.name}}
+                        <div class="mat-option-container">
+                            <span>{{country.name}}</span>
+                            <button type="button" class="btn btn-sm btn-secondary"
+                                (click)="uniqueSelection('countries', 'country', country)">
+                                Only
+                            </button>
+                        </div>
                     </mat-option>
                 </ng-container>
 
@@ -84,7 +90,13 @@
                 <ng-container *ngFor="let retailer of retailerList">
                     <mat-option [hidden]="retailer.hidden" [value]="retailer"
                         (click)="tosslePerOne('allSelectedRetailers', 'retailers', 'retailerList')">
-                        {{retailer.name}}
+                        <div class="mat-option-container">
+                            <span>{{retailer.name}}</span>
+                            <button type="button" class="btn btn-sm btn-secondary"
+                                (click)="uniqueSelection('retailers', 'retailer', retailer)">
+                                Only
+                            </button>
+                        </div>
                     </mat-option>
                 </ng-container>
 
@@ -145,7 +157,13 @@
                 </mat-option>
                 <mat-option *ngFor="let sector of sectorList" [value]="sector"
                     (click)="tosslePerOne('allSelectedSectors', 'sectors', 'sectorList')">
-                    {{sector.name}}
+                    <div class="mat-option-container">
+                        <span>{{sector.name}}</span>
+                        <button type="button" class="btn btn-sm btn-secondary"
+                            (click)="uniqueSelection('sectors', 'sector', sector)">
+                            Only
+                        </button>
+                    </div>
                 </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
@@ -183,7 +201,13 @@
                 </mat-option>
                 <mat-option *ngFor="let category of categoryList" [value]="category"
                     (click)="tosslePerOne('allSelectedCategories', 'categories', 'categoryList')">
-                    {{category.name}}
+                    <div class="mat-option-container">
+                        <span>{{category.name}}</span>
+                        <button type="button" class="btn btn-sm btn-secondary"
+                            (click)="uniqueSelection('categories', 'category', category)">
+                            Only
+                        </button>
+                    </div>
                 </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
@@ -232,10 +256,15 @@
                 <ng-container *ngFor="let campaign of campaignList">
                     <mat-option [hidden]="campaign.hidden" [value]="campaign"
                         (click)="tosslePerOne('allSelectedCampaigns', 'campaigns', 'campaignList')">
-                        {{campaign.name}}
+                        <div class="mat-option-container">
+                            <span>{{campaign.name}}</span>
+                            <button type="button" class="btn btn-sm btn-secondary"
+                                (click)="uniqueSelection('campaigns', 'campaign', campaign)">
+                                Only
+                            </button>
+                        </div>
                     </mat-option>
                 </ng-container>
-
             </mat-select>
             <small class="text-muted mt-1" *ngIf="campaignList?.length < 1 && campaignsReqStatus === 2">
                 No existen campañas para el Periodo, Sectores y Categorías seleccionados
@@ -272,7 +301,13 @@
                 </mat-option>
                 <mat-option *ngFor="let source of sourceList" [value]="source"
                     (click)="tosslePerOne('allSelectedSources', 'sources', 'sourceList')">
-                    {{source.name}}
+                    <div class="mat-option-container">
+                        <span>{{source.name}}</span>
+                        <button type="button" class="btn btn-sm btn-secondary"
+                            (click)="uniqueSelection('sources', 'source', source)">
+                            Only
+                        </button>
+                    </div>
                 </mat-option>
             </mat-select>
         </div>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
@@ -15,3 +15,20 @@
     line-height: 18px;
     display: inline-block;
 }
+
+.mat-option-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+   
+    span {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: calc(100% - 50px);
+    }
+
+    .btn-secondary {
+        box-shadow: 0 2px 2px rgb(50 50 93 / 5%), 0 1px 3px rgb(0 0 0 / 4%);
+    }
+}

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -46,11 +46,11 @@ export class GeneralFiltersComponent implements OnInit {
   categoryList: any[];
   campaignList: any[];
   sourceList: any[] = [
-    { id: 1, name: 'Google' },
-    { id: 2, name: 'Facebook' },
-    { id: 3, name: 'Programmatic' },
-    { id: 4, name: 'Institucional' },
-    { id: 5, name: 'Otro' }
+    { id: 'google', name: 'Google' },
+    { id: 'facebook', name: 'Facebook' },
+    { id: 'programmatic', name: 'Programmatic' },
+    { id: 'institucional', name: 'Institucional' },
+    { id: 'otros', name: 'Otros' }
   ];
 
   filteredCountryList: any[];
@@ -129,7 +129,6 @@ export class GeneralFiltersComponent implements OnInit {
 
     await this.getSectors();
     await this.getCategories();
-    this.applyFilters();
 
     const selectedCountry = this.appStateService.selectedCountry;
     const selectedRetailer = this.appStateService.selectedRetailer;
@@ -258,12 +257,20 @@ export class GeneralFiltersComponent implements OnInit {
       });
   }
 
-  loadLatamContent() {
+  async loadLatamContent() {
     this.isLatamSelected = this.router.url.includes('latam') ? true : false;
     if (this.isLatamSelected) {
-      this.getCountries();
-      this.getRetailers();
+
+      if (!this.filtersStateService.countriesInitial) {
+        await this.getCountries();
+      }
+
+      if (!this.filtersStateService.retailersInitial) {
+        await this.getRetailers();
+      }
     }
+
+    this.applyFilters();
   }
 
   getCountries() {
@@ -299,7 +306,7 @@ export class GeneralFiltersComponent implements OnInit {
         this.retailerList = retailers;
         this.filteredRetailerList = retailers;
         this.retailersCounter = retailers.length;
-        this.filtersStateService.retailersInitial = res;
+        this.filtersStateService.retailersInitial = retailers;
 
         this.retailers.patchValue([...this.retailerList.map(item => item), 0]);
         this.prevRetailers = this.retailers.value;
@@ -527,6 +534,12 @@ export class GeneralFiltersComponent implements OnInit {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value);
     this.filtersStateService.selectCategories(this.categories.value);
+
+    if (this.isLatamSelected) {
+      this.filtersStateService.selectCountries(this.countries.value);
+      this.filtersStateService.selectRetailers(this.retailers.value);
+      this.filtersStateService.selectSources(this.sources.value);
+    }
 
     const areAllCampsSelected = this.areAllCampaignsSelected();
     this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value);

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -504,6 +504,18 @@ export class GeneralFiltersComponent implements OnInit {
     }
   }
 
+  uniqueSelection(controlRef: string, listRef: string, value) {
+    const listRefPascalCase = `${listRef.charAt(0).toUpperCase()}${listRef.slice(1)}`;
+
+    const arrayReference = `${listRef}List`;
+    const filteredArrayRef = `filtered${listRefPascalCase}List`;
+
+    const initialArrayRef = this[filteredArrayRef] ? filteredArrayRef : arrayReference;
+    this[controlRef].patchValue(this[initialArrayRef].filter(item => {
+      item === value;
+    }));
+  }
+
   updateSelectionCounter(controlRef: string) {
     const counterRef = `${controlRef}Counter`;
 

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -49,6 +49,12 @@ export class FiltersStateService {
   campaignsInitial: any[];
   campaignsQParams;
 
+  // selected sources
+  private sourcesSource = new Subject<any[]>();
+  sources$ = this.sourcesSource.asObservable();
+  sources: any[];
+  sourcesQParams;
+
   // filtersChange
   private filtersSource = new Subject<any>();
   filtersChange$ = this.filtersSource.asObservable();
@@ -85,10 +91,18 @@ export class FiltersStateService {
     this.campaigns = campaigns;
   }
 
+  selectSources(sources: any[]) {
+    this.sourcesSource.next(sources);
+    this.sources = sources;
+  }
+
   convertFiltersToQueryParams() {
     this.periodQParams = { startDate: moment(this.period.startDate).format('YYYY-MM-DD'), endDate: moment(this.period.endDate).format('YYYY-MM-DD') }
     this.sectorsQParams = this.sectors && this.convertArrayToQueryParams(this.sectors, 'id');
     this.categoriesQParams = this.categories && this.convertArrayToQueryParams(this.categories, 'id');
+    this.countriesQParams = this.countries && this.convertArrayToQueryParams(this.countries, 'id');
+    this.retailersQParams = this.retailers && this.convertArrayToQueryParams(this.retailers, 'id');
+    this.sourcesQParams = this.retailers && this.convertArrayToQueryParams(this.sources, 'id');
     this.campaignsQParams = this.campaigns && this.convertArrayToQueryParams(this.campaigns, 'id');
   }
 


### PR DESCRIPTION
# Problem Description
- Is necessary add a button to unique selection for each option in filters in order to improve UX facilitating user selection 
- save LATAM filters selection using general-filters service 

# Features
- Add unique selection button in general-filters component
- Add styles to options in general-filters component
- Include latam filters selection using general-filters service
- Save latam filters selection from general-filters component

# Where this change will be used
- Where general-filters component will be used in dashboard module at `/dashboard/*` path

# More details
- View of unique selection button
![image](https://user-images.githubusercontent.com/38545126/119386965-e434ac80-bc8d-11eb-98f8-19ab616f4cc5.png)
![image](https://user-images.githubusercontent.com/38545126/119387004-ee56ab00-bc8d-11eb-9ea8-a8c59ced5043.png)

- Selection of countries, retailers and sources in LATAM endpoints requests
![image](https://user-images.githubusercontent.com/38545126/119387081-09c1b600-bc8e-11eb-87b6-ee462b194186.png)
