### PR TITLE
add functionality to users and sales chart in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -532,17 +532,17 @@ export class GeneralFiltersComponent implements OnInit {
 
   applyFilters() {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
-    this.filtersStateService.selectSectors(this.sectors.value);
-    this.filtersStateService.selectCategories(this.categories.value);
+    this.filtersStateService.selectSectors(this.sectors.value.filter(item => item.id));
+    this.filtersStateService.selectCategories(this.categories.value.filter(item => item.id));
 
     if (this.isLatamSelected) {
-      this.filtersStateService.selectCountries(this.countries.value);
-      this.filtersStateService.selectRetailers(this.retailers.value);
-      this.filtersStateService.selectSources(this.sources.value);
+      this.filtersStateService.selectCountries(this.countries.value.filter(item => item.id));
+      this.filtersStateService.selectRetailers(this.retailers.value.filter(item => item.id));
+      this.filtersStateService.selectSources(this.sources.value.filter(item => item.id));
     }
 
     const areAllCampsSelected = this.areAllCampaignsSelected();
-    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value);
+    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value.filter(item => item.id));
 
     this.filtersStateService.filtersChange();
   }

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 
 // **** Angular Material ****
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
@@ -100,7 +101,8 @@ import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loa
     MatTableModule,
     MatPaginatorModule,
     MatTooltipModule,
-    MatProgressSpinnerModule
+    MatProgressSpinnerModule,
+    NgbModule
   ],
   providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { floatLabel: 'never' } }]
 })

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -35,16 +35,6 @@
                             País</span>
                     </div>
                     <div class="card-body">
-                        <!-- <div class="chart-legend mt-0 mb-2">
-                            <div class="legend-container">
-                                <div class="legend-square on"></div>
-                                <div class="legend-label">Activas</div>
-                            </div>
-                            <div class="legend-container ml-3">
-                                <div class="legend-square off"></div>
-                                <div class="legend-label">Inactivas</div>
-                            </div>
-                        </div> -->
                         <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
                             categoryX="country" [categoryY]="selectedTab1 === 1 ? 'sector' : 'category'" height="250px"
                             [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
@@ -274,6 +264,21 @@
                                         </li>
                                     </ul>
                                 </div>
+                            </div>
+                        </div>
+
+                        <div class="period-popover" ngbDropdown>
+                            <a ngbDropdownToggle>
+                                <i class="fas fa-question-circle"></i>
+                            </a>
+                            <div class="content" ngbDropdownMenu>
+                                <li class="period text-sm" *ngFor="let serie of usersAndSalesBySector; let i = index">
+                                    <div class="line mr-2"
+                                        [ngClass]="{'first': i === 0, 'second': i === 1, 'third': i === 2}">
+                                    </div>
+                                    <strong class="mr-2">{{ serie.name }}</strong>
+                                    <span>{{ serie.period }}</span>
+                                </li>
                             </div>
                         </div>
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -146,11 +146,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
-                                (click)="getDataByUsersAndSales('users', 1)">Usuarios</a>
+                                (click)="getDataByUsersAndSales('users')">Usuarios</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
-                                (click)="getDataByUsersAndSales('sales', 2)">Ventas</a>
+                                (click)="getDataByUsersAndSales('sales')">Ventas</a>
                         </li>
                     </ul>
                 </div>
@@ -170,97 +170,61 @@
                         <div class="row">
                             <div class="col-12 mb-4">
                                 <ul class="nav nav-tabs">
-                                    <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 1}"
-                                            (click)="selectedTab4 = 1; selectedTab5 = 1">
-                                            <span>Sector</span>
-                                        </a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 2}"
-                                            (click)="selectedTab4 = 2; selectedTab5 = 1">
-                                            <span>Categoría</span>
-                                        </a>
-                                    </li>
-                                    <li class="nav-item">
-                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === 3}"
-                                            (click)="selectedTab4 = 3; selectedTab5 = 1">
-                                            <span>Medio</span>
+                                    <li class="nav-item" *ngFor="let metric of usersAndSalesMetrics; let i = index">
+                                        <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === i + 1}"
+                                            (click)="selectedTab4 = i + 1; selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">
+                                            <span>{{ metric | titlecase }}</span>
                                         </a>
                                     </li>
                                 </ul>
                             </div>
