### PR TITLE
fix emission of changes which generate repeated requests from general-filters component

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -118,7 +118,13 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     private overviewService: OverviewService) { }
 
   ngOnInit(): void {
-    if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+    if (this.filtersStateService.countries &&
+      this.filtersStateService.retailers &&
+      this.filtersStateService.period &&
+      this.filtersStateService.sectors &&
+      this.filtersStateService.categories &&
+      this.filtersStateService.sources) {
+
       this.filtersStateService.restoreFilters();
       this.getAllData();
     }


### PR DESCRIPTION
# Problem Description
- Requests made in overview-wrapper are duplicated after retailer change (ej. move from one retailer from another retailer)

# Bug Fixes
- Update loadLatamContent method in general-filters component to call applyFilters after more specific conditions
- Update ngOnInit method in overview-latam component to avoid make requests if there aren't selections on filters 

# Where this change will be used
- Where there's a new selection of country, retailer or main region (latam) from sidebar 