### PR TITLE
update card-stat component to improve responsive display

### DIFF
--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -5,26 +5,28 @@
                 <p class="card-title text-uppercase text-muted mb-0"
                     [ngClass]="{'h4': !smallHeader, 'h5': smallHeader}">{{ stat.metricTitle }}</p>
                 <!-- content -->
-                <ng-container *ngIf="!loader">
+                <p *ngIf="!loader" class="metric-details">
                     <ng-container [ngSwitch]="stat.metricFormat">
-                        <span *ngSwitchCase="'percentage'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue | number : '1.2-2' }}%
-                        </span>
-                        <span *ngSwitchCase="'decimals'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue | number : '1.2-2' }}
-                        </span>
-                        <span *ngSwitchCase="'integer'" class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue | number : '1.0-0' }}
-                        </span>
+                        <div class="h3 font-weight-bold mb-0" [ngClass]="{'mr-1': stat.metricSymbol}">
+                            <span *ngSwitchCase="'percentage'">
+                                {{ stat.metricValue | number : '1.2-2' }}%
+                            </span>
+                            <span *ngSwitchCase="'decimals'">
+                                {{ stat.metricValue | number : '1.2-2' }}
+                            </span>
+                            <span *ngSwitchCase="'integer'">
+                                {{ stat.metricValue | number : '1.0-0' }}
+                            </span>
 
-                        <app-star-raiting *ngSwitchCase="'score'" [value]="stat.metricValue"></app-star-raiting>
+                            <app-star-raiting *ngSwitchCase="'score'" [value]="stat.metricValue"></app-star-raiting>
 
-                        <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
-                            {{ stat.metricValue }}
-                        </span>
+                            <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
+                                {{ stat.metricValue }}
+                            </span>
+                        </div>
                     </ng-container>
                     <span class="h3 font-weight-bold mb-0">{{ stat.metricSymbol }}</span>
-                </ng-container>
+                </p>
 
                 <!-- loader -->
                 <ng-container *ngIf="loader">
@@ -41,7 +43,7 @@
             <div class="submetric-data my-0 h5">
                 <span class="text-nowrap mr-2 text-muted text-uppercase">{{ stat.subMetricTitle }}</span>
                 <!-- content -->
-                <ng-container *ngIf="!loader">
+                <p *ngIf="!loader" class="submetric-details">
                     <ng-container [ngSwitch]="stat.subMetricFormat">
                         <span *ngSwitchCase="'percentage'" class="text-muted">
                             {{ stat.subMetricValue | number : '1.2-2' }}%
@@ -56,8 +58,8 @@
                             {{ stat.subMetricValue }}
                         </span>
                     </ng-container>
-                    <span class="text-muted">{{ stat.subMetricSymbol }}</span>
-                </ng-container>
+                    <span class="text-muted ml-2">{{ stat.subMetricSymbol }}</span>
+                </p>
 
                 <!-- loader -->
                 <ng-container *ngIf="loader">

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
@@ -8,14 +8,30 @@
     
     .metric-container {
         display: grid;
-        grid-template-columns: 1fr;
         gap: 16px;
-        padding: 1rem 1.5rem;
+        grid-template-columns: 1fr;
         height: calc(100% - 24px);
+        padding: 1rem 1.5rem;
 
-        .card-title {
-            @media screen and (min-width: 1200px) and (max-width: 1328px){
+        @media screen and (min-width: 1200px) and (max-width: 1328px) {
+            grid-template-columns: 1fr;
+            .icon {
+                display: none;
+            }
+    
+            .card-title {
                 line-height: 16px;
+            }
+        }
+    
+        .metric-details {
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
+            margin-bottom: 0;
+        
+            span {
+                display: inline-block;
             }
         }
         
@@ -40,10 +56,22 @@
         width: 100%;
     
         .submetric-data {
-            padding: 0.3rem 1.5rem;
+            align-items: center;
+            display: flex;
+            flex-wrap: wrap;
             height: 25px;
             overflow: hidden;
+            padding: 0.1rem 1.5rem;
             text-overflow: ellipsis;
+        }
+
+        .submetric-details {
+            font-size: 13px;
+            margin-bottom: 0;
+           
+            span {
+                display: inline-block;
+            }
         }
     }
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
@@ -1,18 +1,18 @@
 .stats-container {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 20px;
 
     @media screen and (max-width: 1200px) {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
     @media screen and (max-width: 1000px) {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     @media screen and (max-width: 480px) {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
@@ -1,18 +1,18 @@
 .stats-container {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 20px;
 
     @media screen and (max-width: 1200px) {
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 
     @media screen and (max-width: 1000px) {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     @media screen and (max-width: 480px) {
-        grid-template-columns: 1fr;
+        grid-template-columns: minmax(0, 1fr);
     }
 }
 


### PR DESCRIPTION
# Problem Description
- When this component is used to display a set of cards in a row as in LATAM or country overview there is a overflow behaviour

# Bug Fixes
- update card-stat component to hide displayed metric icons when there isn't enough space on screen
- update overview-latam and overview-country-wrappers component to prevent overflow behaviour

# Where this change will be used
- Where card-stat component will be used

# More details
- Before changes:
![image](https://user-images.githubusercontent.com/38545126/121060998-ef590380-c788-11eb-9a72-5e12e90fe5fb.png)

- After changes:
![image](https://user-images.githubusercontent.com/38545126/121061062-026bd380-c789-11eb-8548-709e0ffb3484.png)