-                            <div class="col-12 mb-4">
-                                <div class="pills-container">
+                            <div class="col-12 mb-2">
+                                <div [ngClass]="{'pills-container' : selectedTab4 !== 3}">
                                     <!-- sector -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 1">
-                                        <li class="nav-item">
+                                    <ul class="nav nav-pills nav-fill"
+                                        *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
+                                        <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
                                         </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
-                                                (click)="selectedTab5 = 2">Search</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
-                                                (click)="selectedTab5 = 3">Marketing</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
-                                                (click)="selectedTab5 = 4">Ventas</a>
+                                        <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
+                                            <a class="nav-link p-2"
+                                                [ngClass]="{'active': sector.id + 2 === selectedTab5}"
+                                                (click)="selectedTab5 = sector.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', sector.id)">
+                                                {{ sector.name}}
+                                            </a>
                                         </li>
                                     </ul>
 
                                     <!-- categoria -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 2">
-                                        <li class="nav-item">
+                                    <ul class="nav nav-pills nav-fill"
+                                        *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
+                                        <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
                                         </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
-                                                (click)="selectedTab5 = 2">PS</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
-                                                (click)="selectedTab5 = 3">HW Print</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
-                                                (click)="selectedTab5 = 4">Supplies</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 5}"
-                                                (click)="selectedTab5 = 5">Accesorios</a>
+                                        <li class="nav-item mb-2" *ngFor="let category of selectedCategories">
+                                            <a class="nav-link p-2"
+                                                [ngClass]="{'active': category.id + 2 === selectedTab5}"
+                                                (click)="selectedTab5 = category.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, category.id)">
+                                                {{ category.name}}
+                                            </a>
                                         </li>
                                     </ul>
 
                                     <!-- medio -->
-                                    <ul class="nav nav-pills nav-fill" *ngIf="selectedTab4 === 3">
-                                        <li class="nav-item">
+                                    <ul class="nav nav-pills nav-fill"
+                                        *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
+                                        <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
                                         </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 2}"
-                                                (click)="selectedTab5 = 2">Google</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 3}"
-                                                (click)="selectedTab5 = 3">Facebook</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 4}"
-                                                (click)="selectedTab5 = 4">Programmatic</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 5}"
-                                                (click)="selectedTab5 = 5">Institucional</a>
-                                        </li>
-                                        <li class="nav-item">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 6}"
-                                                (click)="selectedTab5 = 6">Otro</a>
+                                        <li class="nav-item mb-2" *ngFor="let source of selectedSources">
+                                            <a class="nav-link p-2"
+                                                [ngClass]="{'active': source.id + 2 === selectedTab5}"
+                                                (click)="selectedTab5 = source.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, null, source.id)">
+                                                {{ source.name}}
+                                            </a>
                                         </li>
                                     </ul>
                                 </div>
@@ -272,7 +236,7 @@
                                 <i class="fas fa-question-circle"></i>
                             </a>
                             <div class="content" ngbDropdownMenu>
-                                <li class="period text-sm" *ngFor="let serie of usersAndSalesBySector; let i = index">
+                                <li class="period text-sm" *ngFor="let serie of usersAndSalesByMetric; let i = index">
                                     <div class="line mr-2"
                                         [ngClass]="{'first': i === 0, 'second': i === 1, 'third': i === 2}">
                                     </div>
@@ -282,7 +246,7 @@
                             </div>
                         </div>
 
