### PR TITLE
update sidebar to access to users management module

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -106,6 +106,18 @@ export class NavbarComponent implements OnInit, OnDestroy {
       this.customTitle = newMenuItem.title;
       this.customSubtitle && delete this.customSubtitle;
     } else {
+
+      // applies for menu options with submenus
+      for (let item of this.listTitles) {
+        if (item.submenu) {
+          const newSubMenuItem = item.submenu.find(title => title.path === currentUrl);
+          if (newSubMenuItem) {
+            this.customTitle = item.title;
+            this.customSubtitle && delete this.customSubtitle;
+          }
+        }
+      }
+
       if (this.newRetailer?.id) {
         if (this.userService.user.role_name === 'retailer') {
           this.customTitle = this.newRetailer.name;

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -70,6 +70,12 @@
       <!-- Navigation -->
       <ul class="navbar-nav" *ngIf="menuItems?.length > 1">
         <ng-container *ngFor="let menuItem of menuItems">
+
+          <div class="admin-header" *ngIf="menuItem.title === 'Administrador'">
+            <hr class="my-3">
+            <h6 class="navbar-heading text-muted">Configuración</h6>
+          </div>
+
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
             <a routerLinkActive="active" class="nav-link" [ngClass]="{'active' : menuItem === selectedItemL1 }"
               (click)="selectItem(menuItem)">

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -28,3 +28,8 @@ li {
 ul.nav {
    z-index: 1030; 
 }
+
+.admin-header {
+    margin-left: 1.5rem;
+    margin-right: 1.5rem;
+}

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -106,8 +106,17 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
     // Admin routes
     const menuItem2 = {
-      title: 'Administrar usuarios',
-      path: '/dashboard/users',
+      title: 'Administrador',
+      submenu: [
+        {
+          title: 'Usuarios',
+          path: '/dashboard/users',
+        },
+        {
+          title: 'Registro de actividad',
+          path: '/dashboard/users/activity-register',
+        }
+      ],
       isForAdmin: true
     }
     this.menuItems.push(menuItem2);
@@ -224,7 +233,23 @@ export class SidebarComponent implements OnInit, OnDestroy {
       }
     } else {
       const item = this.menuItems.find(item => item.path == this.router.url);
-      this.selectedItemL1 = item;
+      if (item) {
+        this.selectedItemL1 = item;
+      } else {
+        // applies for menu options with submenus
+        for (let item of this.menuItems) {
+          if (item.submenu) {
+            let newSubMenuItem = item.submenu.find(title => title.path === this.router.url);
+            if (newSubMenuItem) {
+              this.selectedItemL1 = item;
+              this.selectedItemL1.submenuOpen = true;
+
+              this.selectedItemL2 = newSubMenuItem;
+            }
+          }
+        }
+      }
+
       this.appStateService.selectCountry();
       this.appStateService.selectRetailer();
     }

--- a/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.html
+++ b/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.html
@@ -1,0 +1,5 @@
+<div class="row mt-4">
+    <div class="col-12">
+        <p class="h2 mb-5 text-xl">Registro de actividad</p>
+    </div>
+</div>

--- a/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.spec.ts
+++ b/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ActivityRegisterComponent } from './activity-register.component';
+
+describe('ActivityRegisterComponent', () => {
+  let component: ActivityRegisterComponent;
+  let fixture: ComponentFixture<ActivityRegisterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ActivityRegisterComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ActivityRegisterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.ts
+++ b/src/app/modules/users-mngmt/pages/activity-register/activity-register.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-activity-register',
+  templateUrl: './activity-register.component.html',
+  styleUrls: ['./activity-register.component.scss']
+})
+export class ActivityRegisterComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/modules/users-mngmt/users-mngmt.module.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.module.ts
@@ -13,6 +13,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { UsersMngmtService } from './services/users-mngmt.service';
 import { InvitationComponent } from './components/invitation/invitation.component';
+import { ActivityRegisterComponent } from './pages/activity-register/activity-register.component';
 
 
 
@@ -23,6 +24,7 @@ import { InvitationComponent } from './components/invitation/invitation.componen
     UsersComponent,
     InviteUserComponent,
     InvitationComponent,
+    ActivityRegisterComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/users-mngmt/users-mngmt.routing.ts
+++ b/src/app/modules/users-mngmt/users-mngmt.routing.ts
@@ -1,8 +1,10 @@
 import { Routes } from '@angular/router';
+import { ActivityRegisterComponent } from './pages/activity-register/activity-register.component';
 import { InviteUserComponent } from './pages/invite-user/invite-user.component';
 import { UsersComponent } from './pages/users/users.component';
 
 export const UsersMngmtRoutes: Routes = [
     { path: '', component: UsersComponent },
     { path: 'invite-user', component: InviteUserComponent },
+    { path: 'activity-register', component: ActivityRegisterComponent },
 ];


### PR DESCRIPTION
# Problem Description
- Is necessary update sidebar to access to users management module. Now is necessary have a menu item with children options:
- Admin
    - Users
    - Activity register

# Features
- Add acitivity-register component in users-mngmt module using `/dashboard/users/activity-register` as route
- Update sidebar component to show settings menu options
- Update loadCustomTitles method in navbar component to consider custom titles based on submenus paths 

# Where this change will be used
- To access to users management module at `/dashboard/users/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/120222814-2d44ad80-c206-11eb-9572-3874a5e8f544.png)