### PR TITLE
remove countries query params in latam requests made from overview service

### DIFF
--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -55,10 +55,11 @@ export class OverviewService {
     if (!isLatam) {
       return `${baseQParams}${campaigns ? `&campaigns=${campaigns}` : ''}`;
     } else {
-      let countries = this.filtersStateService.countriesQParams;
+      // let countries = this.filtersStateService.countriesQParams; 
+      // * NOTE: countries deprecated in LATAM endpoint, now with retailers list is enough
       let retailers = this.filtersStateService.retailersQParams;
       let sources = !uniqueSourceID ? this.filtersStateService.sourcesQParams : uniqueSourceID;
-      return `countries=${countries}&retailers=${retailers}&sources=${sources}&${baseQParams}`;
+      return `retailers=${retailers}&sources=${sources}&${baseQParams}`;
     }
   }
 


### PR DESCRIPTION
# Problem Description
- After changes in country and retailer filters behaviour (#142) countries query param is deprecated because in all cases is enough with retailers query param

# Features
- Remove countries query params in latam requests made from overview service

# Where this change will be used
- In LATAM overview requests

# More details
- Request example:
![image](https://user-images.githubusercontent.com/38545126/120942440-8ae96600-c6ee-11eb-97c6-4659bba17023.png)
