### PR TITLE
show different filters in general-filter-component based on the current page the user is on

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -130,7 +130,8 @@
         </div>
 
         <!-- sector -->
-        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
+        <div class="col-12 col-sm-6 mb-4" [hidden]="currentPage === 'tools'"
+            [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <span class="mb-1 h4">Sector</span>
             <mat-select formControlName="sectors" multiple placeholder="Selecciona un Sector" disableOptionCentering>
                 <mat-select-trigger>
@@ -215,7 +216,7 @@
         </div>
 
         <!-- campaign -->
-        <div [hidden]="!retailerID" class="col-12 col-sm-6 col-lg-3 mb-4">
+        <div [hidden]="!retailerID || currentPage === 'tools'" class="col-12 col-sm-6 col-lg-3 mb-4">
             <span class="mb-1 h4">Campaña</span>
             <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña" disableOptionCentering
                 [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsErrorMsg">
@@ -272,7 +273,7 @@
         </div>
 
         <!-- source -->
-        <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
+        <div [hidden]="!isLatamSelected || currentPage === 'tools'" class="col-12 col-sm-6 col-lg-2 mb-4">
             <span class="mb-1 h4">Fuente</span>
             <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente" disableOptionCentering>
                 <mat-select-trigger>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -112,6 +112,8 @@ export class GeneralFiltersComponent implements OnInit {
 
   campsGetByRetailerChange: boolean;
 
+  currentPage: string; // overview | tools;
+
   @ViewChild('allSelectedCountries') private allSelectedCountries: MatOption;
   @ViewChild('allSelectedRetailers') private allSelectedRetailers: MatOption;
   @ViewChild('allSelectedSectors') private allSelectedSectors: MatOption;
@@ -148,14 +150,19 @@ export class GeneralFiltersComponent implements OnInit {
       this.applyFilters();
     });
 
+    this.getCurrentPage();
+
     this.routeSub = this.router.events.pipe(
       filter(event => event instanceof NavigationEnd)
     )
       .subscribe(event => {
-        if (event instanceof NavigationEnd)
+        if (event instanceof NavigationEnd) {
+          this.getCurrentPage();
+
           this.loadLatamContent().then(() => {
             this.isLatamSelected && this.applyFilters();
           });
+        }
       });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
@@ -172,6 +179,16 @@ export class GeneralFiltersComponent implements OnInit {
       this.countryID = country?.id;
       this.restoreFilters();
     });
+  }
+
+  getCurrentPage() {
+    if (this.router.url.includes('main-region?') || this.router.url.includes('country?') || this.router.url.includes('retailer?')) {
+      this.currentPage = 'overview';
+    } else if (this.router.url.includes('tools?')) {
+      this.currentPage = 'tools';
+    } else {
+      delete this.currentPage;
+    }
   }
 
   restoreFilters() {


### PR DESCRIPTION
# Problem Description
- Show different filters in general-filter-component based on the current page the user is on.

# Features
- Add a variable in general-filters component to update it when the is a change of route and use its value to show or hide filters

# Where this change will be used
- In dashboard module where general-filters component will be use

# More details
- LATAM overview filters:
![image](https://user-images.githubusercontent.com/38545126/121112858-ad56ae80-c7d6-11eb-8697-15acff1a6c97.png)

- LATAM other tools (indexado & omnichat) filters:
![image](https://user-images.githubusercontent.com/38545126/121112903-c3fd0580-c7d6-11eb-9ddb-982ee78611b9.png)

- Country overview filters:
![image](https://user-images.githubusercontent.com/38545126/121112944-d4ad7b80-c7d6-11eb-8e34-657b648655d7.png)

- Country other tools (indexado & omnichat) filters:
![image](https://user-images.githubusercontent.com/38545126/121112984-e3942e00-c7d6-11eb-9db5-d862c657bb9e.png)

- Retailer overview filters:
![image](https://user-images.githubusercontent.com/38545126/121113027-f444a400-c7d6-11eb-869b-a922433112b9.png)

- Retailer other tools (indexado & omnichat) filters:
![image](https://user-images.githubusercontent.com/38545126/121113060-032b5680-c7d7-11eb-8660-8cf4ceda3e27.png)
