### PR TITLE
show unique selection button after hover event in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
@@ -25,10 +25,20 @@
         display: inline-block;
         overflow: hidden;
         text-overflow: ellipsis;
-        width: calc(100% - 50px);
+        width: 100%;
     }
 
     .btn-secondary {
         box-shadow: 0 2px 2px rgb(50 50 93 / 5%), 0 1px 3px rgb(0 0 0 / 4%);
+        display: none;
+    }
+
+    &:hover {
+        span {
+            width: calc(100% - 50px);
+        }
+        .btn-secondary {
+            display: block;
+        }
     }
 }


### PR DESCRIPTION
# Problem Description
- Is necessary update unique selection buttons in filter options in order to show them only when an option is hovered

# Features
- Hide by default unique selection buttons
- Show unique selection buttons after hover event in an option

# Where this change will be used
- Where general-filter will be used in dashboard module at `/dashboard/*`

# More details
![image](https://user-images.githubusercontent.com/38545126/119574263-1112bd80-bd7b-11eb-82f8-2ce53bee6fcf.png)
