### PR TITLE
fix triggers content of filters in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -23,8 +23,8 @@
                             : ''}}
                         </span>
                         <span *ngIf="countriesCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{countriesCounter === 2 ? 'otro' : 'otros'}}
-                            {{ countriesCounter === 2 ? '' : countriesCounter - 1}})
+                            (+ {{countriesCounter === 2 ? 'otro' : 'otros' }}
+                            {{ countriesCounter === 2 ? '' : countriesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -78,9 +78,9 @@
                             : ''
                             }}
                         </span>
-                        <span *ngIf="retailers.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{retailersCounter === 2 ? 'otro' : 'otros'}}
-                            {{ retailersCounter === 2 ? '' : retailersCounter - 1}})
+                        <span *ngIf="retailersCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{ retailersCounter === 2 ? 'otro' : 'otros' }}
+                            {{ retailersCounter === 2 ? '' : retailersCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -146,9 +146,9 @@
                             : ''
                             }}
                         </span>
-                        <span *ngIf="sectors.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{sectorsCounter ? 'otro' : 'otros'}}
-                            {{ sectorsCounter === 2 ? '' : sectorsCounter - 1}})
+                        <span *ngIf="sectorsCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{ sectorsCounter === 2 ? 'otro' : 'otros' }}
+                            {{ sectorsCounter === 2 ? '' : sectorsCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -191,9 +191,9 @@
                             : ''
                             }}
                         </span>
-                        <span *ngIf="categories.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{categoriesCounter === 2 ? 'otra' : 'otras'}}
-                            {{ categoriesCounter === 2 ? '' : categoriesCounter - 1}})
+                        <span *ngIf="categoriesCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{ categoriesCounter === 2 ? 'otra' : 'otras' }}
+                            {{ categoriesCounter === 2 ? '' : categoriesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -244,9 +244,9 @@
                             : ''
                             }}
                         </span>
-                        <span *ngIf="campaigns.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{campaignsCounter === 2 ? 'otra' : 'otras'}}
-                            {{ campaignsCounter === 2 ? '' : campaignsCounter - 1}})
+                        <span *ngIf="campaignsCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{ campaignsCounter === 2 ? 'otra' : 'otras' }}
+                            {{ campaignsCounter === 2 ? '' : campaignsCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
@@ -293,9 +293,9 @@
                             : ''
                             }}
                         </span>
-                        <span *ngIf="sources.value?.length > 1" class="example-additional-selection ml-1">
-                            (+ {{sourcesCounter === 2 ? 'otra' : 'otras'}}
-                            {{ sourcesCounter === 2 ? '' : sourcesCounter - 1}})
+                        <span *ngIf="sourcesCounter > 1" class="example-additional-selection ml-1">
+                            (+ {{ sourcesCounter === 2 ? 'otra' : 'otras' }}
+                            {{ sourcesCounter === 2 ? '' : sourcesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>


### PR DESCRIPTION
# Problem Description
- Triggers in filters show a wrong selection complement as the following image shows:
![image](https://user-images.githubusercontent.com/38545126/119741593-a41b2880-be4b-11eb-8a9b-9b97c81f157a.png)

# Bug Fixes
- Fix triggers content of filters in general-filters component using counters variables as conditional to show complement selection

# Where this change will be used
- Where general-filters componens will be use in dashboard module at `/dashboard/*` path

# More details
- Content in filters triggers after change
![image](https://user-images.githubusercontent.com/38545126/119741759-f9efd080-be4b-11eb-89f1-d4457d15921d.png)
