### PR TITLE
filter userAndSalesByMetric variable value in overview-latam

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -223,7 +223,8 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
     this.overviewService.getUsersAndSalesLatam(metricType, sectorID, categoryID, sourceID).subscribe(
       (resp: any[]) => {
-        this.usersAndSalesByMetric = resp;
+        // this.usersAndSalesByMetric = resp;
+        this.usersAndSalesByMetric = resp.filter(serie => +serie.name >= 2021);
         this.usersAndSalesReqStatus = 2;
       },
       error => {


### PR DESCRIPTION
# Problem Description
- Because there isn't available data of 2019 and 2020 years there isn't possible to load users and sales chart in LATAM overview (chart-line-series component). So it's better option not display these years

# Features
- Filter userAndSalesByMetric variable value in overview-latam component in order to display data when the year is greater than or equal to 2021

# Where this change will be used
- In LATAM overview -> users and sales chart at `/dashboard/main-region?main-region=latam`

# More details
![image](https://user-images.githubusercontent.com/38545126/119917397-1bc08480-bf2c-11eb-8278-fca5d6145c7c.png)
