### PR TITLE
preserve selected tabs in overview components

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -318,7 +318,7 @@
             (!endDate.valid && endDate.touched) ||
             (sectors?.value?.length < 1 && sectors.touched) ||
             (categories?.value?.length < 1 && categories.touched)
-            " (click)="applyFilters()">
+            " (click)="applyFilters(true)">
             <i class="fas fa-filter mr-2"></i>
             Filtrar
         </button>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -565,7 +565,12 @@ export class GeneralFiltersComponent implements OnInit {
     this[counterRef] = selectionCounter.length;
   }
 
-  applyFilters() {
+
+  /**
+   * Applys filters
+   * @param [manualTriggered] change made by "filter" button click triggered manually by the user
+   */
+  applyFilters(manualTriggered?: boolean) {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value.filter(item => item.id));
     this.filtersStateService.selectCategories(this.categories.value.filter(item => item.id));
@@ -579,7 +584,7 @@ export class GeneralFiltersComponent implements OnInit {
     const areAllCampsSelected = this.areAllCampaignsSelected();
     this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value.filter(item => item.id));
 
-    this.filtersStateService.filtersChange();
+    this.filtersStateService.filtersChange(manualTriggered);
   }
 
   arraysAreEquals(array1: any[], array2: any[]): boolean {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -17,7 +17,7 @@
                 <ul class="nav nav-pills nav-fill" *ngIf="selectedSectors?.length > 1">
                     <li class="nav-item mb-2" *ngFor="let sector of selectedSectors; let i = index">
                         <a class="nav-link p-2" [ngClass]="{'active': sector.id === selectedTab1}"
-                            (click)="selectedTab1 = sector.id; getCategoriesBySector(sector.name, sector.id)">
+                            (click)="getCategoriesBySector(sector)">
                             {{ sector.name }}
                         </a>
                     </li>
@@ -62,11 +62,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                            (click)="getDataByTrafficAndSales('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
+                            (click)="getDataByTrafficAndSales('sales'); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
                     </li>
                 </ul>
             </div>
@@ -157,11 +157,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
-                            (click)="getDataByUsersAndSales('users', 1)">Usuarios</a>
+                            (click)="getDataByUsersAndSales('users')">Usuarios</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
-                            (click)="getDataByUsersAndSales('sales', 2)">Ventas</a>
+                            (click)="getDataByUsersAndSales('sales')">Ventas</a>
                     </li>
                 </ul>
             </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -11,7 +11,7 @@ import { OverviewService } from '../../services/overview.service';
 export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   @Input() selectedType: string; // country or retailer
-  @Input() requestInfoChange: Observable<void>;
+  @Input() requestInfoChange: Observable<boolean>;
   @Input() showTrafficAndSalesSection: boolean = true;
 
   selectedTab1: number = 1;
@@ -80,6 +80,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   ];
 
   selectedSectors: any[] = [];
+  selectedSectorTab: any;
   categoriesBySector: any[] = [];
   trafficAndSales = {};
 
@@ -112,18 +113,33 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       this.getAllData();
     }
 
-    this.requestInfoSub = this.requestInfoChange.subscribe(() => {
-      this.getAllData();
+    this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
+      this.getAllData(manualChange);
     })
   }
 
-  getAllData() {
+  getAllData(preserveSelectedTabs?: boolean) {
     this.selectedSectors = this.filtersStateService.sectors;
 
+    let selectedSector;
+    let trafficOrSales;
+    let usersOrSales;
+
+    if (!preserveSelectedTabs) {
+      selectedSector = this.selectedSectors[0];
+      trafficOrSales = 'traffic';
+      usersOrSales = 'users';
+    } else {
+      const previousSector = this.selectedSectors.find(sector => sector.id === this.selectedSectorTab.id);
+      selectedSector = previousSector ? previousSector : this.selectedSectors[0];
+      trafficOrSales = this.selectedTab2 === 1 ? 'traffic' : 'sales';
+      usersOrSales = this.selectedTab3 === 1 ? 'users' : 'sales';
+    }
+
     this.getKpis();
-    this.getCategoriesBySector('Search', this.selectedSectors[0]?.id);
-    this.getDataByTrafficAndSales('traffic', 1);
-    this.getDataByUsersAndSales('users', 1);
+    this.getCategoriesBySector(selectedSector);
+    this.getDataByTrafficAndSales(trafficOrSales);
+    this.getDataByUsersAndSales(usersOrSales);
     this.getInvestmentVsRevenue();
 
     this.chartsInitLoad = true;
@@ -154,9 +170,10 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       });
   }
 