-                        <app-chart-line-series [series]="usersAndSalesBySector"
+                        <app-chart-line-series [series]="usersAndSalesByMetric"
                             [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
                             [valueFormat]="selectedTab3 === 2 && 'USD'" name="latam-sales-users-by-sector"
                             [status]="usersAndSalesReqStatus">
@@ -313,8 +277,8 @@
                 <div class="pills-container mb-4">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item" *ngFor="let category of selectedCategories">
-                            <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab5}"
-                                (click)="selectedTab5 = category.id; getTopProducts(category.id)">
+                            <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab6}"
+                                (click)="selectedTab6 = category.id; getTopProducts(category.id)">
                                 {{ category.name}}
                             </a>
                         </li>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
@@ -129,3 +129,42 @@
     top: 0;
     z-index: 1;
 }
+
+.period-popover {
+    display: flex;
+    justify-content: flex-end;
+    padding-right: 11px;
+
+    i {
+        color: #c7c7c7;
+        cursor: pointer;
+        font-size: 18px;
+    }
+
+    .content {
+        padding: 12px;
+
+        .period {
+            align-items: center;
+            display: flex;
+            justify-content: space-between;
+           
+            .line {
+                width: 25px;
+                height: 2px;
+        
+                &.first {
+                    background-color: #67B6DC;
+                }
+        
+                &.second {
+                    background-color: #A367DC;
+                }
+        
+                &.third {
+                    background-color: #DC67CE;
+                }
+            }
+        }
+    }
+}

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
@@ -27,13 +27,13 @@
 .pills-container {
     width: 60%;
 
-    .nav-item .nav-link {
-        cursor: pointer;
-    }
-
     @media screen and (max-width: 820px) {
         width: 100%;
     }
+}
+
+.nav-item .nav-link {
+    cursor: pointer;
 }
 
 .card-body {

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -83,11 +83,11 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   categoriesBySector: any[] = [];
   trafficAndSales = {};
 
-  usersAndSalesBySector: any[] = [];
+  usersAndSalesMetrics: string[] = ['sector', 'categoría', 'medio'];
+  usersAndSalesByMetric: any[] = [];
   investmentVsRevenue: any[] = [];
 
   // top products
-  selectedCategories: any[] = [];
   topProductsColumns: string[] = ['rank', 'product', 'amount'];
   topProducts: any[] = [];
   topProductsSource = new MatTableDataSource<any>();
@@ -104,6 +104,11 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     { name: 'gender-and-age', reqStatus: 0 }
   ];
   topProductsReqStatus: number = 0;
+
+  // available tabs
+  selectedCategories: any[] = []; // for topProducts and usersAndSalesByMetric
+  selectedSectors: any[] = []; // for usersAndSalesByMetric
+  selectedSources: any[] = []; // for usersAndSalesByMetric
 
   filtersSub: Subscription;
   chartsInitLoad: boolean = true;
@@ -124,12 +129,15 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   getAllData() {
+    this.selectedSectors = this.filtersStateService.sectors;
+    this.selectedCategories = this.filtersStateService.categories;
+    this.selectedSources = this.filtersStateService.sources;
+
     this.getKpis();
     this.getSectorsAndCategories('sectors', 1);
     this.getDataByTrafficAndSales('sales', 2);
-    this.getDataByUsersAndSales('sales', 2);
+    this.getDataByUsersAndSales('sales');
     this.getInvestmentVsRevenue();
-    this.selectedCategories = this.filtersStateService.categories.filter(item => item.id);
     this.getTopProducts(this.selectedCategories[0].id);
 
     this.chartsInitLoad = true;
@@ -203,11 +211,13 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     }
   }
 
