### PR TITLE
hide mock redirects options in sidebar and navbar components

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -19,15 +19,15 @@
           </div>
         </a>
         <div class="dropdown-menu-arrow dropdown-menu-right" ngbDropdownMenu>
-          <a routerLinkActive="active" class="dropdown-item">
+          <!-- <a routerLinkActive="active" class="dropdown-item">
             <i class="ni ni-single-02"></i>
             <span>Mi perfil</span>
           </a>
           <a routerLinkActive="active" class="dropdown-item">
             <i class="ni ni-support-16"></i>
             <span>Soporte</span>
-          </a>
-          <div class="dropdown-divider"></div>
+          </a> -->
+          <!-- <div class="dropdown-divider"></div> -->
           <a class="dropdown-item" (click)="logout()">
             <i class="ni ni-user-run"></i>
             <span>Cerrar sesión</span>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -21,15 +21,15 @@
           </div>
         </a>
         <div class="dropdown-menu-arrow dropdown-menu-right" ngbDropdownMenu>
-          <a routerLinkActive="active" class="dropdown-item">
+          <!-- <a routerLinkActive="active" class="dropdown-item">
             <i class="ni ni-single-02"></i>
             <span>Mi perfil</span>
           </a>
           <a routerLinkActive="active" class="dropdown-item">
             <i class="ni ni-support-16"></i>
             <span>Soporte</span>
-          </a>
-          <div class="dropdown-divider"></div>
+          </a> -->
+          <!-- <div class="dropdown-divider"></div> -->
           <a class="dropdown-item" (click)="logout()">
             <i class="ni ni-user-run"></i>
             <span>Cerrar sesión</span>

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -23,3 +23,8 @@ li {
         padding-bottom: 0.4rem;
     }
 }
+
+
+ul.nav {
+   z-index: 1030; 
+}


### PR DESCRIPTION
# Problem Description
- Is necessary hide mock redirects options in sidebar and navbar components, which was in original forked template

# Features
- Hide mock redirects options in sidebar and navbar components

# Where this change will be used
- In dashboard header (siderbar for mobile and navbar for desktop view)

# More details
![image](https://user-images.githubusercontent.com/38545126/119740827-315d7d80-be4a-11eb-876c-8beaad85e5a8.png)