-  getCategoriesBySector(sector: string, selectedTab: number) {
+  getCategoriesBySector(selectedSector: any) {
     this.categoriesReqStatus = 1;
-    this.overviewService.getCategoriesBySector(sector).subscribe(
+    this.selectedSectorTab = selectedSector;
+    this.overviewService.getCategoriesBySector(selectedSector?.name).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
         this.categoriesReqStatus = 2;
@@ -167,10 +184,11 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         this.categoriesReqStatus = 3;
       });
 
-    this.selectedTab1 = selectedTab;
+    // Tabs are only used for country view
+    this.selectedTab1 = selectedSector.id;
   }
 
-  getDataByTrafficAndSales(metricType: string, selectedTab: number) {
+  getDataByTrafficAndSales(metricType: string) {
     const requiredData = ['device', 'gender', 'age', 'gender-and-age']
 
     for (let subMetricType of requiredData) {
@@ -193,11 +211,11 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
           reqStatusObj.reqStatus = 3;
         });
 
-      this.selectedTab2 = selectedTab;
+      this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
     }
   }
 
-  getDataByUsersAndSales(metricType: string, selectedTab: number) {
+  getDataByUsersAndSales(metricType: string) {
     this.usersAndSalesReqStatus = 1;
     this.overviewService.getUsersAndSales(metricType).subscribe(
       (resp: any[]) => {
@@ -211,7 +229,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       }
     )
 
-    this.selectedTab3 = selectedTab;
+    this.selectedTab3 = metricType === 'users' ? 1 : 2;
   }
 
   getInvestmentVsRevenue() {

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -17,7 +17,7 @@ export class CountryComponent implements OnInit, OnDestroy {
   retailerSub: Subscription;
   filtersSub: Subscription;
 
-  private requestInfoSource = new Subject<void>();
+  private requestInfoSource = new Subject<boolean>();
   requestInfoChange$ = this.requestInfoSource.asObservable();
 
   constructor(
@@ -32,8 +32,8 @@ export class CountryComponent implements OnInit, OnDestroy {
     this.countryID = selectedCountry?.id && selectedCountry?.id;
     this.retailerID = selectedRetailer?.id && selectedRetailer?.id;
 
-    this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
-      this.requestInfoSource.next();
+    this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
+      this.requestInfoSource.next(manualChange);
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -19,11 +19,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                                (click)="getSectorsAndCategories('sectors', 1)">Sector</a>
+                                (click)="getSectorsAndCategories('sectors')">Sector</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                                (click)="getSectorsAndCategories('categories', 2)">Categoría</a>
+                                (click)="getSectorsAndCategories('categories')">Categoría</a>
                         </li>
                     </ul>
                 </div>
@@ -51,11 +51,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                                (click)="getDataByTrafficAndSales('traffic', 1); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                                (click)="getDataByTrafficAndSales('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                                (click)="getDataByTrafficAndSales('sales', 2); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
+                                (click)="getDataByTrafficAndSales('sales'); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
                         </li>
                     </ul>
                 </div>
@@ -185,12 +185,12 @@
                                         *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales'); clearUsersAndSalesTabs()">Todo</a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': sector.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = sector.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', sector.id)">
+                                                (click)="selectedTab5 = sector.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', sector)">
                                                 {{ sector.name}}
                                             </a>
                                         </li>
@@ -206,7 +206,7 @@
                                         <li class="nav-item mb-2" *ngFor="let category of selectedCategories">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': category.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = category.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, category.id)">
+                                                (click)="selectedTab5 = category.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, category)">
                                                 {{ category.name}}
                                             </a>
                                         </li>
@@ -222,7 +222,7 @@
                                         <li class="nav-item mb-2" *ngFor="let source of selectedSources">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': source.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = source.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, null, source.id)">
+                                                (click)="selectedTab5 = source.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, null, source)">
                                                 {{ source.name}}
                                             </a>
                                         </li>
@@ -277,7 +277,7 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item" *ngFor="let category of selectedCategories">
                             <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab6}"
-                                (click)="selectedTab6 = category.id; getTopProducts(category.id)">
+                                (click)="getTopProducts(category)">
                                 {{ category.name}}
                             </a>
                         </li>

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -129,7 +129,7 @@ export class RetailerComponent implements OnInit, OnDestroy {
   filtersSub: Subscription;
   retailerSub: Subscription;
 
-  private requestInfoSource = new Subject<void>();
+  private requestInfoSource = new Subject<boolean>();
   requestInfoChange$ = this.requestInfoSource.asObservable();
 
   constructor(
@@ -141,8 +141,8 @@ export class RetailerComponent implements OnInit, OnDestroy {
     const selectedRetailer = this.appStateService.selectedRetailer;
     this.retailerID = selectedRetailer?.id;
 
-    this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
-      this.requestInfoSource.next();
+    this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
+      this.requestInfoSource.next(manualChange);
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -56,7 +56,7 @@ export class FiltersStateService {
   sourcesQParams;
 
   // filtersChange
-  private filtersSource = new Subject<any>();
+  private filtersSource = new Subject<boolean>();
   filtersChange$ = this.filtersSource.asObservable();
 
   constructor() { }
@@ -153,9 +153,13 @@ export class FiltersStateService {
     this.selectCampaigns([]);
   }
 
-  filtersChange() {
+  /**
+   * Filters change
+   * @param manualChange change made by "filter" button click triggered manually by the user
+   */
+  filtersChange(manualChange: boolean) {
     this.convertFiltersToQueryParams();
-    this.filtersSource.next();
+    this.filtersSource.next(manualChange);
   }
 }
 

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -44,14 +44,14 @@ export class OverviewService {
     });
   }
 
-  concatedQueryParams(isLatam?: boolean, uniqueSectorID?: number, uniqueCategoryID?: number, uniqueSourceID?: number): string {
+  concatedQueryParams(isLatam?: boolean, uniqueSectorID?: number, uniqueCategoryID?: number, uniqueSourceID?: number, omitSectors?: boolean): string {
     let startDate = this.filtersStateService.periodQParams.startDate;
     let endDate = this.filtersStateService.periodQParams.endDate;
     let sectors = !uniqueSectorID ? this.filtersStateService.sectorsQParams : uniqueSectorID;
     let categories = !uniqueCategoryID ? this.filtersStateService.categoriesQParams : uniqueCategoryID;
     let campaigns = this.filtersStateService.campaignsQParams;
 
-    const baseQParams = `start_date=${startDate}&end_date=${endDate}&sectors=${sectors}&categories=${categories}`
+    const baseQParams = `start_date=${startDate}&end_date=${endDate}${!omitSectors ? `&sectors=${sectors}` : ''}&categories=${categories}`;
     if (!isLatam) {
       return `${baseQParams}${campaigns ? `&campaigns=${campaigns}` : ''}`;
     } else {
@@ -93,16 +93,12 @@ export class OverviewService {
   }
 
   // *** categories by sector ***
-  getCategoriesBySector(sector: string) {
-    if (!sector) {
-      return throwError('[overview.service]: not sector provided');
-    }
-
-    let queryParams = this.concatedQueryParams();
-
+  getCategoriesBySector(sector?: string) {
     if (this.retailerID) {
-      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/categories?sector=${sector}&${queryParams}`);
+      let queryParams = this.concatedQueryParams();
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/categories?${queryParams}`);
     } else if (this.countryID) {
+      let queryParams = this.concatedQueryParams(null, null, null, null, true);
       return this.http.get(`${this.baseUrl}/countries/${this.countryID}/retailer/categories?sector=${sector}&${queryParams}`);
     } else {
       return throwError('[overview.service]: not retailerID or countryID provided');


### PR DESCRIPTION
# Problem Description
- Is necessary preserve selected tabs after click in filter button (and restore selected tabs when there isn't a change triggered by filter button, as country or retailer changes)

# Features
- Update **filterChange** method in _filters-state service_
- Update **applyFilters** method in _general-filters component_
- Update **filterSub** subscription in _country_  and _retailer_ _components_
- Update **concatedQueryParams** and **getCategoriesBySector** methods in _overview service_
- Preserve selected tabs in _overview-wrapper_ component
- Preserve selected tabs in _overview-latam_ component

# Where this change will be used
- In overview-wrapper and overview-latam components used in dashboard module