-  getDataByUsersAndSales(metricType: string, selectedTab: number) {
+  getDataByUsersAndSales(metricType: string, sectorID?: number, categoryID?: number, sourceID?: number) {
     this.usersAndSalesReqStatus = 1;
-    this.overviewService.getUsersAndSalesLatam(metricType).subscribe(
+
+    this.overviewService.getUsersAndSalesLatam(metricType, sectorID, categoryID, sourceID).subscribe(
       (resp: any[]) => {
-        this.usersAndSalesBySector = resp;
+        this.usersAndSalesByMetric = resp;
+        console.log('usersAndSalesByMetric', this.usersAndSalesByMetric)
         this.usersAndSalesReqStatus = 2;
       },
       error => {
@@ -216,8 +226,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         this.usersAndSalesReqStatus = 3;
       }
     )
-
-    this.selectedTab3 = selectedTab;
+    this.selectedTab3 = metricType === 'users' ? 1 : 2;
   }
 
   getInvestmentVsRevenue() {

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -43,10 +43,10 @@ export class OverviewService {
     });
   }
 
-  concatedQueryParams(isLatam?: boolean, uniqueCategoryID?: number): string {
+  concatedQueryParams(isLatam?: boolean, uniqueSectorID?: number, uniqueCategoryID?: number, uniqueSourceID?: number): string {
     let startDate = this.filtersStateService.periodQParams.startDate;
     let endDate = this.filtersStateService.periodQParams.endDate;
-    let sectors = this.filtersStateService.sectorsQParams;
+    let sectors = !uniqueSectorID ? this.filtersStateService.sectorsQParams : uniqueSectorID;
     let categories = !uniqueCategoryID ? this.filtersStateService.categoriesQParams : uniqueCategoryID;
     let campaigns = this.filtersStateService.campaignsQParams;
 
@@ -56,7 +56,7 @@ export class OverviewService {
     } else {
       let countries = this.filtersStateService.countriesQParams;
       let retailers = this.filtersStateService.retailersQParams;
-      let sources = this.filtersStateService.sourcesQParams;
+      let sources = !uniqueSourceID ? this.filtersStateService.sourcesQParams : uniqueSourceID;
       return `countries=${countries}&retailers=${retailers}&sources=${sources}&${baseQParams}`;
     }
   }
@@ -189,12 +189,12 @@ export class OverviewService {
   }
 
   // *** users and sales ***
-  getUsersAndSalesLatam(metricType: string) {
+  getUsersAndSalesLatam(metricType: string, sectorID?: number, categoryID?: number, sourceID?: number) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
     }
 
-    let queryParams = this.concatedQueryParams(true);
+    let queryParams = this.concatedQueryParams(true, sectorID, categoryID, sourceID);
     return this.http.get(`${this.baseUrl}/latam/${metricType}?${queryParams}`);
   }
 
@@ -206,7 +206,7 @@ export class OverviewService {
 
   // *** top products ***
   getTopProductsLatam(categoryID: number) {
-    let queryParams = this.concatedQueryParams(true, categoryID);
+    let queryParams = this.concatedQueryParams(true, null, categoryID);
     return this.http.get(`${this.baseUrl}/latam/top-products?${queryParams}`);
   }
 }


### PR DESCRIPTION
# Problem Description
- Is necessary add functionality to users and sales chart in LATAM overview, this chart has multiple metric and sub metrics selection and for each of them is necessary to make a GET resquest with differents query params

# Features
- Add NgbModule to dashboard module imports
- Show ngbDropdown in chart-line-series (users and sales chart) in order to make the displayed periods clearer
- Update concatedQueryParams method in overview service
- Add functionality to users and sales chart depending on selected tabs and sub tabs

# Bug Fixes
- Save a clean data selection in general-filters component

# Where this change will be used
- Where general-filters component instances will be used in dashboard module at `/dashboard/*` path

# More details
- ngbDropdown view
![image](https://user-images.githubusercontent.com/38545126/119544361-3d1c4780-bd57-11eb-919f-c0496132d634.png)

- Default view 
![image](https://user-images.githubusercontent.com/38545126/119543809-b2d3e380-bd56-11eb-8a9c-e7bea659dd95.png)

- Default GET request
![image](https://user-images.githubusercontent.com/38545126/119543910-ca12d100-bd56-11eb-9739-cf52923e1559.png)

- View with with a specific sector selected
![image](https://user-images.githubusercontent.com/38545126/119544119-0a724f00-bd57-11eb-8fe8-251d559f4337.png)

- GET request with a specific sector selected
![image](https://user-images.githubusercontent.com/38545126/119544013-edd61700-bd56-11eb-92ff-68b78b770d65.png)
