### PR TITLE
update chart-line-comparison component

### DIFF
--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -303,7 +303,7 @@
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">Conversiones y tráfico por día de la semana</span>
+                    <span class="h4">Conversiones y tráfico por día</span>
                 </div>
                 <div class="card-body">
                     <app-chart-line-comparison [data]="conversionsTrafficPerDay" name="conv-tra-day"
@@ -319,7 +319,7 @@
                 </div>
                 <div class="card-body">
                     <app-chart-line-comparison [data]="conversionsTrafficPerHour" name="conv-tra-hour"
-                        valueName1="Conversiones" valueName2="Tráfico">
+                        valueName1="Conversiones" valueName2="Tráfico" inputDateFormat="HH:mm">
                     </app-chart-line-comparison>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
@@ -1260,23 +1260,24 @@ export class AudiencesWrapperComponent implements OnInit {
   ]
 
   conversionsTrafficPerDay = [
-    { date: new Date(2021, 3, 15), value1: 150, value2: 280, previousDate: new Date(2021, 3, 12) },
-    { date: new Date(2021, 3, 16), value1: 280, value2: 550, previousDate: new Date(2021, 3, 13) },
-    { date: new Date(2021, 3, 17), value1: 130, value2: 430, previousDate: new Date(2021, 3, 14) },
-    { date: new Date(2021, 3, 18), value1: 140, value2: 470, previousDate: new Date(2021, 3, 15) },
-    { date: new Date(2021, 3, 19), value1: 160, value2: 500, previousDate: new Date(2021, 2, 16) },
-    { date: new Date(2021, 3, 20), value1: 80, value2: 750, previousDate: new Date(2021, 2, 17) },
-    { date: new Date(2021, 3, 21), value1: 88, value2: 650, previousDate: new Date(2021, 2, 18) }
+    { date: new Date(2021, 3, 15), value1: 150, value2: 280, },
+    { date: new Date(2021, 3, 16), value1: 280, value2: 550 },
+    { date: new Date(2021, 3, 17), value1: 130, value2: 430 },
+    { date: new Date(2021, 3, 18), value1: 140, value2: 470 },
+    { date: new Date(2021, 3, 19), value1: 160, value2: 500 },
+    { date: new Date(2021, 3, 20), value1: 80, value2: 750 },
+    { date: new Date(2021, 3, 21), value1: 88, value2: 650 }
   ]
 
   conversionsTrafficPerHour = [
-    { date: new Date(2021, 3, 15, 9, 0, 0), value1: 2, value2: 16, previousDate: new Date(2021, 3, 15, 9, 0, 0) },
-    { date: new Date(2021, 3, 15, 12, 0, 0), value1: 9, value2: 45, previousDate: new Date(2021, 3, 15, 12, 0, 0) },
-    { date: new Date(2021, 3, 15, 13, 0, 0), value1: 14, value2: 62, previousDate: new Date(2021, 3, 15, 13, 0, 0) },
-    { date: new Date(2021, 3, 15, 15, 0, 0), value1: 10, value2: 180, previousDate: new Date(2021, 3, 15, 15, 0, 0) },
-    { date: new Date(2021, 3, 15, 18, 0, 0), value1: 6, value2: 140, previousDate: new Date(2021, 3, 15, 18, 0, 0) },
-    { date: new Date(2021, 3, 15, 22, 0, 0), value1: 3, value2: 60, previousDate: new Date(2021, 3, 15, 22, 0, 0) },
-    { date: new Date(2021, 3, 15, 23, 0, 0), value1: 9, value2: 140, previousDate: new Date(2021, 3, 15, 23, 0, 0) }
+    { date: '07:00', value1: 2, value2: 16 },
+    { date: '09:00', value1: 9, value2: 45 },
+    { date: '12:00', value1: 13, value2: 30 },
+    { date: '15:00', value1: 10, value2: 18 },
+    { date: '18:00', value1: 16, value2: 50 },
+    { date: '20:00', value1: 6, value2: 16 },
+    { date: '22:00', value1: 3, value2: 60 },
+    { date: '23:00', value1: 9, value2: 14 }
   ]
 
 

--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -14,6 +14,7 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
   @Input() value2: string = 'value2';
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() inputDateFormat: string; // date format in data array e.g yyyy-MM-dd HH:mm:ss | HH:mm. Char by default uses: yyyy-MM-dd
 
   chart;
   chartID;
@@ -95,6 +96,10 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
     dateAxis.renderer.minGridDistance = 50;
     dateAxis.renderer.labels.template.fontSize = 12;
+
+    if (this.inputDateFormat) {
+      chart.dateFormatter.inputDateFormat = this.inputDateFormat;
+    }
 
     let valueAxis = chart.yAxes.push(new am4charts.ValueAxis());
     valueAxis.renderer.labels.template.fontSize = 12;


### PR DESCRIPTION
# Problem Description
- It is necessary to use a different date format in the data provided for the chart-line-comparison component, this in the case of charts that represent a time (hour) as a period on the x-axis

# Features
- Add inputDateFormat input in chart-line-comparison component and use it if exists as a property
- Update data in audiences-wrapper component and add inputDateFormat property in chart-line.comparison component instance

# Where this change will be used
- Where this component will be used (e.g audiences-wrapper component in "Campa en el retail" > "Audiencias" section

# More details
![image](https://user-images.githubusercontent.com/38545126/121227730-87222480-c851-11eb-97bc-e39cf74da45f.png)

