### PR TITLE
update number format in charts components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
@@ -48,6 +48,7 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
     // Create chart instance
     var chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.data = this.data;
+    chart.numberFormatter.numberFormat = '#,###.##';
 
     // chart.exporting.menu = new am4core.ExportMenu();
 

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -52,6 +52,7 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     this.loadStatus = 1;
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
+    chart.numberFormatter.numberFormat = '#,###.##';
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -70,7 +70,8 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     this.loadChartData(chart);
 
     // Use only absolute numbers
-    chart.numberFormatter.numberFormat = '#.#s';
+    // chart.numberFormatter.numberFormat = '#.#s';
+    chart.numberFormatter.numberFormat = '#,###.##s';
 
     // Create axes
     let categoryAxis = chart.yAxes.push(new am4charts.CategoryAxis());

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -247,8 +247,7 @@
                         </div> -->
 
                         <app-chart-line-series [series]="usersAndSalesByMetric"
-                            [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
-                            [valueFormat]="selectedTab3 === 2 && 'USD'" name="latam-sales-users-by-sector"
+                            [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'" name="latam-sales-users-by-sector"
                             [status]="usersAndSalesReqStatus">
                         </app-chart-line-series>
                     </div>


### PR DESCRIPTION
# Problem Description
- Is necessary use `#,###.##` as chart format in order to standarize data displayed in charts used in overview components
- In sales by sector chart, displayed in LATAM overview is necessary remove "USD" as value format property because this charts will represent amount instead of currency 

# Features
- Update number format in the following charts components:
  - chart-pyramid
  - chart-line-series.component.ts
  - chart-column-line-mix
- Update valueFormat property in chart-line-series component instance used from overview-latam component

# Where this change will be used
- Where these components instances will be used in dashboard module at `/dashboard/*` path (e.g. overview components)

# More details
![image](https://user-images.githubusercontent.com/38545126/120213942-6f1b2700-c1f9-11eb-94fc-72562c782b53.png)
