### PR TITLE
update kpis value formats displayed in overview components

### DIFF
--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -6,9 +6,6 @@
                 <!-- content -->
                 <ng-container *ngIf="!loader">
                     <ng-container [ngSwitch]="stat.metricFormat">
-                        <span *ngSwitchCase="'currency'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue | number : '1.0-0' }}
-                        </span>
                         <span *ngSwitchCase="'percentage'" class="h3 font-weight-bold mb-0">
                             {{ stat.metricValue | number : '1.2-2' }}%
                         </span>
@@ -16,7 +13,7 @@
                             {{ stat.metricValue | number : '1.2-2' }}
                         </span>
                         <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue }}
+                            {{ stat.metricValue | number : '1.0-0' }}
                         </span>
                     </ng-container>
                     <span class="h3 font-weight-bold mb-0">{{ stat.metricSymbol }}</span>
@@ -39,9 +36,6 @@
                 <!-- content -->
                 <ng-container *ngIf="!loader">
                     <ng-container [ngSwitch]="stat.subMetricFormat">
-                        <span *ngSwitchCase="'currency'">
-                            {{ stat.subMetricValue | number : '1.0-0' }}
-                        </span>
                         <span *ngSwitchCase="'percentage'">
                             {{ stat.subMetricValue | number : '1.2-2' }}%
                         </span>
@@ -49,7 +43,7 @@
                             {{ stat.subMetricValue | number : '1.2-2' }}
                         </span>
                         <span *ngSwitchDefault>
-                            {{ stat.subMetricValue }}
+                            {{ stat.subMetricValue | number : '1.0-0' }}
                         </span>
                     </ng-container>
                     <span>{{ stat.subMetricSymbol }}</span>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -69,6 +69,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       metricName: 'revenue',
       metricValue: 0,
       metricFormat: 'currency',
+      metricSymbol: 'USD',
       subMetricTitle: 'roas',
       subMetricName: 'roas',
       subMetricValue: 0,

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -71,6 +71,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       metricName: 'revenue',
       metricValue: 0,
       metricFormat: 'currency',
+      metricSymbol: 'USD',
       subMetricTitle: 'roas',
       subMetricName: 'roas',
       subMetricValue: 0,


### PR DESCRIPTION
# Problem Description
For cards kpis displayed in overview components is necessary:
- Use a coma as thousands separator in values for clicks, transactions and users metrics
- Show a corrency code in revenue metric

# Features
- Update number pipes in card-stat component
- Update default kpis variable of overview components

# Where this change will be used
- Where card-stat component instances will be use in dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/119913936-cb91f400-bf24-11eb-88b6-1aceeb51aa94.png)
