### PR TITLE
show dynamic tabs depending on filters selection in overview components

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -14,18 +14,12 @@
     <div class="row mt-5">
         <div class="col-12" *ngIf="selectedType === 'country'">
             <div class="pills-container">
-                <ul class="nav nav-pills nav-fill">
-                    <li class="nav-item">
-                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="getCategoriesBySector('Search', 1)">Search</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="getCategoriesBySector('Marketing', 2)">Marketing</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                            (click)="getCategoriesBySector('Ventas', 3)">Ventas</a>
+                <ul class="nav nav-pills nav-fill" *ngIf="selectedSectors?.length > 1">
+                    <li class="nav-item mb-2" *ngFor="let sector of selectedSectors; let i = index">
+                        <a class="nav-link p-2" [ngClass]="{'active': sector.id === selectedTab1}"
+                            (click)="selectedTab1 = sector.id; getCategoriesBySector(sector.name, sector.id)">
+                            {{ sector.name }}
+                        </a>
                     </li>
                 </ul>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -78,6 +78,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     }
   ];
 
+  selectedSectors: any[] = [];
   categoriesBySector: any[] = [];
   trafficAndSales = {};
 
@@ -116,8 +117,10 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   }
 
   getAllData() {
+    this.selectedSectors = this.filtersStateService.sectors;
+
     this.getKpis();
-    this.getCategoriesBySector('Search', 1);
+    this.getCategoriesBySector('Search', this.selectedSectors[0]?.id);
     this.getDataByTrafficAndSales('traffic', 1);
     this.getDataByUsersAndSales('users', 1);
     this.getInvestmentVsRevenue();

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -288,7 +288,15 @@
             <div class="col-12">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">Top Productos</span>
+                        <span class="h4">Top Productos </span>
+                        <ng-container *ngIf="selectedCategories?.length > 1">
+                            <ng-container [ngSwitch]="selectedTab6">
+                                <span *ngSwitchCase="1" class="h4">- PS</span>
+                                <span *ngSwitchCase="2" class="h4">- HW Print</span>
+                                <span *ngSwitchCase="3" class="h4">- Supplies</span>
+                            </ng-container>
+                        </ng-container>
+
                     </div>
                     <div class="card-body">
                         <div class="adaptable-container" [ngClass]="{'auto': topProductsReqStatus === 3}">

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -217,7 +217,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     this.overviewService.getUsersAndSalesLatam(metricType, sectorID, categoryID, sourceID).subscribe(
       (resp: any[]) => {
         this.usersAndSalesByMetric = resp;
-        console.log('usersAndSalesByMetric', this.usersAndSalesByMetric)
         this.usersAndSalesReqStatus = 2;
       },
       error => {
@@ -260,6 +259,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       }
     )
 
+    this.selectedTab6 = categoryID;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
# Problem Description
- Both in LATAM overview (latam-overview component) and country/retailer overview (overview-wrapper) is necessary show dynamic tabs, depending on filters selection

# Features
- Show dynamic titles of top products list in overview-latam component
- Show dynamic tabs of chart-heatmap in overview-wrapper component

# Where this change will be used
- In overview components at `/dashboard/latam`, `/dashboard/countries` and `/dashboard/retailers` paths

# More details
- All options selected in sectors filter:
![image](https://user-images.githubusercontent.com/38545126/119555334-5c20d680-bd63-11eb-8216-2b288d3a8d26.png)

- All options shown in tabs on heatmap chart:
![image](https://user-images.githubusercontent.com/38545126/119555461-81ade000-bd63-11eb-9890-fb65a7f1e3c4.png)

- Some options selected in sectors filter:
![image](https://user-images.githubusercontent.com/38545126/119555630-b0c45180-bd63-11eb-9be3-af97e87ba9ac.png)

- Some options shown in tabs on heatmap chart:
![image](https://user-images.githubusercontent.com/38545126/119555685-c0dc3100-bd63-11eb-8846-5877c12f7867.png)

- Only one option selected in sectors filter:
![image](https://user-images.githubusercontent.com/38545126/119555824-ea955800-bd63-11eb-8ea0-bfdd037e5472.png)

- Default view in heatmap chart (without tabs)
![image](https://user-images.githubusercontent.com/38545126/119555910-01d44580-bd64-11eb-83f8-664db61cbdcb.png)
