### PR TITLE
update states and responsive properties in charts components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -77,7 +77,6 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
 
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.maskBullets = false;
-    chart.responsive.enabled = true;
     chart.numberFormatter.numberFormat = '#,###.##';
 
     let xAxis = chart.xAxes.push(new am4charts.CategoryAxis());

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
@@ -1,6 +1,6 @@
 <div class="chart">
     <!-- loader -->
-    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
     <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%"></div>

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -84,7 +84,6 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     chart.cursor = new am4charts.XYCursor();
     chart.cursor.xAxis = dateAxis;
     this.chart = chart;
-    chart.responsive.enabled = true;
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
@@ -1,6 +1,6 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
     <div [hidden]="status !== 2 || data?.length < 1" [id]="graphID" style="height: 100%"></div>

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -115,7 +115,6 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
     let bullet = series.bullets.create(am4charts.CircleBullet);
 
     chart.cursor = new am4charts.XYCursor();
-    chart.responsive.enabled = true;
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
@@ -1,6 +1,6 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader *ngIf="status === 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
     <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%"></div>

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
@@ -1,6 +1,6 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
@@ -1,6 +1,6 @@
 <div class="chart" [style.height]="height">
     <!-- loader -->
-    <app-chart-loader [hidden]="status !== 1"></app-chart-loader>
+    <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -123,7 +123,7 @@
                 </div>
                 <div class="card-body" style="height: 328px">
                     <!-- loader -->
-                    <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 1">
+                    <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus <= 1">
                     </app-chart-loader>
 
                     <!-- ready -->

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -112,7 +112,7 @@
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
-                        <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 1">
+                        <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus <= 1">
                         </app-chart-loader>
 
                         <!-- ready -->


### PR DESCRIPTION
# Problem Description
- Show loaders  in charts where the requests status is equal to 0 (init page -> initial value) and 1 (waiting a request response)
- Remove responsive property in charts components in order to display all charts legends and copys in mobile version

# Bug Fixes
- Update condition to show loader in the following charts components
  - chart-pictorial
  - chart-lollipop
  - chart-pyramid (component and instances)
  - chart-line-series
  - chart-multiple-axes
 
- Remove responsive property in the following charts components
   - chart-heat-map
   - chart-line-series
   - chat-lollipop

# Where this change will be used
- Where these charts components will be used in dashboard module (e.g LATAM, country or retailer overview)

# More details
![image](https://user-images.githubusercontent.com/38545126/119997113-ffa4fd80-bf94-11eb-8666-6e1f2cf64dda.png)
![image](https://user-images.githubusercontent.com/38545126/119997067-f2880e80-bf94-11eb-84f2-a492cca3d0b6.png)
![image](https://user-images.githubusercontent.com/38545126/119997167-0df31980-bf95-11eb-8773-5937ecd77009.png)
![image](https://user-images.githubusercontent.com/38545126/119997189-15b2be00-bf95-11eb-85c1-f4c89a7c9d97.png)

