### PR TITLE
add es as language in charts components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
@@ -80,6 +80,5 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit {
 
     // Cursor
     chart.cursor = new am4charts.XYCursor();
-    chart.responsive.enabled = true;
   }
 }

--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -1,6 +1,7 @@
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
+import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
 
 @Component({
   selector: 'app-chart-line-comparison',
@@ -86,6 +87,7 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     this.loadStatus = 1;
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
+    chart.language.locale = am4lang_es_ES;
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
 
 @Component({
   selector: 'app-chart-line-series',
@@ -53,6 +54,7 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.numberFormatter.numberFormat = '#,###.##';
+    chart.language.locale = am4lang_es_ES;
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
 
 @Component({
   selector: 'app-chart-line',
@@ -11,8 +12,8 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 export class ChartLineComponent implements OnInit, AfterViewInit {
 
   @Input() data;
-  @Input() value;
-  @Input() date;
+  @Input() value = 'value';
+  @Input() date = 'date';
   chartID;
   loadStatus: number = 0;
 
@@ -38,6 +39,7 @@ export class ChartLineComponent implements OnInit, AfterViewInit {
     am4core.useTheme(am4themes_animated);
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
+    chart.language.locale = am4lang_es_ES;
 
     // Add data
     chart.data = this.data;
@@ -72,6 +74,5 @@ export class ChartLineComponent implements OnInit, AfterViewInit {
     chart.cursor = new am4charts.XYCursor();
     chart.cursor.xAxis = dateAxis;
     chart.cursor.snapToSeries = series;
-    chart.responsive.enabled = true;
   }
 }


### PR DESCRIPTION
# Problem Description
- Use spanish as chart language in charts components which use date in one axe

# Features
- Update chart.language.local value in the following charts components
  - chart-line
  - chart-line-comparison
  - chart-line-series

# Bug Fixes
- Remove responsive property in chart-bar-horizonal component
- Add default input values in chart-line component

# Where this change will be used
- Where charts will be used in dashboard module at `/dashboard/*`

# More details
![image](https://user-images.githubusercontent.com/38545126/120393416-84767b00-c2f7-11eb-9a36-b466bddfd0ee.png)
