### PR TITLE
hide top products in overview-latam component template

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -271,7 +271,7 @@
             </div>
         </div>
 
-        <div class="row mt-5">
+        <div class="row mt-5" [hidden]="true">
             <div class="col-12" *ngIf="selectedCategories.length > 1">
                 <div class="pills-container mb-4">
                     <ul class="nav nav-pills nav-fill">


### PR DESCRIPTION
# Problem Description
- To prevent confusions "Top Products" section in LATAM overview will be hidden because there isn't available data yet.

# Features
- Hide top products section container

# Where this change will be used
- In LATAM overview at `/dashboard/main-region?main-region=latam` path