### PR TITLE
use generic-table component instance in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -298,53 +298,10 @@
 
                     </div>
                     <div class="card-body">
-                        <div class="adaptable-container" [ngClass]="{'auto': topProductsReqStatus === 3}">
-                            <div class="loading-shade" [hidden]="topProductsReqStatus > 1">
-                                <mat-spinner></mat-spinner>
-                            </div>
-
-                            <table mat-table [dataSource]="topProductsSource">
-                                <!-- category column -->
-                                <ng-container matColumnDef="rank">
-                                    <th mat-header-cell *matHeaderCellDef [style.width.px]="150">Rank</th>
-                                    <td mat-cell *matCellDef="let element">
-                                        {{element.rank}} </td>
-                                </ng-container>
-
-                                <!-- product column -->
-                                <ng-container matColumnDef="product">
-                                    <th mat-header-cell *matHeaderCellDef>Producto </th>
-                                    <td mat-cell *matCellDef="let element">
-                                        <!-- <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.product"
-                                            matTooltipPosition="right" matTooltipClass="custom-tooltip">
-                                            {{element.product}}
-                                        </span> -->
-                                        <span>{{element.product}}</span>
-                                    </td>
-                                </ng-container>
-
-                                <!-- amount -->
-                                <ng-container matColumnDef="amount">
-                                    <th mat-header-cell *matHeaderCellDef [style.width.px]="150">Cantidad</th>
-                                    <td mat-cell *matCellDef="let element">
-                                        {{element.amount}} </td>
-                                </ng-container>
-
-                                <!-- ERROR COLUMN -->
-                                <ng-container matColumnDef="disclaimer">
-                                    <td mat-footer-cell *matFooterCellDef colspan="3">
-                                        <div class="text-danger text-center" [hidden]="topProductsReqStatus !== 3">
-                                            Ocurrió un error al consultar los productos
-                                        </div>
-                                    </td>
-                                </ng-container>
-
-                                <tr mat-header-row *matHeaderRowDef="topProductsColumns"></tr>
-                                <tr mat-row *matRowDef="let row; columns: topProductsColumns;"></tr>
-                                <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
-                                    [hidden]="topProductsReqStatus !== 3"></tr>
-                            </table>
-                        </div>
+                        <app-generic-table [displayedColumns]="topProductsColumns" [tableData]="topProducts"
+                            [tableDataChange]="topProducts.data" errorMsg="Error al consultar productos"
+                            emptyDataMsg="No se encontraron productos">
+                        </app-generic-table>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
@@ -16,10 +16,6 @@
     }
 }
 
-.card-header {
-    padding: 0.5rem 1.5rem;
-}
-
 .header {
    border-radius: 0.375rem;;
 }
@@ -53,81 +49,6 @@
             box-shadow: 0 2px 3px rgb(50 50 93 / 11%), 0 1px 3px rgb(0 0 0 / 8%);
         } 
     }
-}
-
-.chart-legend {
-    align-items: center;
-    display: flex;
-    justify-content: flex-end;
-    padding: 0 15px;
-
-    .legend-container {
-        align-items: center;
-        display: flex;
-       
-        .legend-square {
-            border-radius: 4px;
-            height: 25px;
-            margin-right: 4px;
-            width: 25px;
-
-            &.on {
-                background-color: #67B6DC;
-            }
-
-            &.off {
-                background-color: #e9e9e9;
-            }
-        }
-
-        .legend-label {
-            color: #000000;
-            font-size: 12px;
-        }
-    }
-}
-
-.adaptable-container {
-    min-height: 250px;
-    overflow: auto;
-    position: relative;
-   
-    table {
-        width: 100%;
-    
-        th:nth-of-type(n + 3),
-        td:nth-of-type(n + 3) {
-            text-align: center;
-        }
-    }
-
-    .lg-container {
-        max-width: 27rem;
-        span {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
-            max-width: inherit;
-            display: inline-block;
-        }
-    }
-
-    &.auto {
-        min-height: auto;
-    }
-}
-
-.loading-shade {
-    align-items: center;
-    background: rgba(0, 0, 0, 0.03);
-    bottom: 0px;
-    display: flex;
-    justify-content: center;
-    left: 0;
-    position: absolute;
-    right: 0;
-    top: 0;
-    z-index: 1;
 }
 
 .period-popover {

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { MatTableDataSource } from '@angular/material/table';
 import { Subscription } from 'rxjs';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { OverviewService } from '../../services/overview.service';
-import { equalsArrays } from 'src/app/tools/validators/arrays-comparator';
+import { TableItem } from '../../components/generic-table/generic-table.component';
 
 @Component({
   selector: 'app-overview-latam',
@@ -93,9 +92,28 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   investmentVsRevenue: any[] = [];
 
   // top products
-  topProductsColumns: string[] = ['rank', 'product', 'amount'];
-  topProducts: any[] = [];
-  topProductsSource = new MatTableDataSource<any>();
+  topProductsColumns: TableItem[] = [
+    {
+      name: 'rank',
+      title: 'Posición',
+      tooltip: true,
+    },
+    {
+      name: 'product',
+      title: 'Producto',
+      tooltip: true,
+    },
+    {
+      name: 'amount',
+      title: 'Cantidad',
+      textAlign: 'center'
+    }
+  ];
+
+  topProducts = {
+    data: [],
+    reqStatus: 0
+  }
 
   // requests status
   kpisReqStatus: number = 0;
@@ -108,7 +126,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     { name: 'age', reqStatus: 0 },
     { name: 'gender-and-age', reqStatus: 0 }
   ];
-  topProductsReqStatus: number = 0;
 
   // available tabs
   selectedCategories: any[] = []; // for topProducts and usersAndSalesByMetric
@@ -285,19 +302,17 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   getTopProducts(selectedCategory?: any) {
-    this.topProductsReqStatus = 1;
+    this.topProducts.reqStatus = 1;
     this.selectedCategoryTab2 = selectedCategory;
     this.overviewService.getTopProductsLatam(selectedCategory.id).subscribe(
       (resp: any[]) => {
-        this.topProducts = resp;
-
-        this.topProductsSource = new MatTableDataSource<any>(this.topProducts);
-        this.topProductsReqStatus = 2;
+        this.topProducts.data = resp;
+        this.topProducts.reqStatus = 2;
       },
       error => {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-latam.component]: ${errorMsg}`);
-        this.topProductsReqStatus = 3;
+        this.topProducts.reqStatus = 3;
       }
     )
 


### PR DESCRIPTION
# Problem Description
- In order to reduce code lines and reuse code replace mat-table by generic-table component in LATAM overview > Top Products table

# Features
- Use generic-table component instance in overview-latam component

# Where this change will be used
- In  LATAM overview > Top Products table at `/dashboard/main-region?main-region=latam` path

# More details
![image](https://user-images.githubusercontent.com/38545126/120899965-eedd3300-c5f7-11eb-85d1-def5bf244dc2.png)
