### PR TITLE
add chart language property to charts components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -88,6 +88,8 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.language.locale = am4lang_es_ES;
+    chart.language.locale["_decimalSeparator"] = ".";
+    chart.language.locale["_thousandSeparator"] = ",";
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -55,6 +55,8 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.numberFormatter.numberFormat = '#,###.##';
     chart.language.locale = am4lang_es_ES;
+    chart.language.locale["_decimalSeparator"] = ".";
+    chart.language.locale["_thousandSeparator"] = ",";
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
@@ -40,6 +40,8 @@ export class ChartLineComponent implements OnInit, AfterViewInit {
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.language.locale = am4lang_es_ES;
+    chart.language.locale["_decimalSeparator"] = ".";
+    chart.language.locale["_thousandSeparator"] = ",";
 
     // Add data
     chart.data = this.data;


### PR DESCRIPTION
# Problem Description
- Update decimal and thousand separators in charts components which is used spanish as chart language

# Features
- Update chart.language.locale _decimalSeparator _thousandSeparator properties in the following charts components
  - chart-line
  - chart-line-comparison
  - chart-line-series

# Where this change will be used
- Where charts will be used in dashboard module at `/dashboard/*`

# More details
![image](https://user-images.githubusercontent.com/38545126/120404896-fc02d500-c30c-11eb-9bd5-fef7cf49a492.png)

