### PR TITLE
save default init page after login depending on user role and level properties

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -81,8 +81,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
     try {
       this.menuReqStatus = 1;
       if (this.userRole === 'admin' || this.userRole === 'hp' || this.userRole === 'country') {
+
         // load LATAM menu items
-        this.loadLatamSubmenu();
+        this.userService.viewLevel === 'latam' && this.loadLatamSubmenu();
+
         // load countries menu items
         await this.getAvailableCountries();
       } else if (this.userRole === 'retailer') {
@@ -122,20 +124,20 @@ export class SidebarComponent implements OnInit, OnDestroy {
       submenu: [
         {
           title: 'Programa COOP',
-          path: '/dashboard/coop',
-          paramName: 'country',
+          path: '/dashboard/main-region',
+          paramName: 'main-region',
           param: 'latam'
         },
         {
           title: 'Otras herramientas',
           path: '/dashboard/tools',
-          paramName: 'country',
+          paramName: 'main-region',
           param: 'latam'
         },
         {
           title: 'Análisis de sentimientos OmniChat',
           path: '/dashboard/omnichat',
-          paramName: 'country',
+          paramName: 'main-region',
           param: 'latam'
         }
       ],
@@ -147,6 +149,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
   async getPrevSelection() {
     const params = this.route.snapshot.queryParams;
 
+    const mainRegion = params['main-region'];
     const region = params['region'];
     const country = params['country'];
     const retailer = params['retailer'];
@@ -202,8 +205,8 @@ export class SidebarComponent implements OnInit, OnDestroy {
         this.selectedItemL2 = itemL2;
       }
 
-    } else if (country && country === 'latam') {
-      this.selectedItemL1 = this.menuItems.find(item => item.title.toLowerCase() === country);
+    } else if (mainRegion && mainRegion === 'latam') {
+      this.selectedItemL1 = this.menuItems.find(item => item.title.toLowerCase() === mainRegion);
       this.selectedItemL1.submenuOpen = true;
       this.selectedItemL2 = this.getSelectionUsingRoute(this.selectedItemL1);
       this.appStateService.selectCountry({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });

--- a/src/app/login.guard.ts
+++ b/src/app/login.guard.ts
@@ -20,7 +20,6 @@ export class LoginGuard implements CanActivate {
             return true;
         } else {
             // Store the attempted URL for redirecting
-            this.userService.redirectUrl = rss.url;
             this.router.navigate(['/login']);
         }
         return false;

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -261,13 +261,10 @@ export class GeneralFiltersComponent implements OnInit {
     this.isLatamSelected = this.router.url.includes('latam') ? true : false;
     if (this.isLatamSelected) {
 
-      if (!this.filtersStateService.countriesInitial) {
-        await this.getCountries();
-      }
-
-      if (!this.filtersStateService.retailersInitial) {
-        await this.getRetailers();
-      }
+      // There are countriesInitial and retailerInitial after login
+      // There aren't countriesInitial and retailerInitial after a page refresh
+      this.filtersStateService.countriesInitial ? this.loadCountriesData() : await this.getCountries();
+      this.filtersStateService.retailersInitial ? this.loadRetailersData() : await this.getRetailers();
     }
 
     this.applyFilters();
@@ -277,14 +274,7 @@ export class GeneralFiltersComponent implements OnInit {
     return this.usersMngmtService.getCountries()
       .toPromise()
       .then((res: any[]) => {
-        this.countryList = res;
-        this.filteredCountryList = res;
-        this.countriesCounter = res.length;
-        this.filtersStateService.countriesInitial = res;
-
-        this.countries.patchValue([...this.countryList.map(item => item), 0]);
-        this.prevCountries = this.countries.value;
-
+        this.loadCountriesData(res);
         this.countriesErrorMsg && delete this.countriesErrorMsg;
       })
       .catch((error) => {
@@ -303,20 +293,37 @@ export class GeneralFiltersComponent implements OnInit {
 
         retailers.sort((a, b) => a.name.localeCompare(b.name));
 
-        this.retailerList = retailers;
-        this.filteredRetailerList = retailers;
-        this.retailersCounter = retailers.length;
-        this.filtersStateService.retailersInitial = retailers;
-
-        this.retailers.patchValue([...this.retailerList.map(item => item), 0]);
-        this.prevRetailers = this.retailers.value;
-
+        this.loadRetailersData(retailers);
         this.retailersErrorMsg && delete this.retailersErrorMsg;
       })
       .catch((error) => {
         this.retailersErrorMsg = 'Error al consultar retailers';
         console.error(`[general-filers.component]: ${error}`);
       });
+  }
+
+  loadCountriesData(newCountries?: any[]) {
+    const countries = newCountries ? newCountries : this.filtersStateService.countriesInitial;
+    this.countryList = countries;
+    this.filteredCountryList = countries;
+    this.countriesCounter = countries.length;
+    this.filtersStateService.countriesInitial = countries;
+
+    this.countries.patchValue([...this.countryList.map(item => item), 0]);
+    this.prevCountries = this.countries.value;
+  }
+
+  loadRetailersData(newRetailers?: any[]) {
+    const retailers = newRetailers ? newRetailers : this.filtersStateService.retailersInitial;
+    retailers.sort((a, b) => a.name.localeCompare(b.name));
+
+    this.retailerList = retailers;
+    this.filteredRetailerList = retailers;
+    this.retailersCounter = retailers.length;
+    this.filtersStateService.retailersInitial = retailers;
+
+    this.retailers.patchValue([...this.retailerList.map(item => item), 0]);
+    this.prevRetailers = this.retailers.value;
   }
 
   getSectors() {

--- a/src/app/modules/dashboard/dashboard.routing.ts
+++ b/src/app/modules/dashboard/dashboard.routing.ts
@@ -13,5 +13,5 @@ export const DashboardRoutes: Routes = [
     { path: 'tools', component: OtherToolsComponent },
     { path: 'campaign-comparator', component: CampaignComparatorComponent },
     { path: 'omnichat', component: SentimentAnalysisComponent },
-    { path: 'coop', component: OverviewLatamComponent },
+    { path: 'main-region', component: OverviewLatamComponent },
 ];

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -97,12 +97,12 @@ export class FiltersStateService {
   }
 
   convertFiltersToQueryParams() {
-    this.periodQParams = { startDate: moment(this.period.startDate).format('YYYY-MM-DD'), endDate: moment(this.period.endDate).format('YYYY-MM-DD') }
+    this.periodQParams = { startDate: moment(this.period.startDate).format('YYYY-MM-DD'), endDate: moment(this.period.endDate).format('YYYY-MM-DD') };
     this.sectorsQParams = this.sectors && this.convertArrayToQueryParams(this.sectors, 'id');
     this.categoriesQParams = this.categories && this.convertArrayToQueryParams(this.categories, 'id');
     this.countriesQParams = this.countries && this.convertArrayToQueryParams(this.countries, 'id');
     this.retailersQParams = this.retailers && this.convertArrayToQueryParams(this.retailers, 'id');
-    this.sourcesQParams = this.retailers && this.convertArrayToQueryParams(this.sources, 'id');
+    this.sourcesQParams = this.sources && this.convertArrayToQueryParams(this.sources, 'id');
     this.campaignsQParams = this.campaigns && this.convertArrayToQueryParams(this.campaigns, 'id');
   }
 
@@ -125,6 +125,34 @@ export class FiltersStateService {
     this.convertFiltersToQueryParams();
   }
 
+  deleteFilters() {
+    if (this.countriesInitial) {
+      delete this.countriesInitial;
+      delete this.countries;
+    }
+
+    if (this.retailersInitial) {
+      delete this.retailersInitial;
+      delete this.retailers;
+    }
+
+    if (this.periodInitial) {
+      delete this.periodInitial;
+      delete this.period;
+    }
+
+    if (this.sectorsInitial) {
+      delete this.sectorsInitial;
+      delete this.sectors;
+    }
+
+    if (this.categoriesInitial) {
+      delete this.categoriesInitial;
+      delete this.categories;
+    }
+    this.selectCampaigns([]);
+  }
+
   filtersChange() {
     this.convertFiltersToQueryParams();
     this.filtersSource.next();
@@ -135,4 +163,3 @@ interface Period {
   startDate: Date,
   endDate: Date
 }
-


### PR DESCRIPTION
# Problem Description
- After successful login the first (and default page) that the user will be redirected is depending on role and level user properties
- For users with role _hp_ or _admin_ use LATAM overview page as default page
- For users with role _country_ but _latam_ level use LATAM overview page as default page
- For users with role _country_ and _retailer_ but _general_ level use the first country or retailer which they have access as default page

# Features
- Add **deleteFilters** method in filter-state service and use it after user logout
- Add **getDefaultRedirect** method to user service and use it after successful login request
- Update routes and query params used for LATAM pages
- Update general-filters component to avoid repeated requests after login

# Bug Fixes
- Update login guard to avoid to use an deleted variable in user service

# Where this change will be used
- When will be necessary redirect the user to the dashboard module 
