### PR TITLE
use different characters for decimal and thousand separators in spanish, portuguese and english versions

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { NgModule } from '@angular/core';
+import { LOCALE_ID, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
@@ -22,6 +22,10 @@ import { LoginGuard } from './login.guard';
 import { ConfigurationProvider } from './app.constants';
 import { SharedModule } from './modules/shared/shared.module';
 import { AppStateService } from './services/app-state.service';
+
+import localeEsAr from '@angular/common/locales/es-AR';
+import { registerLocaleData } from '@angular/common';
+registerLocaleData(localeEsAr);
 
 @NgModule({
   imports: [
@@ -52,7 +56,8 @@ import { AppStateService } from './services/app-state.service';
       useClass: SessionInterceptor,
       multi: true
     },
-    ConfigurationProvider
+    ConfigurationProvider,
+    { provide: LOCALE_ID, useValue: 'es-Ar' },
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
-import am4lang_es_ES from '@amcharts/amcharts4/lang/es_ES';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-bar-group',
@@ -53,15 +53,13 @@ export class ChartBarGroupComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
-
-    chart.numberFormatter.numberFormat = '#,###.##';
-    chart.language.locale = am4lang_es_ES;
-    chart.language.locale['_decimalSeparator'] = '.';
-    chart.language.locale['_thousandSeparator'] = ',';
-
     chart.paddingBottom = 50;
     chart.cursor = new am4charts.XYCursor();
 
@@ -214,6 +212,7 @@ export class ChartBarGroupComponent implements OnInit, AfterViewInit {
 
     chart.data = chartData;
     this.chart = chart;
+    loadLanguage(chart, lang);
 
     // last tick
     let range = categoryAxis.axisRanges.create();

--- a/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-bar-horizontal',
@@ -51,10 +52,15 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
 
     let categoryAxis = chart.yAxes.push(new am4charts.CategoryAxis());
     categoryAxis.dataFields.category = this.category;

--- a/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-bar',
@@ -38,13 +39,18 @@ export class ChartBarComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+   * Load chart 
+   * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+   */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
     // chart.scrollbarX = new am4core.Scrollbar();
 
     chart.data = this.data;
+    loadLanguage(chart, lang);
 
     // Create axes
     let categoryAxis = chart.xAxes.push(new am4charts.CategoryAxis());

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-column-line-mix',
@@ -40,7 +41,11 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     this.loadStatus = 1;
 
     am4core.useTheme(am4themes_animated);
@@ -48,8 +53,7 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
     // Create chart instance
     var chart = am4core.create(this.chartID, am4charts.XYChart);
     chart.data = this.data;
-    chart.numberFormatter.numberFormat = '#,###.##';
-
+    loadLanguage(chart, lang);
     // chart.exporting.menu = new am4core.ExportMenu();
 
     /* Create axes */
@@ -68,7 +72,7 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
     columnSeries.dataFields.valueY = this.columnValue;
     columnSeries.dataFields.categoryX = this.category;
 
-    columnSeries.columns.template.tooltipText = `[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 20px]{valueY}[/] [#fff]{additional} ${this.valueFormat ? this.valueFormat : ''}[/]`
+    columnSeries.columns.template.tooltipText = `[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 16px]{valueY}[/] [#fff]{additional} ${this.valueFormat ? this.valueFormat : ''}[/]`
     columnSeries.columns.template.propertyFields.fillOpacity = 'fillOpacity';
     columnSeries.columns.template.propertyFields.stroke = 'stroke';
     columnSeries.columns.template.propertyFields.strokeWidth = 'strokeWidth';
@@ -77,18 +81,18 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
     columnSeries.columns.template.column.cornerRadiusTopLeft = 10;
     columnSeries.columns.template.column.cornerRadiusTopRight = 10;
     columnSeries.columns.template.column.fillOpacity = 0.8;
-    columnSeries.columns.template.adapter.add("fill", function (fill, target) {
+    columnSeries.columns.template.adapter.add('fill', function (fill, target) {
       if (target.dataItem && target.dataItem._index % 2) {
-        return am4core.color("#85A8E3");
+        return am4core.color('#85A8E3');
       }
       else {
         return fill;
       }
     });
 
-    columnSeries.columns.template.adapter.add("stroke", (value, target, key) => {
+    columnSeries.columns.template.adapter.add('stroke', (value, target, key) => {
       if (target.dataItem && target.dataItem._index % 2) {
-        return am4core.color("#85A8E3");
+        return am4core.color('#85A8E3');
       }
       else {
         return value;
@@ -107,7 +111,7 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit {
 
     let bullet = lineSeries.bullets.push(new am4charts.Bullet());
     bullet.fill = am4core.color('#fdd400'); // tooltips grab fill from parent by default
-    bullet.tooltipText = `[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 20px]{valueY}[/] [#fff]{additional} ${this.valueFormat ? this.valueFormat : ''}[/]`
+    bullet.tooltipText = `[#fff font-size: 15px]{name} en {categoryX}:\n[/][#fff font-size: 16px]{valueY}[/] [#fff]{additional} ${this.valueFormat ? this.valueFormat : ''}[/]`
     let circle = bullet.createChild(am4core.Circle);
     circle.radius = 4;
     circle.fill = am4core.color('#fff');

--- a/src/app/modules/dashboard/components/charts/chart-gauge/chart-gauge.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-gauge/chart-gauge.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-gauge',
@@ -36,7 +37,11 @@ export class ChartGaugeComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
 
     let chart = am4core.create(this.chartID, am4charts.GaugeChart);
@@ -84,7 +89,7 @@ export class ChartGaugeComponent implements OnInit, AfterViewInit {
     label.horizontalCenter = 'middle';
     label.verticalCenter = 'bottom';
     label.text = `${this.value}%`;
+
+    loadLanguage(chart, lang);
   }
-
-
 }

--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-heat-map',
@@ -72,7 +73,11 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+  * Load chart 
+  * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+  */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
 
     let chart = am4core.create(this.chartID, am4charts.XYChart);
@@ -127,6 +132,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
     });
 
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
 
     if (!this.showHeatLegend) {
       return;

--- a/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-comparison/chart-line-comparison.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
-import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-line-comparison',
@@ -83,13 +83,14 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     this.loadStatus = 1;
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
-    chart.language.locale = am4lang_es_ES;
-    chart.language.locale["_decimalSeparator"] = ".";
-    chart.language.locale["_thousandSeparator"] = ",";
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
@@ -137,6 +138,7 @@ export class ChartLineComparisonComponent implements OnInit, AfterViewInit {
 
     this.loadChartData(chart);
     this.loadNamesAndFormats();
+    loadLanguage(chart, lang);
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
-import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-line-series',
@@ -39,6 +39,7 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
   }
 
   chart;
+  axis: any;
 
   constructor() { }
 
@@ -49,14 +50,14 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+   * Load chart 
+   * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+   */
+  loadChart(lang?: string) {
     this.loadStatus = 1;
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
-    chart.numberFormatter.numberFormat = '#,###.##';
-    chart.language.locale = am4lang_es_ES;
-    chart.language.locale["_decimalSeparator"] = ".";
-    chart.language.locale["_thousandSeparator"] = ",";
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
@@ -69,12 +70,12 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
     // dateAxis.renderer.labels.template.rotation = -90;
 
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
 
     chart.legend = new am4charts.Legend();
     chart.legend.position = 'bottom';
     chart.legend.align = 'center';
     chart.legend.contentAlign = 'center';
-
     chart.legend.scrollable = true;
 
     chart.legend.itemContainers.template.events.on('over', function (event) {

--- a/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line/chart-line.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
-import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-line',
@@ -35,16 +35,18 @@ export class ChartLineComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+ * Load chart 
+ * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     // Create chart instance
     let chart = am4core.create(this.chartID, am4charts.XYChart);
-    chart.language.locale = am4lang_es_ES;
-    chart.language.locale["_decimalSeparator"] = ".";
-    chart.language.locale["_thousandSeparator"] = ",";
 
     // Add data
     chart.data = this.data;
+    loadLanguage(chart, lang);
 
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit, AfterViewInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-lollipop',
@@ -72,11 +73,16 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+   * Load chart 
+   * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+   */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
 
     let chart = am4core.create(this.graphID, am4charts.XYChart);
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
 
     let categoryAxis = chart.xAxes.push(new am4charts.CategoryAxis());
     categoryAxis.renderer.grid.template.location = 0;

--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
-import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-multiple-axes',
@@ -84,14 +84,13 @@ export class ChartMultipleAxesComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+   * Loads chart 
+   * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+   */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
-    chart.numberFormatter.numberFormat = '#,###.##';
-    chart.language.locale = am4lang_es_ES;
-    chart.language.locale["_decimalSeparator"] = ".";
-    chart.language.locale["_thousandSeparator"] = ",";
-
     // Create axes
     let dateAxis = chart.xAxes.push(new am4charts.DateAxis());
     dateAxis.renderer.labels.template.fontSize = 12;
@@ -148,6 +147,7 @@ export class ChartMultipleAxesComponent implements OnInit, AfterViewInit {
     this.axis = { valueAxis1, valueAxis2 };
 
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-pictorial',
@@ -52,7 +53,11 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+   * Load chart 
+   * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+   */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
 
     let iconPath = this.iconPath ? this.iconPath : this.getIconPath();
@@ -108,6 +113,7 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit {
 
     chart.responsive.enabled = true;
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
   }
 
   getIconPath(): string {

--- a/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
@@ -3,6 +3,7 @@ import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 import { isPlatformBrowser } from '@angular/common';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-pie',
@@ -61,13 +62,19 @@ export class ChartPieComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+  * Load chart 
+  * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+  */
+  loadChart(lang?: string) {
     this.browserOnly(() => {
       this.loadStatus = 1;
       // Chart code goes in here
       am4core.useTheme(am4themes_animated);
       let chart = am4core.create(this.chartID, am4charts.PieChart);
+
       this.loadChartData(chart);
+      loadLanguage(chart, lang);
 
       // Add and configure Series
       let pieSeries = chart.series.push(new am4charts.PieSeries());

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -2,6 +2,7 @@ import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
+import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 
 @Component({
   selector: 'app-chart-pyramid',
@@ -63,11 +64,16 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     this.loadChart();
   }
 
-  loadChart() {
+  /**
+  * Load chart 
+  * @param [lang] 'es': Spanish | 'en': English | 'pt': Portuguese
+  */
+  loadChart(lang?: string) {
     am4core.useTheme(am4themes_animated);
     let chart = am4core.create(this.chartID, am4charts.XYChart);
 
     this.loadChartData(chart);
+    loadLanguage(chart, lang);
 
     // Use only absolute numbers
     // chart.numberFormatter.numberFormat = '#.#s';

--- a/src/app/tools/functions/chart-lang.ts
+++ b/src/app/tools/functions/chart-lang.ts
@@ -1,7 +1,7 @@
 import * as am4core from '@amcharts/amcharts4/core';
-import am4lang_en_US from "@amcharts/amcharts4/lang/en_US";
-import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
-import am4lang_pt_BR from "@amcharts/amcharts4/lang/pt_BR";
+import am4lang_en_US from '@amcharts/amcharts4/lang/en_US';
+import am4lang_es_ES from '@amcharts/amcharts4/lang/es_ES';
+import am4lang_pt_BR from '@amcharts/amcharts4/lang/pt_BR';
 
 // pt_BR (Portuguese) uses ',' character as decimal separator and '.' for thousand separator
 // es_ES and en_US  (Spanish and English) use '.' character as decimal separator and ',' for thousand separator

--- a/src/app/tools/functions/chart-lang.ts
+++ b/src/app/tools/functions/chart-lang.ts
@@ -1,0 +1,42 @@
+import * as am4core from '@amcharts/amcharts4/core';
+import am4lang_en_US from "@amcharts/amcharts4/lang/en_US";
+import am4lang_es_ES from "@amcharts/amcharts4/lang/es_ES";
+import am4lang_pt_BR from "@amcharts/amcharts4/lang/pt_BR";
+
+// pt_BR (Portuguese) uses ',' character as decimal separator and '.' for thousand separator
+// es_ES and en_US  (Spanish and English) use '.' character as decimal separator and ',' for thousand separator
+// Is required use: 
+//    a) For Spanish and Portuguese language: ',' character as decimal separator and '.' for thousand separator
+//    b) For English language: '.' character as decimal separator and ',' for thousand separator
+
+/**
+ * load Language
+ * @param chart chart instance
+ * @param lang // 'es': Spanish | 'en': English | 'pt': Portuguese
+ */
+
+export function loadLanguage(chart, lang?: string) {
+    let am4LangDate;
+    let am4LangNumber;
+    switch (lang) {
+        case 'en':
+            am4LangDate = am4lang_en_US;
+            am4LangNumber = am4lang_en_US;
+            break;
+        case 'pt':
+            am4LangDate = am4lang_pt_BR;
+            am4LangNumber = am4lang_pt_BR;
+            break;
+
+        default:
+            am4LangDate = am4lang_es_ES;
+            am4LangNumber = am4lang_pt_BR;
+    }
+
+    chart.dateFormatter.language = new am4core.Language();
+    chart.dateFormatter.language.locale = am4LangDate;
+
+    chart.numberFormatter.numberFormat = '#,###.##';
+    chart.numberFormatter.language = new am4core.Language();
+    chart.numberFormatter.language.locale = am4LangNumber;
+}


### PR DESCRIPTION
# Problem Description
- Setup app default language in order to use different characters for decimal and thousand separators in Spanish, Portuguese and English versions
   - For Spanish and Portuguese language: ',' character as decimal separator and '.' for thousand separator
   - For English language: '.' character as decimal separator and ',' for thousand separator

# Features
- Add default locale language in app module
- Add function in tools to load language in a chart component
- Use loadLanguage function method in charts components

# Where this change will be used
- In copys where a currency o number pipe will be use inside the app
- In charts components numbers and dates

# More details
![image](https://user-images.githubusercontent.com/38545126/121248061-93fe4280-c868-11eb-808c-b1cdebf928db.png)
![image](https://user-images.githubusercontent.com/38545126/121248106-a37d8b80-c868-11eb-93e7-63ecbfbec22c.png)
