### PR TITLE
avoid event propagation in inputs of general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -11,7 +11,7 @@
                     </div>
                     <input class="form-control" [(ngModel)]="countryFilter" matInput type="text"
                         (keyup)="filterFromList('countries', 'country', $event.target.value)" placeholder="Buscar País"
-                        [ngModelOptions]="{standalone: true}">
+                        [ngModelOptions]="{standalone: true}" (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -65,7 +65,8 @@
                     </div>
                     <input class="form-control" [(ngModel)]="retailerFilter" matInput type="text"
                         (keyup)="filterFromList('retailers', 'retailer', $event.target.value)"
-                        placeholder="Buscar Retailer" [ngModelOptions]="{standalone: true}">
+                        placeholder="Buscar Retailer" [ngModelOptions]="{standalone: true}"
+                        (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -231,7 +232,8 @@
                     </div>
                     <input class="form-control" [(ngModel)]="campaignFilter" matInput type="text"
                         (keyup)="filterFromList('campaigns', 'campaign', $event.target.value)"
-                        placeholder="Buscar Campaña" [ngModelOptions]="{standalone: true}">
+                        placeholder="Buscar Campaña" [ngModelOptions]="{standalone: true}"
+                        (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">


### PR DESCRIPTION
# Problem Description
- A defaullt behavior of mat-select is select or deselect a option with hover state if there is a keydown.space event, so in order to avoid UX problems when the search input is used by the user (writting two or more words using spaces) the propagation of this event have to stop.

# Bug Fixes
- Avoid event propagation in inputs of general-filters component

# Where this change will be used
- Where general-filters component will be use in dashboard module at `/dashboard/*` pat

# More details
![image](https://user-images.githubusercontent.com/38545126/119911934-004f7c80-bf20-11eb-922f-259637e23e66.png)
