### PR TITLE
add functionality to campaigns-towards-retail component

### DIFF
--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
@@ -1,0 +1,14 @@
+<div class="row my-5">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <app-chart-line-series [series]="campPerformance" [status]="campPerformanceReqStatus"
+                    name="campaign-towards-retail-metrics">
+                </app-chart-line-series>
+            </div>
+        </div>
+    </div>
+</div>
+
+<app-campaigns-tables *ngFor="let campaigns of campList" [campList]="campaigns" [campListChange]="campaigns.campaigns">
+</app-campaigns-tables>

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.spec.ts
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CampaignTowardsRetailWrapperComponent } from './campaign-towards-retail-wrapper.component';
+
+describe('CampaignTowardsRetailWrapperComponent', () => {
+  let component: CampaignTowardsRetailWrapperComponent;
+  let fixture: ComponentFixture<CampaignTowardsRetailWrapperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CampaignTowardsRetailWrapperComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CampaignTowardsRetailWrapperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
@@ -1,0 +1,94 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+import { CampaignTowardsRetailService } from '../../services/campaign-towards-retail.service';
+
+@Component({
+  selector: 'app-campaign-towards-retail-wrapper',
+  templateUrl: './campaign-towards-retail-wrapper.component.html',
+  styleUrls: ['./campaign-towards-retail-wrapper.component.scss']
+})
+export class CampaignTowardsRetailWrapperComponent implements OnInit {
+  @Input() requestInfoChange: Observable<boolean>;
+
+  campPerformance: any[] = [];
+  campPerformanceReqStatus: number = 0;
+
+  campList: any[] = [
+    {
+      source: 'google',
+      name: 'Google Search y MDF',
+      campaigns: [],
+      reqStatus: 0
+    },
+    {
+      source: 'programmatic',
+      name: 'Programmatic',
+      campaigns: [],
+      reqStatus: 0
+    },
+    {
+      source: 'facebook',
+      name: 'Social Media',
+      campaigns: [],
+      reqStatus: 0
+    }
+  ];
+
+  requestInfoSub: Subscription;
+
+  constructor(
+    private campTowardsRetailServ: CampaignTowardsRetailService
+  ) { }
+
+  ngOnInit(): void {
+    this.getAllData();
+
+    this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
+      this.getAllData();
+    })
+  }
+
+  getAllData() {
+    this.getCampaignsPerformance();
+    this.getCampaignList();
+  }
+
+  getCampaignsPerformance() {
+    this.campPerformanceReqStatus = 1;
+    this.campTowardsRetailServ.getCampaignsPerformance().subscribe(
+      (metrics: any) => {
+        for (let metric of metrics) {
+          if (metric.name === 'Impresiones' || metric.name === 'Clicks') {
+            metric.customLineStye = 'dashed';
+          }
+          if (metric.name === 'Inversión') {
+            metric.valueFormat = 'USD';
+          }
+        }
+
+        this.campPerformance = metrics;
+        this.campPerformanceReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[campaign-towards-retail.component]: ${errorMsg}`);
+        this.campPerformanceReqStatus = 3;
+      });
+  }
+
+  getCampaignList() {
+    this.campList.forEach(item => {
+      item.reqStatus = 1;
+      this.campTowardsRetailServ.getCampaignsList(item.source).subscribe(
+        (campaigns: any) => {
+          item.campaigns = campaigns;
+          item.reqStatus = 2;
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[campaign-towards-retail.component]: ${errorMsg}`);
+          item.reqStatus = 3;
+        });
+    });
+  }
+}

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { CampaignTowardsRetailService } from '../../services/campaign-towards-retail.service';
 
@@ -7,7 +7,7 @@ import { CampaignTowardsRetailService } from '../../services/campaign-towards-re
   templateUrl: './campaign-towards-retail-wrapper.component.html',
   styleUrls: ['./campaign-towards-retail-wrapper.component.scss']
 })
