### PR TITLE
show tooltip in campaign options of general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -36,7 +36,7 @@
                     <mat-option [hidden]="country.hidden" [value]="country"
                         (click)="tosslePerOne('allSelectedCountries', 'countries', 'countryList')">
                         <div class="mat-option-container">
-                            <span>{{country.name}}</span>
+                            <span>{{ country.name }}</span>
                             <button type="button" class="btn btn-sm btn-secondary"
                                 (click)="uniqueSelection('countries', 'country', country)">
                                 Only
@@ -92,7 +92,7 @@
                     <mat-option [hidden]="retailer.hidden" [value]="retailer"
                         (click)="tosslePerOne('allSelectedRetailers', 'retailers', 'retailerList')">
                         <div class="mat-option-container">
-                            <span>{{retailer.name}}</span>
+                            <span>{{ retailer.name }}</span>
                             <button type="button" class="btn btn-sm btn-secondary"
                                 (click)="uniqueSelection('retailers', 'retailer', retailer)">
                                 Only
@@ -159,7 +159,7 @@
                 <mat-option *ngFor="let sector of sectorList" [value]="sector"
                     (click)="tosslePerOne('allSelectedSectors', 'sectors', 'sectorList')">
                     <div class="mat-option-container">
-                        <span>{{sector.name}}</span>
+                        <span>{{ sector.name }}</span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('sectors', 'sector', sector)">
                             Only
@@ -204,7 +204,7 @@
                 <mat-option *ngFor="let category of categoryList" [value]="category"
                     (click)="tosslePerOne('allSelectedCategories', 'categories', 'categoryList')">
                     <div class="mat-option-container">
-                        <span>{{category.name}}</span>
+                        <span>{{ category.name }}</span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('categories', 'category', category)">
                             Only
@@ -258,7 +258,10 @@
                     <mat-option [hidden]="campaign.hidden" [value]="campaign"
                         (click)="tosslePerOne('allSelectedCampaigns', 'campaigns', 'campaignList')">
                         <div class="mat-option-container">
-                            <span>{{campaign.name}}</span>
+                            <span #tooltip="matTooltip" md-raised-button [matTooltip]="campaign.name"
+                                matTooltipPosition="below" matTooltipClass="custom-tooltip">
+                                {{ campaign.name }}
+                            </span>
                             <button type="button" class="btn btn-sm btn-secondary"
                                 (click)="uniqueSelection('campaigns', 'campaign', campaign)">
                                 Only
@@ -303,7 +306,7 @@
                 <mat-option *ngFor="let source of sourceList" [value]="source"
                     (click)="tosslePerOne('allSelectedSources', 'sources', 'sourceList')">
                     <div class="mat-option-container">
-                        <span>{{source.name}}</span>
+                        <span>{{ source.name }}</span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('sources', 'source', source)">
                             Only
@@ -318,14 +321,14 @@
 <div class="row">
     <div class="col-12 text-right">
         <button type="button" class="btn btn-primary" [disabled]="
-        (isLatamSelected && this.countries?.value?.length < 1) ||
-        (isLatamSelected && this.retailers?.value?.length < 1) ||
-        (isLatamSelected && this.sources?.value?.length < 1) ||
-        (!startDate.valid && startDate.touched) ||
-        (!endDate.valid && endDate.touched) ||
-        (sectors?.value?.length < 1 && sectors.touched) ||
-        (categories?.value?.length < 1 && categories.touched)
-        " (click)="applyFilters()">
+            (isLatamSelected && this.countries?.value?.length < 1) ||
+            (isLatamSelected && this.retailers?.value?.length < 1) ||
+            (isLatamSelected && this.sources?.value?.length < 1) ||
+            (!startDate.valid && startDate.touched) ||
+            (!endDate.valid && endDate.touched) ||
+            (sectors?.value?.length < 1 && sectors.touched) ||
+            (categories?.value?.length < 1 && categories.touched)
+            " (click)="applyFilters()">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.scss
@@ -20,7 +20,7 @@
     align-items: center;
     display: flex;
     justify-content: space-between;
-   
+    
     span {
         display: inline-block;
         overflow: hidden;
@@ -41,4 +41,11 @@
             display: block;
         }
     }
+}
+
+::ng-deep .custom-tooltip {
+    font-size: 12px !important;
+    margin-bottom: 0px !important;
+    margin-top: 0px !important;
+    max-width: unset !important;
 }


### PR DESCRIPTION
# Problem Description
- As campaign name in filter options can be a large text it's possible that the whole name may not be displayed in full inside filter options container, so is necessay show a tooltip with whole campaign name

# Features
- Show tooltip in campaign options of general-filters component
- Add custom styles to mat-tooltip in general-filters component

# Where this change will be used
- Where general-filters will be used in dashboard module at `/dashboard/*` path
