### PR TITLE
update properties of chart-line-series used in overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -175,8 +175,7 @@
                 <div class="card-body">
                     <app-chart-line-series [series]="usersAndSalesBySector"
                         [valueName]="selectedTab3 === 1 ? 'Usuarios' : 'Ventas'"
-                        [valueFormat]="selectedTab3 === 2 && 'USD'" [name]="selectedType + 'sales-users-by-sector'"
-                        [status]="usersAndSalesReqStatus">
+                        [name]="selectedType + 'sales-users-by-sector'" [status]="usersAndSalesReqStatus">
                     </app-chart-line-series>
                 </div>
             </div>


### PR DESCRIPTION
# Problem Description
- Remove value format of chart-line-series instance component used in overview-wrapper component in order to show amount instead of USD data

# Bug Fixes
- Remove valueFormant property of chart-line-series used in overview-wrapper compnent

# Where this change will be used
- In country or retailer overview > Users & sales > sales section > chart line series

# More details
![image](https://user-images.githubusercontent.com/38545126/120359641-84618580-c2cd-11eb-9f02-af02818197f1.png)