### PR TITLE
fix getCampaigns method calls in general-filters components

### DIFF
--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -4,6 +4,7 @@ import { Subscription, throwError } from 'rxjs';
 import { Configuration } from 'src/app/app.constants';
 import { AppStateService } from 'src/app/services/app-state.service';
 import { FiltersStateService } from './filters-state.service';
+import * as moment from 'moment';
 
 @Injectable({
   providedIn: 'root'
@@ -66,12 +67,16 @@ export class OverviewService {
   * ****/
 
   // *** filters ***
-  getCampaigns(sectorsStrList?: string, categoriesStrList?: string) {
+  getCampaigns(period?: any, sectorsStrList?: string, categoriesStrList?: string) {
     if (!this.retailerID) {
       return throwError('[overview.service]: not countryID provided');
     }
 
-    return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/campaigns?sectors=${sectorsStrList}&categories=${categoriesStrList}`);
+    const periodQParams = period ? `start_date=${moment(period.startDate).format('YYYY-MM-DD')}&end_date=${moment(period.endDate).format('YYYY-MM-DD')}` : '';
+    const sectorsQParams = sectorsStrList ? `sectors=${sectorsStrList}` : '';
+    const categoriesQParams = categoriesStrList ? `categories=${categoriesStrList}` : '';
+
+    return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/campaigns?${periodQParams}&${sectorsQParams}&${categoriesQParams}`);
   }
 
   // *** kpis ***

--- a/src/app/tools/validators/arrays-comparator.ts
+++ b/src/app/tools/validators/arrays-comparator.ts
@@ -1,0 +1,23 @@
+/**
+ * Equals arrays: Compare two objects arrays where objects have an id property
+ * @param array1 
+ * @param array2 
+ * @returns true if arrays are equals
+ */
+export function equalsArrays(array1, array2): boolean {
+    let cleanArray1 = array1.filter(item => item?.id);
+    let cleanArray2 = array2.filter(item => item?.id);
+
+    if (cleanArray1.length !== cleanArray2.length) {
+        return false;
+    }
+
+    let sortedArray1 = cleanArray1.sort((a, b) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 : 0));
+    let sortedArray2 = cleanArray2.sort((a, b) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 : 0));
+
+    const areEquals = sortedArray1.every((value, index) => {
+        return value.id === sortedArray2[index].id;
+    });
+
+    return areEquals;
+}


### PR DESCRIPTION
# Problem Description
In these method there are the following problems:
- When a component init doesn't call getCampaigns method to show options in campaigns filters. This represents a problem when user role is "retailer"
- A change in filters can make multiple get /campaigns requests

# Bug Fixes
- Add period parameter to getCampaigns method in overview service
- Add arrays-comparator file in app tools with equealsArray function
- Use equalsArray from arrays-comparator file in order to avoid repeated requests
- Update previous period and current period comparison  in order to avoid repeated requests

# Where this change will be used
- Where campaign filters will be use (e.g retailer page at `/dashboard/retailer `path)