### PR TITLE
add and use maintenance component for under development sections

### DIFF
--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { SharedModule } from '../shared/shared.module';
 
 // **** Angular Material ****
 import { MatNativeDateModule, MatRippleModule } from '@angular/material/core';
@@ -102,7 +103,8 @@ import { ChartLoaderComponent } from './components/charts/chart-loader/chart-loa
     MatPaginatorModule,
     MatTooltipModule,
     MatProgressSpinnerModule,
-    NgbModule
+    NgbModule,
+    SharedModule
   ],
   providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { floatLabel: 'never' } }]
 })

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
@@ -1,1 +1,3 @@
-<p class="h3">Comparador de campaña</p>
+<div class="main-container">
+    <app-maintenance></app-maintenance>
+</div>

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.scss
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.scss
@@ -1,0 +1,7 @@
+.main-container {
+    align-items: center;
+    display: flex;
+    height: calc(90vh - 64px);
+    justify-content: center;
+    width: 100%;
+}

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -17,7 +17,7 @@
         </li>
     </ul>
 
-    <ng-container *ngIf="activeTabView === 1">
+    <!-- <ng-container *ngIf="activeTabView === 1">
         <p class="text-muted">Indexado</p>
     </ng-container>
 
@@ -27,5 +27,7 @@
 
     <ng-container *ngIf="activeTabView === 3">
         <p class="text-muted">PC Selector</p>
-    </ng-container>
+    </ng-container> -->
+
+    <app-maintenance></app-maintenance>
 </div>

--- a/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.html
+++ b/src/app/modules/dashboard/pages/sentiment-analysis/sentiment-analysis.component.html
@@ -22,7 +22,7 @@
         </li>
     </ul>
 
-    <ng-container *ngIf="activeTabView === 1">
+    <!-- <ng-container *ngIf="activeTabView === 1">
         <p class="text-muted">General</p>
     </ng-container>
 
@@ -36,5 +36,7 @@
 
     <ng-container *ngIf="activeTabView === 4">
         <p class="text-muted">Supplies</p>
-    </ng-container>
+    </ng-container> -->
+
+    <app-maintenance></app-maintenance>
 </div>

--- a/src/app/modules/shared/components/maintenance/maintenance.component.html
+++ b/src/app/modules/shared/components/maintenance/maintenance.component.html
@@ -1,0 +1,37 @@
+<div class="container my-5">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="message-container">
+                <h1>
+                    En construcción
+                </h1>
+                <h3 class="text-muted">
+                    Sección temporalmente inactiva
+                </h3>
+            </div>
+        </div>
+        <div class="col-md-6 d-none d-md-block">
+            <svg class="svg-box" width="300px" height="350px" viewbox="0 0 300 350" version="1.1"
+                xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+                <g transform="scale(0.3)" id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"
+                    sketch:type="MSPage">
+                    <path d="M353,9 L626.664028,170 L626.664028,487 L353,642 L79.3359724,487 L79.3359724,170 L353,9 Z"
+                        id="Polygon-1" stroke="#3bafda" stroke-width="6" sketch:type="MSShapeGroup"></path>
+                    <path
+                        d="M78.5,529 L147,569.186414 L147,648.311216 L78.5,687 L10,648.311216 L10,569.186414 L78.5,529 Z"
+                        id="Polygon-2" stroke="#7266ba" stroke-width="6" sketch:type="MSShapeGroup"></path>
+                    <path
+                        d="M773,186 L827,217.538705 L827,279.636651 L773,310 L719,279.636651 L719,217.538705 L773,186 Z"
+                        id="Polygon-3" stroke="#f76397" stroke-width="6" sketch:type="MSShapeGroup"></path>
+                    <path
+                        d="M639,529 L773,607.846761 L773,763.091627 L639,839 L505,763.091627 L505,607.846761 L639,529 Z"
+                        id="Polygon-4" stroke="#00b19d" stroke-width="6" sketch:type="MSShapeGroup"></path>
+                    <path
+                        d="M281,801 L383,861.025276 L383,979.21169 L281,1037 L179,979.21169 L179,861.025276 L281,801 Z"
+                        id="Polygon-5" stroke="#ffaa00" stroke-width="6" sketch:type="MSShapeGroup"></path>
+                </g>
+            </svg>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/shared/components/maintenance/maintenance.component.scss
+++ b/src/app/modules/shared/components/maintenance/maintenance.component.scss
@@ -1,0 +1,8 @@
+.message-container {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: center;
+    width: 100%;
+}

--- a/src/app/modules/shared/components/maintenance/maintenance.component.spec.ts
+++ b/src/app/modules/shared/components/maintenance/maintenance.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MaintenanceComponent } from './maintenance.component';
+
+describe('MaintenanceComponent', () => {
+  let component: MaintenanceComponent;
+  let fixture: ComponentFixture<MaintenanceComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MaintenanceComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MaintenanceComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/shared/components/maintenance/maintenance.component.ts
+++ b/src/app/modules/shared/components/maintenance/maintenance.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-maintenance',
+  templateUrl: './maintenance.component.html',
+  styleUrls: ['./maintenance.component.scss']
+})
+export class MaintenanceComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/shared/shared.module.ts
+++ b/src/app/modules/shared/shared.module.ts
@@ -2,19 +2,22 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalComponent } from './components/modal/modal.component';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MaintenanceComponent } from './components/maintenance/maintenance.component';
 
 
 
 @NgModule({
   declarations: [
-    ModalComponent
+    ModalComponent,
+    MaintenanceComponent
   ],
   imports: [
     CommonModule,
     MatDialogModule
   ],
   exports: [
-    ModalComponent
+    ModalComponent,
+    MaintenanceComponent
   ]
 })
 export class SharedModule { }


### PR DESCRIPTION
# Problem Description
- Is necessary to use a generic message to let the user know that a section within the page is under construction

# Features
- Add maintenance component to shared module
- Use maintenance component in the following components:
   - other-tools
   - sentiment-analysis
   - campaign-comparator

# Where this change will be used
- Where the instances of this compoments will be used in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/119749641-1d6f4700-be5d-11eb-90c0-d48f5872e87d.png)