-export class CampaignTowardsRetailWrapperComponent implements OnInit {
+export class CampaignTowardsRetailWrapperComponent implements OnInit, OnDestroy {
   @Input() requestInfoChange: Observable<boolean>;
 
   campPerformance: any[] = [];
@@ -90,5 +90,9 @@ export class CampaignTowardsRetailWrapperComponent implements OnInit {
           item.reqStatus = 3;
         });
     });
+  }
+
+  ngOnDestroy() {
+    this.requestInfoSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.html
+++ b/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.html
@@ -3,11 +3,14 @@
         <div class="col-12">
             <div class="header bg-light mb-2">
                 <p class="h4 py-1 ml-3 mr-3">
-                    <span>Google Search y MDF</span>
+                    <span>{{ campList.name }}</span>
                 </p>
             </div>
-            <div class="adaptable-container">
-                <table mat-table [dataSource]="dataSource1">
+            <div class="adaptable-container" [ngClass]="{'auto': campList?.reqStatus > 1 }">
+                <div class="loading-shade" [hidden]="campList?.reqStatus > 1">
+                    <mat-spinner></mat-spinner>
+                </div>
+                <table mat-table [dataSource]="dataSource">
                     <!-- name column -->
                     <ng-container matColumnDef="name">
                         <th mat-header-cell *matHeaderCellDef> Campaña </th>
@@ -45,9 +48,10 @@
 
                         <td mat-cell *matCellDef="let element">
                             <div class="value-container">
-                                <span>{{element.ctr}}</span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.ctr >= element.ctr_benchmark"></i>
+                                <span>{{ element.ctr | number : '1.2-2' }}</span>
+                                <i class="fas fa-arrow-up text-success" *ngIf="element.ctr > element.ctr_benchmark"></i>
+                                <i class="fas fa-arrow-up text-warning"
+                                    *ngIf="element.ctr === element.ctr_benchmark"></i>
                                 <i class="fas fa-arrow-down text-danger"
                                     *ngIf="element.ctr < element.ctr_benchmark"></i>
                             </div>
@@ -58,29 +62,34 @@
                     <!-- CPM -->
                     <ng-container matColumnDef="cpm">
                         <th mat-header-cell *matHeaderCellDef> CPM</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpm}} </td>
+                        <td mat-cell *matCellDef="let element"> {{ element.cpm | number : '1.2-2'}} </td>
                     </ng-container>
 
                     <!-- CPC -->
                     <ng-container matColumnDef="cpc">
                         <th mat-header-cell *matHeaderCellDef> CPC</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpc}} </td>
+                        <td mat-cell *matCellDef="let element"> {{ element.cpc | number : '1.2-2' }} </td>
                     </ng-container>
 
                     <!-- ROAS -->
                     <ng-container>
                         <ng-container matColumnDef="roas">
                             <th mat-header-cell *matHeaderCellDef> ROAS</th>
-                            <td mat-cell *matCellDef="let element"> {{element.roas ? element.roas + '%' : '-' }}
+                            <td mat-cell *matCellDef="let element">
+                                {{ element.roas ? (element.roas | number : '1.2-2') + '%' : '-' }}
                             </td>
                         </ng-container>
                     </ng-container>
 
                     <!-- disclaimer column -->
                     <ng-container matColumnDef="disclaimer">
-                        <td mat-footer-cell *matFooterCellDef colspan="3">
-                            <div class="text-danger text-center" *ngIf="getReqStatus === 3">
-                                Ocurrió un error al consultar los usuarios
+                        <td mat-footer-cell *matFooterCellDef colspan="8">
+                            <div class="text-danger text-center" *ngIf="campList?.reqStatus === 3">
+                                Ocurrió un error al consultar las campañas
+                            </div>
+                            <div class="text-muted text-center"
+                                *ngIf="campList?.campaigns.length === 0 && campList?.reqStatus !== 3">
+                                No se encontraron campañas
                             </div>
                         </td>
                     </ng-container>
@@ -91,208 +100,10 @@
                     </ng-container>
 
                     <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
-                        [hidden]="getReqStatus !== 3"></tr>
+                        [hidden]="campList?.reqStatus <=1 || campList?.campaigns.length > 0"></tr>
                 </table>
             </div>
             <mat-paginator class="paginator" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
         </div>
     </div>
-    <div class="row mb-5">
-        <div class="col-12">
-            <div class="header bg-light mb-2">
-                <p class="h4 py-1 ml-3 mr-3">
-                    <span>Programmatic</span>
-                </p>
-            </div>
-            <div class="adaptable-container">
-                <table mat-table [dataSource]="dataSource2">
-                    <!-- name column -->
-                    <ng-container matColumnDef="name">
-                        <th mat-header-cell *matHeaderCellDef> Campaña </th>
-                        <td mat-cell *matCellDef="let element" [style.width.%]="45">
-                            <div class="lg-container">
-                                <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.name"
-                                    matTooltipPosition="right" matTooltipClass="custom-tooltip">
-                                    {{element.name}}
-                                </span>
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <!-- investment column -->
-                    <ng-container matColumnDef="investment">
-                        <th mat-header-cell *matHeaderCellDef> Inversión </th>
-                        <td mat-cell *matCellDef="let element"> {{element.investment}} </td>
-                    </ng-container>
-
-                    <!-- impressions -->
-                    <ng-container matColumnDef="impressions">
-                        <th mat-header-cell *matHeaderCellDef> Impresiones</th>
-                        <td mat-cell *matCellDef="let element"> {{element.impressions}} </td>
-                    </ng-container>
-
-                    <!-- clicks -->
-                    <ng-container matColumnDef="clicks">
-                        <th mat-header-cell *matHeaderCellDef> Clicks</th>
-                        <td mat-cell *matCellDef="let element"> {{element.clicks}} </td>
-                    </ng-container>
-
-                    <!-- CTR -->
-                    <ng-container matColumnDef="ctr">
-                        <th mat-header-cell *matHeaderCellDef> CTR</th>
-
-                        <td mat-cell *matCellDef="let element">
-                            <div class="value-container">
-                                <span>{{element.ctr}}</span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.ctr >= element.ctr_benchmark"></i>
-                                <i class="fas fa-arrow-down text-danger"
-                                    *ngIf="element.ctr < element.ctr_benchmark"></i>
-                            </div>
-                        </td>
-
-                    </ng-container>
-
-                    <!-- CPM -->
-                    <ng-container matColumnDef="cpm">
-                        <th mat-header-cell *matHeaderCellDef> CPM</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpm}} </td>
-                    </ng-container>
-
-                    <!-- CPC -->
-                    <ng-container matColumnDef="cpc">
-                        <th mat-header-cell *matHeaderCellDef> CPC</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpc}} </td>
-                    </ng-container>
-
-                    <!-- ROAS -->
-                    <ng-container>
-                        <ng-container matColumnDef="roas">
-                            <th mat-header-cell *matHeaderCellDef> ROAS</th>
-                            <td mat-cell *matCellDef="let element"> {{element.roas ? element.roas + '%' : '-' }}
-                            </td>
-                        </ng-container>
-                    </ng-container>
-
-                    <!-- disclaimer column -->
-                    <ng-container matColumnDef="disclaimer">
-                        <td mat-footer-cell *matFooterCellDef colspan="3">
-                            <div class="text-danger text-center" *ngIf="getReqStatus === 3">
-                                Ocurrió un error al consultar los usuarios
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <ng-container>
-                        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-                    </ng-container>
-
-                    <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
-                        [hidden]="getReqStatus !== 3"></tr>
-                </table>
-            </div>
-            <mat-paginator class="paginator" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-        </div>
-    </div>
-    <div class="row mb-5">
-        <div class="col-12">
-            <div class="header bg-light mb-2">
-                <p class="h4 py-1 ml-3 mr-3">
-                    <span>Social Media</span>
-                </p>
-            </div>
-            <div class="adaptable-container">
-                <table mat-table [dataSource]="dataSource3">
-                    <!-- name column -->
-                    <ng-container matColumnDef="name">
-
-                        <th mat-header-cell *matHeaderCellDef> Campaña </th>
-                        <td mat-cell *matCellDef="let element" [style.width.%]="45">
-                            <div class="lg-container">
-                                <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.name"
-                                    matTooltipPosition="right" matTooltipClass="custom-tooltip">
-                                    {{element.name}}
-                                </span>
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <!-- investment column -->
-                    <ng-container matColumnDef="investment">
-                        <th mat-header-cell *matHeaderCellDef> Inversión </th>
-                        <td mat-cell *matCellDef="let element"> {{element.investment}} </td>
-                    </ng-container>
-
-                    <!-- impressions -->
-                    <ng-container matColumnDef="impressions">
-                        <th mat-header-cell *matHeaderCellDef> Impresiones</th>
-                        <td mat-cell *matCellDef="let element"> {{element.impressions}} </td>
-                    </ng-container>
-
-                    <!-- clicks -->
-                    <ng-container matColumnDef="clicks">
-                        <th mat-header-cell *matHeaderCellDef> Clicks</th>
-                        <td mat-cell *matCellDef="let element"> {{element.clicks}} </td>
-                    </ng-container>
-
-                    <!-- CTR -->
-                    <ng-container matColumnDef="ctr">
-                        <th mat-header-cell *matHeaderCellDef> CTR</th>
-
-                        <td mat-cell *matCellDef="let element">
-                            <div class="value-container">
-                                <span>{{element.ctr}}</span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.ctr >= element.ctr_benchmark"></i>
-                                <i class="fas fa-arrow-down text-danger"
-                                    *ngIf="element.ctr < element.ctr_benchmark"></i>
-                            </div>
-                        </td>
-
-                    </ng-container>
-
-                    <!-- CPM -->
-                    <ng-container matColumnDef="cpm">
-                        <th mat-header-cell *matHeaderCellDef> CPM</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpm}} </td>
-                    </ng-container>
-
-                    <!-- CPC -->
-                    <ng-container matColumnDef="cpc">
-                        <th mat-header-cell *matHeaderCellDef> CPC</th>
-                        <td mat-cell *matCellDef="let element"> {{element.cpc}} </td>
-                    </ng-container>
-
-                    <!-- ROAS -->
-                    <ng-container>
-                        <ng-container matColumnDef="roas">
-                            <th mat-header-cell *matHeaderCellDef> ROAS</th>
-                            <td mat-cell *matCellDef="let element"> {{element.roas ? element.roas + '%' : '-' }}
-                            </td>
-                        </ng-container>
-                    </ng-container>
-
-                    <!-- disclaimer column -->
-                    <ng-container matColumnDef="disclaimer">
-                        <td mat-footer-cell *matFooterCellDef colspan="3">
-                            <div class="text-danger text-center" *ngIf="getReqStatus === 3">
-                                Ocurrió un error al consultar los usuarios
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <ng-container>
-                        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-                    </ng-container>
-
-                    <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
-                        [hidden]="getReqStatus !== 3"></tr>
-                </table>
-            </div>
-            <mat-paginator class="paginator" [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-        </div>
-    </div>
-
 </div>

--- a/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.html
+++ b/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.html
@@ -84,8 +84,8 @@
                     <!-- disclaimer column -->
                     <ng-container matColumnDef="disclaimer">
                         <td mat-footer-cell *matFooterCellDef colspan="8">
-                            <div class="text-danger text-center" *ngIf="campList?.reqStatus === 3">
-                                Ocurrió un error al consultar las campañas
+                            <div class="text-muted text-center" *ngIf="campList?.reqStatus === 3">
+                                Error al consultar datos
                             </div>
                             <div class="text-muted text-center"
                                 *ngIf="campList?.campaigns.length === 0 && campList?.reqStatus !== 3">

--- a/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.scss
+++ b/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.scss
@@ -1,4 +1,9 @@
-.campaigns-tables {
+.adaptable-container {
+    background-color: #ffffff;
+    min-height: 250px;
+    overflow: auto;
+    position: relative;
+  
     table {
         border-collapse: collapse;
         table-layout: auto;
@@ -9,11 +14,7 @@
             text-align: center;
         }
     }
-    
-    .adaptable-container {
-        overflow: auto;
-    }
-    
+
     .lg-container {
         max-width: 700px;
         span {
@@ -24,7 +25,7 @@
             display: inline-block;
         }
     }
-    
+
     .value-container {
         align-items: center;
         display: grid;
@@ -32,8 +33,28 @@
         gap: 8px;
         justify-content: center;
     } 
+
+    &.auto {
+        min-height: auto;
+    }
+
+    .loading-shade {
+        align-items: center;
+        background: rgba(0, 0, 0, 0.03);
+        bottom: 0px;
+        display: flex;
+        justify-content: center;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        z-index: 1;
+    }
 }
 
-.custom-tooltip {
+::ng-deep .custom-tooltip {
+    font-size: 12px !important;
+    margin-bottom: 0px !important;
+    margin-top: 0px !important;
     max-width: unset !important;
 }

--- a/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.ts
+++ b/src/app/modules/dashboard/components/campaigns-tables/campaigns-tables.component.ts
@@ -1,46 +1,39 @@
-import { AfterViewInit, Component, OnInit, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, Component, Input, OnInit, QueryList, ViewChild, ViewChildren, ViewEncapsulation } from '@angular/core';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatTableDataSource } from '@angular/material/table';
 
 @Component({
   selector: 'app-campaigns-tables',
   templateUrl: './campaigns-tables.component.html',
-  styleUrls: ['./campaigns-tables.component.scss'],
-  encapsulation: ViewEncapsulation.None,
+  styleUrls: ['./campaigns-tables.component.scss']
 })
 export class CampaignsTablesComponent implements OnInit, AfterViewInit {
 
-  displayedColumns: string[] = ['name', 'investment', 'impressions', 'clicks', 'ctr', 'cpm', 'cpc', 'roas'];
-  private campaigns1 = [
-    { name: 'Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact_Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50, roas: 40 },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Spectre_Premium_Local_Intel_CCF_Google_All_SEM_ROAS_HP_Exact', investment: 7000, impressions: 150000, clicks: 8000, ctr: 25.55, ctr_benchmark: 22.12, cpm: 450, cpc: 30, roas: 50 },
-    { name: 'MX_Q1_FY21_PS_CPS_CPS-Gaming_OMEN_OMG_Local__Omen____', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80, roas: 250 },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact_Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50, roas: 40 },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Spectre_Premium_Local_Intel_CCF_Google_All_SEM_ROAS_HP_Exact', investment: 7000, impressions: 150000, clicks: 8000, ctr: 25.55, ctr_benchmark: 22.12, cpm: 450, cpc: 30, roas: 50 },
-    { name: 'MX_Q1_FY21_PS_CPS_CPS-Gaming_OMEN_OMG_Local__Omen____', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80, roas: 250 }
-  ];
-  private campaigns2 = [
-    { name: 'Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50 },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Spectre_Premium', investment: 7000, impressions: 150000, clicks: 8000, ctr: 25.55, ctr_benchmark: 22.12, cpm: 450, cpc: 30, roas: undefined },
-    { name: 'MX_Q1_FY21_PS_CPS_CPS-Gaming_OMEN_OMG', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80, roas: undefined },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact_Liverpool_MX_BRA_PS_CPS_Laptops_Omen_Gaming_Local_AMD_Google_All_SEM_ROAS_HP_Exact', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50, roas: 40 },
-    { name: 'Liverpool_MX_BRA_PS_CPS_Spectre_Premium_Local_Intel_CCF_Google_All_SEM_ROAS_HP_Exact', investment: 7000, impressions: 150000, clicks: 8000, ctr: 25.55, ctr_benchmark: 22.12, cpm: 450, cpc: 30, roas: 50 },
-    { name: 'MX_Q1_FY21_PS_CPS_CPS-Gaming_OMEN_OMG_Local__Omen____', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80, roas: 250 },
-    { name: 'Liverpool_MX_BRA_PS_CPS', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50, roas: null },
-    { name: 'MX_Q1_FY21_PS', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80 }
-  ];
-  private campaigns3 = [
-    { name: 'Liverpool_MX_BRA_PS_CPS', investment: 5000, impressions: 130000, clicks: 7000, ctr: 0.55, ctr_benchmark: 0.12, cpm: 750, cpc: 50, roas: null },
-    { name: 'MX_Q1_FY21_PS', investment: 2000, impressions: 80000, clicks: 4000, ctr: 10.30, ctr_benchmark: 11.20, cpm: 120, cpc: 80 },
-  ];
 
-  dataSource1 = new MatTableDataSource<any>(this.campaigns1);
-  dataSource2 = new MatTableDataSource<any>(this.campaigns2);
-  dataSource3 = new MatTableDataSource<any>(this.campaigns3);
+  private _campList;
+  get campList() {
+    return this._campList;
+  }
+  @Input() set campList(value) {
+    this._campList = value;
+    this.dataSource = new MatTableDataSource<any>(this.campList['campaigns']);
+  }
+
+  private _campListChange;
+  get campListChange() {
+    return this._campList;
+  }
+  @Input() set campListChange(value) {
+    this.campList.campaigns = value;
+    this.dataSource = new MatTableDataSource<any>(this.campList['campaigns']);
+    this.loadPaginator();
+  }
+
+  dataSource;
+  displayedColumns: string[] = ['name', 'investment', 'impressions', 'clicks', 'ctr', 'cpm', 'cpc', 'roas'];
 
   loadedPaginator: boolean;
 
-  // @ViewChild(MatPaginator) paginator: MatPaginator;
   @ViewChildren(MatPaginator) paginator = new QueryList<MatPaginator>();
 
   constructor() { }
@@ -53,9 +46,9 @@ export class CampaignsTablesComponent implements OnInit, AfterViewInit {
   }
 
   loadPaginator() {
-    this.dataSource1.paginator = this.paginator.toArray()[0];
-    this.dataSource2.paginator = this.paginator.toArray()[1];
-    this.dataSource3.paginator = this.paginator.toArray()[2];
+    this.dataSource.paginator = this.paginator.toArray()[0];
+    // this.dataSource2.paginator = this.paginator.toArray()[1];
+    // this.dataSource3.paginator = this.paginator.toArray()[2];
 
     for (let i = 0; i < this.paginator.toArray().length; i++) {
       this.paginator.toArray()[i]._intl.itemsPerPageLabel = 'Registros por página';

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -105,10 +105,12 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
 
     for (var i = 0; i < this.series.length; i++) {
       const color = colors[i] ? colors[i] : colors[0]
-      createSeries(this.value + i, this.series[i], this.value, this.valueName, this.valueFormat, color);
+      // createSeries(this.value + i, this.series[i], this.value, this.valueName, this.valueFormat, color);
+      createSeries(this.value + i, this.series[i], this.value, color);
     }
 
-    function createSeries(s, serieData, serieValueProp, serieValueName, serieValueFormat, color) {
+    // function createSeries(s, serieData, serieValueProp, serieValueName, serieValueFormat, color)
+    function createSeries(s, serieData, serieValueProp, color) {
       let name = serieData.name;
       let serie = serieData.serie;
 
@@ -118,7 +120,8 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
       series.name = name;
       series.tensionX = 0.85;
       series.strokeWidth = 2;
-      series.tooltipText = `${serieValueName ? serieValueName + ': ' : ''}[bold]${typeof serieValueFormat === 'string' ? serieValueFormat : ''} {valueY}[/]`;
+      // series.tooltipText = `${serieValueName ? serieValueName + ': ' : ''}[bold]${typeof serieValueFormat === 'string' ? serieValueFormat : ''} {valueY}[/]`;
+      series.tooltipText = `${serieData.name ? serieData.name + ': ' : ''}[bold]{valueY} ${typeof serieData.valueFormat === 'string' ? serieData.valueFormat : ''}[/]`;
       series.tooltip.getFillFromObject = false;
 
       if (serieData.customLineStye === 'dashed') {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -112,7 +112,8 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
-      this.filtersStateService.restoreFilters();
+      // removed line and used it from country & retailer components (init)
+      // this.filtersStateService.restoreFilters();
       this.getAllData();
     }
 

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -40,6 +40,7 @@ import { AcquisitionWrapperComponent } from './components/acquisition-wrapper/ac
 import { BehaviourWrapperComponent } from './components/behaviour-wrapper/behaviour-wrapper.component';
 import { ConversionWrapperComponent } from './components/conversion-wrapper/conversion-wrapper.component';
 import { OmnichatWrapperComponent } from './components/omnichat-wrapper/omnichat-wrapper.component';
+import { CampaignTowardsRetailWrapperComponent } from './components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component';
 
 // charts
 import { ChartBarComponent } from './components/charts/chart-bar/chart-bar.component';
@@ -96,6 +97,7 @@ import { StarRaitingComponent } from './components/star-raiting/star-raiting.com
     ChartGaugeComponent,
     ChartBarGroupComponent,
     StarRaitingComponent,
+    CampaignTowardsRetailWrapperComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/country/country.component.ts
+++ b/src/app/modules/dashboard/pages/country/country.component.ts
@@ -32,6 +32,10 @@ export class CountryComponent implements OnInit, OnDestroy {
     this.countryID = selectedCountry?.id && selectedCountry?.id;
     this.retailerID = selectedRetailer?.id && selectedRetailer?.id;
 
+    if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+      this.filtersStateService.restoreFilters();
+    }
+
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
       this.requestInfoSource.next(manualChange);
     });

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -28,18 +28,8 @@
     </ng-container>
 
     <ng-container *ngIf="activeTabView === 2">
-        <div class="row my-5">
-            <div class="col-12">
-                <div class="card">
-                    <div class="card-body">
-                        <app-chart-line-series [series]="campMetrics" name="campaign-metrics">
-                        </app-chart-line-series>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <app-campaigns-tables></app-campaigns-tables>
+        <app-campaign-towards-retail-wrapper [requestInfoChange]="requestInfoChange$">
+        </app-campaign-towards-retail-wrapper>
     </ng-container>
 
     <ng-container *ngIf="activeTabView === 3">

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -17,61 +17,6 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
   activeTabView: number = 1;
 
-  campMetrics = [
-    {
-      name: 'Inversión',
-      serie: [
-        { date: new Date(2021, 3, 15), value: 25000 },
-        { date: new Date(2021, 3, 16), value: 47000 },
-        { date: new Date(2021, 3, 17), value: 50000 },
-        { date: new Date(2021, 3, 18), value: 45000 },
-        { date: new Date(2021, 3, 19), value: 41000 },
-        { date: new Date(2021, 3, 20), value: 43500 },
-        { date: new Date(2021, 3, 21), value: 44000 },
-      ]
-    },
-    {
-      name: 'Impresiones',
-      serie: [
-        { date: new Date(2021, 3, 15), value: 20000 },
-        { date: new Date(2021, 3, 16), value: 35000 },
-        { date: new Date(2021, 3, 17), value: 40000 },
-        { date: new Date(2021, 3, 18), value: 36000 },
-        { date: new Date(2021, 3, 19), value: 38500 },
-        { date: new Date(2021, 3, 20), value: 37000 },
-        { date: new Date(2021, 3, 21), value: 38700 }
-      ],
-      customLineStye: 'dashed',
-      // customLineColor: '#228b22'
-    },
-    {
-      name: 'Clicks',
-      serie: [
-        { date: new Date(2021, 3, 15), value: 45000 },
-        { date: new Date(2021, 3, 16), value: 37000 },
-        { date: new Date(2021, 3, 17), value: 40000 },
-        { date: new Date(2021, 3, 18), value: 39000 },
-        { date: new Date(2021, 3, 19), value: 37000 },
-        { date: new Date(2021, 3, 20), value: 38500 },
-        { date: new Date(2021, 3, 21), value: 38000 }
-      ],
-      customLineStye: 'dashed'
-    },
-    {
-      name: 'Conversiones',
-      serie: [
-        { date: new Date(2021, 3, 15), value: 30000 },
-        { date: new Date(2021, 3, 16), value: 27510 },
-        { date: new Date(2021, 3, 17), value: 50000 },
-        { date: new Date(2021, 3, 18), value: 52000 },
-        { date: new Date(2021, 3, 19), value: 54000 },
-        { date: new Date(2021, 3, 20), value: 50000 },
-        { date: new Date(2021, 3, 21), value: 48000 },
-      ]
-    }
-  ]
-
-  getReqStatus: number = 0;
 
   stats: any[] = [
     {

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -96,8 +96,12 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
         if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
           if (this.retailerID) {
+
             this.filtersStateService.restoreFilters();
-            this.requestInfoSource.next();
+            if (this.activeTabView === 1) {
+              this.requestInfoSource.next();
+            }
+            this.activeTabView = 1;
           }
         }
       }

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -86,6 +86,10 @@ export class RetailerComponent implements OnInit, OnDestroy {
     const selectedRetailer = this.appStateService.selectedRetailer;
     this.retailerID = selectedRetailer?.id;
 
+    if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
+      this.filtersStateService.restoreFilters();
+    }
+
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
       this.requestInfoSource.next(manualChange);
     });

--- a/src/app/modules/dashboard/services/campaign-towards-retail.service.spec.ts
+++ b/src/app/modules/dashboard/services/campaign-towards-retail.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CampaignTowardsRetailService } from './campaign-towards-retail.service';
+
+describe('CampaignTowardsRetailService', () => {
+  let service: CampaignTowardsRetailService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CampaignTowardsRetailService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/services/campaign-towards-retail.service.ts
+++ b/src/app/modules/dashboard/services/campaign-towards-retail.service.ts
@@ -11,7 +11,6 @@ import { FiltersStateService } from './filters-state.service';
 export class CampaignTowardsRetailService {
   private baseUrl: string;
 
-  private countryID: number;
   private retailerID: number;
 
 
@@ -23,17 +22,8 @@ export class CampaignTowardsRetailService {
 
     this.baseUrl = this.config.endpoint;
 
-    const selectedCountry = this.appStateService.selectedCountry;
     const selectedRetailer = this.appStateService.selectedRetailer;
-
-    if (selectedCountry?.id || selectedRetailer?.id) {
-      this.countryID = selectedCountry?.id ? selectedCountry.id : undefined;
-      this.retailerID = selectedRetailer?.id ? selectedRetailer.id : undefined;
-    }
-
-    this.appStateService.selectedCountry$.subscribe(country => {
-      this.countryID = country?.id;
-    });
+    this.retailerID = selectedRetailer?.id ? selectedRetailer.id : undefined;
 
     this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;


### PR DESCRIPTION
# Problem Description
- Add API GET requests to use real data in "Campaña hacia el retail" section in retailer view

# Features
- Add **campaigns-towards-retail** service to add GET requests methods
- Add **campaign-towards-retail-wrapper** component
- Update **campaign-table** component to use dynamic data from its parent
- Update **chart-line-series** component to use different values format (displayed in tooltip) for each line serie
- Restore activeView variable value in retailer component in order to to position the user in the "Overview" tab each time the country or retailer changes

# Bug Fixes
- Remove restoreFilters method call from **overview-wrapper** component init
- Add **restoreFilters** method call from country and retailer components
Note: This fix is in order to reestablish the value of the filters when the user selects a country or a retailer but not when moving between tabs.

# Where this change will be used
- In retailer view > "Campaña hacia el retail" section at `/dashboard/retailer` path

# More details
![image](https://user-images.githubusercontent.com/38545126/120871002-1da7ca80-c560-11eb-9b78-ebbb60f0c243.png)
![image](https://user-images.githubusercontent.com/38545126/120871037-2ef0d700-c560-11eb-9f64-32992574eae0.png)
