### PR TITLE
add i18n to sidebar, general-filters and latam-overview components

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -31,7 +31,7 @@
           <!-- <div class="dropdown-divider"></div> -->
           <a class="dropdown-item" (click)="logout()">
             <i class="ni ni-user-run"></i>
-            <span class="mb-0 text-sm font-weight-bold"> | {{ 'navbar.logout' | translate }}</span>
+            <span class="mb-0 text-sm">{{ 'navbar.logout' | translate }}</span>
           </a>
         </div>
       </li>
@@ -40,17 +40,17 @@
         <a class="nav-link pr-0" role="button" ngbDropdownToggle>
           <div class="media align-items-center">
             <i class="fas fa-globe"></i>
-            <span class="ml-2"> {{ lang }} </span>
+            <span class="ml-2">{{ lang | uppercase }}</span>
           </div>
         </a>
         <div class="dropdown-menu-arrow dropdown-menu-right" ngbDropdownMenu>
-          <a class="dropdown-item" (click)="changeLang('en')">
+          <a class="dropdown-item" (click)="changeLang('en')" [hidden]="lang === 'en'">
             <span>{{ 'navbar.english' | translate }}</span>
           </a>
-          <a class="dropdown-item" (click)="changeLang('pt')">
+          <a class="dropdown-item" (click)="changeLang('pt')" [hidden]="lang === 'pt'">
             <span>{{ 'navbar.portuguese' | translate }}</span>
           </a>
-          <a class="dropdown-item" (click)="changeLang('es')">
+          <a class="dropdown-item" (click)="changeLang('es')" [hidden]="lang === 'es'">
             <span>{{ 'navbar.spanish' | translate }}</span>
           </a>
         </div>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -32,7 +32,7 @@
           <!-- <div class="dropdown-divider"></div> -->
           <a class="dropdown-item" (click)="logout()">
             <i class="ni ni-user-run"></i>
-            <span>Cerrar sesión</span>
+            <span>{{ 'navbar.logout' | translate }}</span>
           </a>
         </div>
       </li>
@@ -71,9 +71,9 @@
       <ul class="navbar-nav" *ngIf="menuItems?.length > 1">
         <ng-container *ngFor="let menuItem of menuItems">
 
-          <div class="admin-header" *ngIf="menuItem.title === 'Administrador'">
+          <div class="admin-header" *ngIf="menuItem.id === 'admin' && menuItem.isForAdmin && userIsAdmin">
             <hr class="my-3">
-            <h6 class="navbar-heading text-muted">Configuración</h6>
+            <h6 class="navbar-heading text-muted">{{ 'dashboard.settings' | translate }}</h6>
           </div>
 
           <li class="{{menuItem.class}} nav-item" *ngIf="!menuItem.isForAdmin || (menuItem.isForAdmin && userIsAdmin)">
@@ -129,8 +129,11 @@
 
       <div class="text-danger mt-5 pl-3 pr-3" *ngIf="menuReqStatus === 3 || submenuReqStatus === 3">
         <small>
-          Ocurrió un error al consultar los {{ userRole === 'retailer' ? 'retailers' : 'países o retailers' }} a los que
-          tienes acceso. Intenta más tarde.
+          {{
+          ('dashboard.sidebarError1' | translate) + ' ' +
+          ((userRole === 'retailer' ? 'retailers' : 'dashboard.sidebarError2') | translate) + ' ' +
+          ('dashboard.sidebarError3' | translate)
+          }}
         </small>
       </div>
 

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -66,49 +66,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
     });
   }
 
-  loadI18nMenuItems(menuItems) {
-    if (!menuItems) {
-      return;
-    }
-    for (let item of menuItems) {
-      this.loadTitles(item);
-      if (item.submenu) {
-        this.loadI18nMenuItems(item.submenu)
-      }
-    }
-  }
-
-  loadTitles(item) {
-    const path = item.path?.split('/dashboard/')[1];
-
-    if (!path) {
-      return;
-    }
-
-    switch (path) {
-      case 'main-region':
-      case 'country':
-      case 'retailer':
-        item.title = this.translate.instant('general.coop');
-        break;
-      case 'tools':
-        item.title = this.translate.instant('dashboard.otherTools');
-        break;
-      case 'omnichat':
-        item.title = this.translate.instant('dashboard.feelingsAnalysis');
-        break;
-      case 'campaign-comparator':
-        item.title = this.translate.instant('dashboard.campaignComparator');
-        break;
-      case 'users':
-        item.title = this.translate.instant('general.users');
-        break;
-      case 'users/activity-register':
-        item.title = this.translate.instant('dashboard.activityRegister');
-        break;
-    }
-  }
-
   async ngOnInit() {
     this.userIsAdmin = this.userService.isAdmin();
     this.userRole = this.userService.user.role_name;
@@ -140,7 +97,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
       } else if (this.userRole === 'retailer') {
         const newMenuItems = await this.getAvailableRetailers();
         this.menuItems = [... this.menuItems, ...newMenuItems];
-        this.loadI18nMenuItems(this.menuItems);
       }
       this.menuReqStatus = 2;
 
@@ -158,6 +114,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
     // Admin routes
     const menuItem2 = {
+      id: 'admin',
       title: this.translate.instant('dashboard.manager'),
       submenu: [
         {
@@ -433,13 +390,13 @@ export class SidebarComponent implements OnInit, OnDestroy {
         menuItems = retailers.map(item => {
           const submenu = [
             {
-              title: 'Programa COOP',
+              title: this.translate.instant('general.coop'),
               path: '/dashboard/retailer',
               paramName: 'retailer',
               param: item.name.toLowerCase().replaceAll(' ', '-')
             },
             {
-              title: 'Otras herramientas',
+              title: this.translate.instant('dashboard.otherTools'),
               path: '/dashboard/tools',
               paramName: 'retailer',
               param: item.name.toLowerCase().replaceAll(' ', '-')
@@ -533,7 +490,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
     item.path && this.redirectToSelectedItem(item);
 
-    if (!item.isParentOf && item.title.toLowerCase() !== 'latam') {
+    if (!item.isParentOf && item.title.toLowerCase() !== 'latam' && item.id !== 'admin') {
       this.emitNewSelection(item);
     }
   }
@@ -665,6 +622,53 @@ export class SidebarComponent implements OnInit, OnDestroy {
 
   logout() {
     this.userService.logout();
+  }
+
+  loadI18nMenuItems(menuItems) {
+    if (!menuItems) {
+      return;
+    }
+    for (let item of menuItems) {
+      this.loadTitles(item);
+      if (item.submenu) {
+        this.loadI18nMenuItems(item.submenu)
+      }
+
+      if (item.id === 'admin') {
+        item.title = this.translate.instant('dashboard.manager');
+      }
+    }
+  }
+
+  loadTitles(item) {
+    const path = item.path?.split('/dashboard/')[1];
+
+    if (!path) {
+      return;
+    }
+
+    switch (path) {
+      case 'main-region':
+      case 'country':
+      case 'retailer':
+        item.title = this.translate.instant('general.coop');
+        break;
+      case 'tools':
+        item.title = this.translate.instant('dashboard.otherTools');
+        break;
+      case 'omnichat':
+        item.title = this.translate.instant('dashboard.feelingsAnalysis');
+        break;
+      case 'campaign-comparator':
+        item.title = this.translate.instant('dashboard.campaignComparator');
+        break;
+      case 'users':
+        item.title = this.translate.instant('general.users');
+        break;
+      case 'users/activity-register':
+        item.title = this.translate.instant('dashboard.activityRegister');
+        break;
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.ts
@@ -1,15 +1,17 @@
-import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 import { loadLanguage } from 'src/app/tools/functions/chart-lang';
+import { AppStateService } from 'src/app/services/app-state.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-chart-line-series',
   templateUrl: './chart-line-series.component.html',
   styleUrls: ['./chart-line-series.component.scss']
 })
-export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
+export class ChartLineSeriesComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @Input() value = 'value'; // property name in the object to show in valueAxis
   @Input() valueName; // property to show in tooltips
@@ -40,10 +42,16 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
 
   chart;
   axis: any;
+  langSub: Subscription;
 
-  constructor() { }
+  constructor(
+    private appStateService: AppStateService
+  ) { }
 
   ngOnInit(): void {
+    this.langSub = this.appStateService.selectedLang$.subscribe((lang: string) => {
+      this.loadChart(lang);
+    });
   }
 
   ngAfterViewInit() {
@@ -166,6 +174,10 @@ export class ChartLineSeriesComponent implements OnInit, AfterViewInit {
       series.data = data;
       return series;
     }
+  }
+
+  ngOnDestroy() {
+    this.langSub?.unsubscribe();
   }
 }
 

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -1,21 +1,24 @@
-import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
 import * as am4core from '@amcharts/amcharts4/core';
 import * as am4charts from '@amcharts/amcharts4/charts';
 import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 import { loadLanguage } from 'src/app/tools/functions/chart-lang';
+import { TranslateService } from '@ngx-translate/core';
+import { AppStateService } from 'src/app/services/app-state.service';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-chart-pyramid',
   templateUrl: './chart-pyramid.component.html',
   styleUrls: ['./chart-pyramid.component.scss']
 })
-export class ChartPyramidComponent implements OnInit, AfterViewInit {
+export class ChartPyramidComponent implements OnInit, AfterViewInit, OnDestroy {
 
   @Input() category: string = 'age';
   @Input() value1: string = 'male';
   @Input() value2: string = 'female';
-  @Input() valueName1: string = 'Hombres';
-  @Input() valueName2: string = 'Mujeres';
+  @Input() valueName1: string = this.translate.instant('others.men');
+  @Input() valueName2: string = this.translate.instant('others.women');
   @Input() height: string = '350px'; // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
@@ -54,10 +57,20 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
   labels: any;
   valueAxis: any;
   columns: any;
+  langSub: Subscription;
 
-  constructor() { }
+  constructor(
+    private translate: TranslateService,
+    private appStateService: AppStateService
+  ) { }
 
   ngOnInit(): void {
+    this.langSub = this.appStateService.selectedLang$.subscribe((lang: string) => {
+      this.valueName1 = this.translate.instant('others.men');
+      this.valueName2 = this.translate.instant('others.women');
+
+      this.loadChart(lang);
+    });
   }
 
   ngAfterViewInit() {
@@ -171,5 +184,9 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit {
     this.valueAxis.renderer.labels.template.adapter.add('text', function (text) {
       return `${text} ${valueFormat !== false && valueFormat?.length === 1 ? valueFormat : ''}`;
     })
+  }
+
+  ngOnDestroy() {
+    this.langSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -3,15 +3,17 @@
 
         <!-- country -->
         <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
-            <span class="mb-1 h4">País</span>
-            <mat-select formControlName="countries" multiple placeholder="Selecciona un País" disableOptionCentering>
+            <span class="mb-1 h4">{{ 'filters.country' | translate }}</span>
+            <mat-select formControlName="countries" multiple [placeholder]="'filters.countryPh' | translate"
+                disableOptionCentering>
                 <div class="input-group input-group-alternative mb-1">
                     <div class="input-group-prepend">
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
                     <input class="form-control" [(ngModel)]="countryFilter" matInput type="text"
-                        (keyup)="filterFromList('countries', 'country', $event.target.value)" placeholder="Buscar País"
-                        [ngModelOptions]="{standalone: true}" (keydown.space)="$event.stopPropagation()">
+                        (keyup)="filterFromList('countries', 'country', $event.target.value)"
+                        [placeholder]="'filters.countrySearchPh' | translate" [ngModelOptions]="{standalone: true}"
+                        (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -23,14 +25,15 @@
                             : ''}}
                         </span>
                         <span *ngIf="countriesCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{countriesCounter === 2 ? 'otro' : 'otros' }}
+                            (+
+                            {{ (countriesCounter === 2 ? 'others.otherSingularM' : 'others.otherPluralM') | translate }}
                             {{ countriesCounter === 2 ? '' : countriesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
                 <mat-option #allSelectedCountries [value]="0" class="font-weight-bold"
                     (click)="toggleAllSelection('countries', 'country'); selectAllComplementaryFilter('retailers')">
-                    Todos
+                    {{ 'others.allPluralM' | translate | titlecase }}
                 </mat-option>
                 <ng-container *ngFor="let country of countryList">
                     <mat-option class="mat-option-container" [hidden]="country.hidden" [value]="country"
@@ -38,7 +41,7 @@
                         <span class="option-name">{{ country.name }}</span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('countries', 'country', country); selectOnlyComplementaryFilter('retailers', country)">
-                            Solamente
+                            {{ 'others.only' | translate | titlecase }}
                         </button>
                     </mat-option>
                 </ng-container>
@@ -47,15 +50,15 @@
             <!-- <small class="text-danger" *ngIf="countries?.value?.length < 1 && countries.touched">
                 Selecciona al menos un País
             </small> -->
-            <small class="text-danger" *ngIf="countriesErrorMsg">
-                {{ countriesErrorMsg }}
+            <small class="text-danger" *ngIf="countriesError">
+                {{ 'filters.countryError1' | translate }}
             </small>
         </div>
 
         <!-- retailer -->
         <div [hidden]="!isLatamSelected" class="col-12 col-sm-6 col-lg-2 mb-4">
             <span class="mb-1 h4">Retailer</span>
-            <mat-select formControlName="retailers" multiple placeholder="Selecciona un Retailer"
+            <mat-select formControlName="retailers" multiple [placeholder]="'filters.retailerPh' | translate"
                 disableOptionCentering>
                 <div class="input-group input-group-alternative mb-1">
                     <div class="input-group-prepend">
@@ -63,7 +66,7 @@
                     </div>
                     <input class="form-control" [(ngModel)]="retailerFilter" matInput type="text"
                         (keyup)="filterFromList('retailers', 'retailer', $event.target.value)"
-                        placeholder="Buscar Retailer" [ngModelOptions]="{standalone: true}"
+                        [placeholder]="'filters.retailerSearchPh' | translate" [ngModelOptions]="{standalone: true}"
                         (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
@@ -78,7 +81,8 @@
                             }}
                         </span>
                         <span *ngIf="retailersCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{ retailersCounter === 2 ? 'otro' : 'otros' }}
+                            (+
+                            {{ (retailersCounter === 2 ? 'others.otherSingularM' : 'others.otherPluralM') | translate }}
                             {{ retailersCounter === 2 ? '' : retailersCounter - 1 }} )
                         </span>
                     </div>
@@ -86,7 +90,7 @@
                 <mat-option #allSelectedRetailers
                     (click)="toggleAllSelection('retailers', 'retailer'); selectAllComplementaryFilter('countries')"
                     [value]="0" class="font-weight-bold">
-                    Todos
+                    {{ 'others.allPluralM' | translate | titlecase }}
                 </mat-option>
                 <ng-container *ngFor="let retailer of retailerList">
                     <mat-option class="mat-option-container" [hidden]="retailer.hidden" [value]="retailer"
@@ -94,37 +98,37 @@
                         <span class="option-name">{{ retailer.name }}</span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('retailers', 'retailer', retailer); selectOnlyComplementaryFilter('countries', retailer)">
-                            Solamente
+                            {{ 'others.only' | translate | titlecase }}
                         </button>
                     </mat-option>
                 </ng-container>
 
             </mat-select>
             <small class="text-danger" *ngIf="retailers?.value?.length < 1 && (retailers.touched || countries.touched)">
-                Selecciona al menos un Retailer
+                {{ 'filters.retailerError1' | translate }}
             </small>
-            <small class="text-danger" *ngIf="retailersErrorMsg">
-                {{ retailersErrorMsg }}
+            <small class="text-danger" *ngIf="retailersError">
+                {{ 'filters.retailerError2' | translate }}
             </small>
         </div>
 
         <!-- period -->
         <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <div class="date-picker">
-                <span class="mb-1 h4">Período</span>
+                <span class="mb-1 h4">{{ 'filters.period' | translate }}</span>
                 <mat-form-field appearance="fill">
                     <mat-date-range-input [rangePicker]="picker">
-                        <input matStartDate formControlName="startDate" placeholder="Fecha inicio">
-                        <input matEndDate formControlName="endDate" placeholder="Fecha fin">
+                        <input matStartDate formControlName="startDate" [placeholder]="'filters.periodPh1' | translate">
+                        <input matEndDate formControlName="endDate" [placeholder]="'filters.periodPh2' | translate">
                     </mat-date-range-input>
                     <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
                     <mat-date-range-picker #picker></mat-date-range-picker>
                 </mat-form-field>
                 <small class="text-danger" *ngIf="!startDate.valid && startDate.touched">
-                    Fecha inicio inválida
+                    {{ 'filters.periodError1' | translate }}
                 </small>
                 <small class="text-danger" *ngIf="!endDate.valid && endDate.touched">
-                    Fecha fin inválida
+                    {{ 'filters.periodError2' | translate }}
                 </small>
             </div>
         </div>
@@ -132,8 +136,9 @@
         <!-- sector -->
         <div class="col-12 col-sm-6 mb-4" [hidden]="currentPage === 'tools'"
             [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
-            <span class="mb-1 h4">Sector</span>
-            <mat-select formControlName="sectors" multiple placeholder="Selecciona un Sector" disableOptionCentering>
+            <span class="mb-1 h4">{{ 'general.sector' | translate }}</span>
+            <mat-select formControlName="sectors" multiple [placeholder]="'filters.sectorPh' | translate"
+                disableOptionCentering>
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">
@@ -146,36 +151,37 @@
                             }}
                         </span>
                         <span *ngIf="sectorsCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{ sectorsCounter === 2 ? 'otro' : 'otros' }}
+                            (+
+                            {{ (sectorsCounter === 2 ? 'others.otherSingularM' : 'others.otherPluralM') | translate }}
                             {{ sectorsCounter === 2 ? '' : sectorsCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
                 <mat-option #allSelectedSectors (click)="toggleAllSelection('sectors','sector')" [value]="0"
                     class="font-weight-bold">
-                    Todos
+                    {{ 'others.allPluralM' | translate | titlecase }}
                 </mat-option>
                 <mat-option class="mat-option-container" *ngFor="let sector of sectorList" [value]="sector"
                     (click)="tosslePerOne('allSelectedSectors', 'sectors', 'sectorList')">
                     <span class="option-name">{{ sector.name }}</span>
                     <button type="button" class="btn btn-sm btn-secondary"
                         (click)="uniqueSelection('sectors', 'sector', sector)">
-                        Solamente
+                        {{ 'others.only' | translate | titlecase }}
                     </button>
                 </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="sectors?.value?.length < 1 && sectors.touched">
-                Selecciona al menos un Sector
+                {{ 'filters.sectorError1' | translate }}
             </small>
-            <small class="text-danger" *ngIf="sectorsErrorMsg">
-                {{ sectorsErrorMsg }}
+            <small class="text-danger" *ngIf="sectorsError">
+                {{ 'filters.sectorError2' | translate }}
             </small>
         </div>
 
         <!-- category -->
         <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
-            <span class="mb-1 h4">Categoría</span>
-            <mat-select formControlName="categories" multiple placeholder="Selecciona una Categoría"
+            <span class="mb-1 h4">{{ 'general.category' | translate }}</span>
+            <mat-select formControlName="categories" multiple [placeholder]="'filters.categoryPh' | translate"
                 disableOptionCentering>
                 <mat-select-trigger>
                     <div class="select-value-container">
@@ -189,44 +195,47 @@
                             }}
                         </span>
                         <span *ngIf="categoriesCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{ categoriesCounter === 2 ? 'otra' : 'otras' }}
+                            (+
+                            {{ (categoriesCounter === 2 ? 'others.otherSingularF' : 'others.otherPluralF') | translate
+                            }}
                             {{ categoriesCounter === 2 ? '' : categoriesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
                 <mat-option #allSelectedCategories (click)="toggleAllSelection('categories', 'category')" [value]="0"
                     class="font-weight-bold">
-                    Todas
+                    {{ 'others.allPluralF' | translate | titlecase}}
                 </mat-option>
                 <mat-option class="mat-option-container" *ngFor="let category of categoryList" [value]="category"
                     (click)="tosslePerOne('allSelectedCategories', 'categories', 'categoryList')">
                     <span class="option-name">{{ category.name }}</span>
                     <button type="button" class="btn btn-sm btn-secondary"
                         (click)="uniqueSelection('categories', 'category', category)">
-                        Solamente
+                        {{ 'others.only' | translate | titlecase }}
                     </button>
                 </mat-option>
             </mat-select>
             <small class="text-danger" *ngIf="categories?.value?.length < 1 && categories.touched">
-                Selecciona al menos una Categoría
+                {{ 'filters.categoryError1' | translate }}
             </small>
-            <small class="text-danger" *ngIf="categoriesErrorMsg">
-                {{ categoriesErrorMsg }}
+            <small class="text-danger" *ngIf="categoriesError">
+                {{ 'filters.categoryError2' | translate }}
             </small>
         </div>
 
         <!-- campaign -->
         <div [hidden]="!retailerID || currentPage === 'tools'" class="col-12 col-sm-6 col-lg-3 mb-4">
-            <span class="mb-1 h4">Campaña</span>
-            <mat-select formControlName="campaigns" multiple placeholder="Selecciona una Campaña" disableOptionCentering
-                [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsErrorMsg">
+            <span class="mb-1 h4">{{ 'general.campaign' | translate }}</span>
+            <mat-select formControlName="campaigns" multiple [placeholder]="'filters.campaignPh' | translate"
+                disableOptionCentering
+                [disabled]="(campaignList?.length < 1 && campaignsReqStatus === 2) || campaignsError">
                 <div class="input-group input-group-alternative mb-1">
                     <div class="input-group-prepend">
                         <span class="input-group-text"><i class="fas fa-search"></i></span>
                     </div>
                     <input class="form-control" [(ngModel)]="campaignFilter" matInput type="text"
                         (keyup)="filterFromList('campaigns', 'campaign', $event.target.value)"
-                        placeholder="Buscar Campaña" [ngModelOptions]="{standalone: true}"
+                        [placeholder]="'filters.campaignSearchPh' | translate" [ngModelOptions]="{standalone: true}"
                         (keydown.space)="$event.stopPropagation()">
                 </div>
                 <mat-select-trigger>
@@ -241,14 +250,15 @@
                             }}
                         </span>
                         <span *ngIf="campaignsCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{ campaignsCounter === 2 ? 'otra' : 'otras' }}
+                            (+
+                            {{ (campaignsCounter === 2 ? 'others.otherSingularF' : 'others.otherPluralF') | translate }}
                             {{ campaignsCounter === 2 ? '' : campaignsCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
                 <mat-option #allSelectedCampaigns (click)="toggleAllSelection('campaigns', 'campaign')" [value]="0"
                     class="font-weight-bold">
-                    Todas
+                    {{ 'others.allPluralF' | translate | titlecase}}
                 </mat-option>
                 <ng-container *ngFor="let campaign of campaignList">
                     <mat-option class="mat-option-container" [hidden]="campaign.hidden" [value]="campaign"
@@ -259,23 +269,24 @@
                         </span>
                         <button type="button" class="btn btn-sm btn-secondary"
                             (click)="uniqueSelection('campaigns', 'campaign', campaign)">
-                            Solamente
+                            {{ 'others.only' | translate | titlecase }}
                         </button>
                     </mat-option>
                 </ng-container>
             </mat-select>
             <small class="text-muted mt-1" *ngIf="campaignList?.length < 1 && campaignsReqStatus === 2">
-                No existen campañas para el Periodo, Sectores y Categorías seleccionados
+                {{ 'filters.campaignError1' | translate }}
             </small>
-            <small class="text-danger" *ngIf="campaignsErrorMsg">
-                {{ campaignsErrorMsg }}
+            <small class="text-danger" *ngIf="campaignsError">
+                {{ 'filters.campaignError2' | translate }}
             </small>
         </div>
 
         <!-- source -->
         <div [hidden]="!isLatamSelected || currentPage === 'tools'" class="col-12 col-sm-6 col-lg-2 mb-4">
-            <span class="mb-1 h4">Fuente</span>
-            <mat-select formControlName="sources" multiple placeholder="Selecciona una Fuente" disableOptionCentering>
+            <span class="mb-1 h4">{{ 'general.source' | translate }}</span>
+            <mat-select formControlName="sources" multiple [placeholder]="'filters.sourcePh' | translate"
+                disableOptionCentering>
                 <mat-select-trigger>
                     <div class="select-value-container">
                         <span class="select-value">
@@ -288,24 +299,28 @@
                             }}
                         </span>
                         <span *ngIf="sourcesCounter > 1" class="example-additional-selection ml-1">
-                            (+ {{ sourcesCounter === 2 ? 'otra' : 'otras' }}
+                            (+
+                            {{ (sourcesCounter === 2 ? 'others.otherSingularF' : 'others.otherPluralF') | translate }}
                             {{ sourcesCounter === 2 ? '' : sourcesCounter - 1 }} )
                         </span>
                     </div>
                 </mat-select-trigger>
                 <mat-option #allSelectedSources (click)="toggleAllSelection('sources', 'source')" [value]="0"
                     class="font-weight-bold">
-                    Todas
+                    {{ 'others.allPluralF' | translate | titlecase }}
                 </mat-option>
                 <mat-option class="mat-option-container" *ngFor="let source of sourceList" [value]="source"
                     (click)="tosslePerOne('allSelectedSources', 'sources', 'sourceList')">
                     <span class="option-name">{{ source.name }}</span>
                     <button type="button" class="btn btn-sm btn-secondary"
                         (click)="uniqueSelection('sources', 'source', source)">
-                        Solamente
+                        {{ 'others.only' | translate | titlecase }}
                     </button>
                 </mat-option>
             </mat-select>
+            <small class="text-danger" *ngIf="sources?.value?.length < 1 && sources.touched">
+                {{ 'filters.sourceError1' | translate }}
+            </small>
         </div>
     </div>
 </form>
@@ -322,7 +337,7 @@
             (categories?.value?.length < 1 && categories.touched)
             " (click)="applyFilters(true)">
             <i class="fas fa-filter mr-2"></i>
-            Filtrar
+            {{ 'filters.filter' | translate }}
         </button>
     </div>
 </div>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -97,11 +97,11 @@ export class GeneralFiltersComponent implements OnInit {
 
   campaignsReqStatus: number = 0;
 
-  countriesErrorMsg: string;
-  retailersErrorMsg: string;
-  sectorsErrorMsg: string;
-  categoriesErrorMsg: string;
-  campaignsErrorMsg: string;
+  countriesError: boolean;
+  retailersError: boolean;
+  sectorsError: boolean;
+  categoriesError: boolean;
+  campaignsError: boolean;
 
   countriesCounter: number;
   retailersCounter: number;
@@ -226,7 +226,7 @@ export class GeneralFiltersComponent implements OnInit {
     let today = new Date();
     let startDate = new Date();
     let endDate = new Date();
-    let daysAgo = 15;
+    let daysAgo = 150;
 
     startDate.setDate(today.getDate() - daysAgo);
     endDate.setDate(today.getDate() - 1);
@@ -319,10 +319,10 @@ export class GeneralFiltersComponent implements OnInit {
       .toPromise()
       .then((res: any[]) => {
         this.loadCountriesData(res);
-        this.countriesErrorMsg && delete this.countriesErrorMsg;
+        this.countriesError = this.countriesError && false;
       })
       .catch((error) => {
-        this.countriesErrorMsg = 'Error al consultar países';
+        this.countriesError = true;
         console.error(`[general-filers.component]: ${error}`);
       });
   }
@@ -343,10 +343,10 @@ export class GeneralFiltersComponent implements OnInit {
         retailers.sort((a, b) => a.name.localeCompare(b.name));
 
         this.loadRetailersData(retailers);
-        this.retailersErrorMsg && delete this.retailersErrorMsg;
+        this.retailersError = this.retailersError && false;
       })
       .catch((error) => {
-        this.retailersErrorMsg = 'Error al consultar retailers';
+        this.retailersError = true;
         console.error(`[general-filers.component]: ${error}`);
       });
   }
@@ -386,10 +386,10 @@ export class GeneralFiltersComponent implements OnInit {
         this.sectors.patchValue([...this.sectorList.map(item => item), 0]);
         this.prevSectors = this.sectors.value;
 
-        this.sectorsErrorMsg && delete this.sectorsErrorMsg;
+        this.sectorsError = this.sectorsError && false;
       })
       .catch((error) => {
-        this.sectorsErrorMsg = 'Error al consultar sectores';
+        this.sectorsError = true;
         console.error(`[general-filers.component]: ${error}`);
       });
   }
@@ -405,10 +405,10 @@ export class GeneralFiltersComponent implements OnInit {
         this.categories.patchValue([...this.categoryList.map(item => item), 0]);
         this.prevCategories = this.categories.value;
 
-        this.categoriesErrorMsg && delete this.categoriesErrorMsg;
+        this.categoriesError = this.categoriesError && false;
       })
       .catch((error) => {
-        this.categoriesErrorMsg = 'Error al consultar categorías';
+        this.categoriesError = true;
         console.error(`[general-filers.component]: ${error}`);
       });
   }
@@ -429,12 +429,12 @@ export class GeneralFiltersComponent implements OnInit {
           this.campaignList = res;
           this.filteredCampaignList = res;
 
-          this.campaignsErrorMsg && delete this.campaignsErrorMsg;
+          this.campaignsError = this.campaignsError && false;
           this.campaignsReqStatus = 2;
         },
         error => {
           this.campaignList = [];
-          this.campaignsErrorMsg = 'Error al consultar campañas';
+          this.campaignsError = true;
           console.error(`[general-filers.component]: ${error}`);
           this.campaignsReqStatus = 3;
         }
@@ -784,6 +784,23 @@ export class GeneralFiltersComponent implements OnInit {
     const cleanArray2 = array2?.filter(item => item.id);
 
     return JSON.stringify(cleanArray1) == JSON.stringify(cleanArray2) ? true : false;
+  }
+
+  geti18nTexts() {
+    // const salesSector = this.selectedSectors.find(sectors => sectors.id === 3);
+    // if (salesSector) {
+    //   salesSector.name = this.translate.instant('general.sales');
+    // }
+
+    // const institutionalSource = this.selectedSources.find(sources => sources.id === 'institucional');
+    // if (institutionalSource) {
+    //   institutionalSource.name = this.translate.instant('general.institutional');
+    // }
+
+    // const othersSource = this.selectedSources.find(sources => sources.id === 'otros');
+    // if (othersSource) {
+    //   othersSource.name = this.translate.instant('general.others');
+    // }
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -8,7 +8,7 @@
                     </app-card-stat>
                 </div>
                 <p class="text-center text-muted mt-3 mb-0" [hidden]="kpisReqStatus !== 3">
-                    Error al consultar datos
+                    {{ 'general.errorData' | translate }}
                 </p>
             </div>
         </div>
@@ -19,11 +19,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                                (click)="getSectorsAndCategories('sectors')">Sector</a>
+                                (click)="getSectorsAndCategories('sectors')">{{ 'general.sector' | translate }}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                                (click)="getSectorsAndCategories('categories')">Categoría</a>
+                                (click)="getSectorsAndCategories('categories')">{{ 'general.category' | translate }}</a>
                         </li>
                     </ul>
                 </div>
@@ -31,8 +31,14 @@
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">Inversión en {{ selectedTab1 === 1 ? 'Sectores' : 'Categorías' }} por
-                            País</span>
+                        <span class="h4">
+                            {{
+                            ('overviewLatam.chart1CardTitle1' | translate) +
+                            (( selectedTab1 === 1 ? 'overviewLatam.chart1CardTitle2' : 'overviewLatam.chart1CardTitle3')
+                            | translate) +
+                            ('overviewLatam.chart1CardTitle4' | translate)
+                            }}
+                        </span>
                     </div>
                     <div class="card-body">
                         <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
@@ -51,11 +57,15 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                                (click)="getDataByTrafficAndSales('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                                (click)="getDataByTrafficAndSales('traffic'); chartsInitLoad = chartsInitLoad && false">
+                                {{ 'general.traffic' | translate }}
+                            </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                                (click)="getDataByTrafficAndSales('sales'); chartsInitLoad = chartsInitLoad && false;">Ventas</a>
+                                (click)="getDataByTrafficAndSales('sales'); chartsInitLoad = chartsInitLoad && false">
+                                {{ 'general.sales' | translate }}
+                            </a>
                         </li>
                     </ul>
                 </div>
@@ -65,7 +75,10 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart2CardTitle1' | translate) }}
+                        </span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['device']" name="latam-devices" category="name"
@@ -79,7 +92,10 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart3CardTitle1' | translate) }}
+                        </span>
                     </div>
                     <div class="card-body">
                         <app-chart-pictorial [data]="trafficAndSales['gender']" name="latam-gender" category="name"
@@ -93,7 +109,10 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Edad</span>
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart4CardTitle1' | translate) }}
+                        </span>
                     </div>
                     <div class="card-body">
                         <app-chart-lollipop [data]="trafficAndSales['age']" name="latam-age" category="age"
@@ -108,7 +127,10 @@
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género y Edad</span>
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart5CardTitle1' | translate) }}
+                        </span>
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
@@ -125,15 +147,15 @@
                         <div *ngIf="trafficSalesReqStatus[3].reqStatus === 2 && trafficAndSales['genderByAge']?.length === 0"
                             class="chart-error-container text-muted">
                             <p class="text-center">
-                                Sin datos disponibles <br>
-                                Muestra insuficiente
+                                {{ 'general.withoutData' | translate }} <br>
+                                {{ 'general.withoutData2' | translate }}
                             </p>
                         </div>
 
                         <!-- error -->
                         <div *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 3"
                             class="chart-error-container text-muted">
-                            <span>Error al consultar datos</span>
+                            <span> {{ 'general.errorData' | translate }}</span>
                         </div>
                     </div>
                 </div>
@@ -146,11 +168,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
-                                (click)="getDataByUsersAndSales('users')">Usuarios</a>
+                                (click)="getDataByUsersAndSales('users')">{{ 'general.users' | translate }}</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
-                                (click)="getDataByUsersAndSales('sales')">Ventas</a>
+                                (click)="getDataByUsersAndSales('sales')">{{ 'general.sales' | translate }}</a>
                         </li>
                     </ul>
                 </div>
@@ -159,11 +181,16 @@
             <div class="col-12 mt-4">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">{{ selectedTab3 === 1 ? 'Usuarios' : 'Ventas'}} por </span>
+                        <span class="h4">
+                            {{
+                            ((selectedTab3 === 1 ? 'general.users' : 'general.sales') | translate) + ' ' +
+                            ('others.by' | translate)
+                            }}
+                        </span>
                         <ng-container [ngSwitch]="selectedTab4">
-                            <span *ngSwitchCase="1" class="h4">Sector</span>
-                            <span *ngSwitchCase="2" class="h4">Categoría</span>
-                            <span *ngSwitchCase="3" class="h4">Medio</span>
+                            <span *ngSwitchCase="1" class="h4">{{ 'general.sector' | translate }}</span>
+                            <span *ngSwitchCase="2" class="h4">{{ 'general.category' | translate }}</span>
+                            <span *ngSwitchCase="3" class="h4">{{ 'general.source' | translate }}</span>
                         </ng-container>
                     </div>
                     <div class="card-body">
@@ -185,13 +212,15 @@
                                         *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales'); clearUsersAndSalesTabs()">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales'); clearUsersAndSalesTabs()">
+                                                {{ 'others.all' | translate | titlecase }}
+                                            </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': sector.id + 2 === selectedTab5}"
                                                 (click)="selectedTab5 = sector.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', sector)">
-                                                {{ sector.name}}
+                                                {{ sector.name }}
                                             </a>
                                         </li>
                                     </ul>
@@ -201,13 +230,15 @@
                                         *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">
+                                                {{ 'others.all' | translate | titlecase }}
+                                            </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let category of selectedCategories">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': category.id + 2 === selectedTab5}"
                                                 (click)="selectedTab5 = category.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, category)">
-                                                {{ category.name}}
+                                                {{ category.name }}
                                             </a>
                                         </li>
                                     </ul>
@@ -217,13 +248,15 @@
                                         *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">Todo</a>
+                                                (click)="selectedTab5 = 1; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales')">
+                                                {{ 'others.all' | translate | titlecase }}
+                                            </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let source of selectedSources">
                                             <a class="nav-link p-2"
                                                 [ngClass]="{'active': source.id + 2 === selectedTab5}"
                                                 (click)="selectedTab5 = source.id + 2; getDataByUsersAndSales(selectedTab3 === 1 ? 'users' : 'sales', null, null, source)">
-                                                {{ source.name}}
+                                                {{ source.name }}
                                             </a>
                                         </li>
                                     </ul>
@@ -259,7 +292,7 @@
             <div class="col-12">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">Inversión vs Revenue</span>
+                        <span class="h4">{{ 'overviewLatam.chart7CardTitle1' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <app-chart-multiple-axes [data]="investmentVsRevenue"
@@ -272,14 +305,14 @@
             </div>
         </div>
 
-        <div class="row mt-5" [hidden]="true">
+        <div class="row mt-5">
             <div class="col-12" *ngIf="selectedCategories.length > 1">
                 <div class="pills-container mb-4">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item" *ngFor="let category of selectedCategories">
                             <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab6}"
                                 (click)="getTopProducts(category)">
-                                {{ category.name}}
+                                {{ category.name }}
                             </a>
                         </li>
                     </ul>
@@ -288,19 +321,19 @@
             <div class="col-12">
                 <div class="card">
                     <div class="card-header">
-                        <span class="h4">Top Productos </span>
+                        <span class="h4">{{ 'overviewLatam.table1CardTitle1' | translate }}</span>
                         <ng-container *ngIf="selectedCategories?.length > 1">
                             <ng-container [ngSwitch]="selectedTab6">
-                                <span *ngSwitchCase="1" class="h4">- PS</span>
-                                <span *ngSwitchCase="2" class="h4">- HW Print</span>
-                                <span *ngSwitchCase="3" class="h4">- Supplies</span>
+                                <span *ngSwitchCase="1" class="h4"> - PS</span>
+                                <span *ngSwitchCase="2" class="h4"> - HW Print</span>
+                                <span *ngSwitchCase="3" class="h4"> - Supplies</span>
                             </ng-container>
                         </ng-container>
 
                     </div>
                     <div class="card-body">
                         <app-generic-table [displayedColumns]="topProductsColumns" [tableData]="topProducts"
-                            [tableDataChange]="topProducts.data" errorMsg="Error al consultar productos"
+                            [tableDataChange]="topProducts.data" errorData="Error al consultar productos"
                             emptyDataMsg="No se encontraron productos">
                         </app-generic-table>
                     </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -3,6 +3,7 @@ import { Subscription } from 'rxjs';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { OverviewService } from '../../services/overview.service';
 import { TableItem } from '../../components/generic-table/generic-table.component';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-overview-latam',
@@ -138,11 +139,44 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   selectedSourceTab: any;
 
   filtersSub: Subscription;
+  translateSub: Subscription;
   chartsInitLoad: boolean = true;
 
   constructor(
     private filtersStateService: FiltersStateService,
-    private overviewService: OverviewService) { }
+    private overviewService: OverviewService,
+    private translate: TranslateService) {
+
+    this.translateSub = translate.stream('overviewLatam').subscribe(() => {
+      this.kpis[0].metricTitle = this.translate.instant('kpis.investment');
+      this.kpis[2].subMetricTitle = this.translate.instant('general.users');
+      this.kpis[3].metricTitle = this.translate.instant('kpis.transactions');
+      this.kpis[3].metricTitle = this.translate.instant('kpis.transactions');
+
+      this.topProductsColumns[0].title = this.translate.instant('general.ranking');
+      this.topProductsColumns[1].title = this.translate.instant('general.product');
+      this.topProductsColumns[2].title = this.translate.instant('general.amount');
+
+      this.usersAndSalesMetrics[0] = this.translate.instant('general.sector').toLowerCase();
+      this.usersAndSalesMetrics[1] = this.translate.instant('general.category').toLowerCase();
+      this.usersAndSalesMetrics[2] = this.translate.instant('general.source').toLowerCase();
+
+      const salesSector = this.selectedSectors.find(sectors => sectors.id === 3);
+      if (salesSector) {
+        salesSector.name = this.translate.instant('general.sales');
+      }
+
+      const institutionalSource = this.selectedSources.find(sources => sources.id === 'institucional');
+      if (institutionalSource) {
+        institutionalSource.name = this.translate.instant('general.institutional');
+      }
+
+      const othersSource = this.selectedSources.find(sources => sources.id === 'otros');
+      if (othersSource) {
+        othersSource.name = this.translate.instant('general.others');
+      }
+    });
+  }
 
   ngOnInit(): void {
     if (this.filtersStateService.countries &&
@@ -327,5 +361,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.filtersSub?.unsubscribe();
+    this.translateSub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -145,7 +145,8 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   constructor(
     private filtersStateService: FiltersStateService,
     private overviewService: OverviewService,
-    private translate: TranslateService) {
+    private translate: TranslateService
+  ) {
 
     this.translateSub = translate.stream('overviewLatam').subscribe(() => {
       this.kpis[0].metricTitle = this.translate.instant('kpis.investment');
@@ -161,20 +162,13 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       this.usersAndSalesMetrics[1] = this.translate.instant('general.category').toLowerCase();
       this.usersAndSalesMetrics[2] = this.translate.instant('general.source').toLowerCase();
 
-      const salesSector = this.selectedSectors.find(sectors => sectors.id === 3);
-      if (salesSector) {
-        salesSector.name = this.translate.instant('general.sales');
-      }
-
-      const institutionalSource = this.selectedSources.find(sources => sources.id === 'institucional');
-      if (institutionalSource) {
-        institutionalSource.name = this.translate.instant('general.institutional');
-      }
-
-      const othersSource = this.selectedSources.find(sources => sources.id === 'otros');
-      if (othersSource) {
-        othersSource.name = this.translate.instant('general.others');
-      }
+      this.trafficAndSales['gender'] = this.trafficAndSales['gender']?.map(item => {
+        if (item.id === 1) {
+          return { ...item, name: this.translate.instant('others.women') }
+        } else if (item.id === 2) {
+          return { ...item, name: this.translate.instant('others.men') }
+        }
+      });
     });
   }
 
@@ -276,6 +270,16 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         (resp: any[]) => {
           if (subMetricType === 'gender-and-age') {
             this.trafficAndSales['genderByAge'] = resp;
+
+          } else if (subMetricType === 'gender') {
+            this.trafficAndSales['gender'] = resp.map(item => {
+              if (item.name.toLowerCase() == 'mujer') {
+                return { id: 1, name: this.translate.instant('others.women'), value: item.value }
+              } else if (item.name.toLowerCase() == 'hombre') {
+                return { id: 2, name: this.translate.instant('others.men'), value: item.value }
+              }
+            });
+
           } else {
             this.trafficAndSales[subMetricType] = resp;
           }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -14,7 +14,10 @@
         "campaignComparator": "Campaign comparator",
         "settings": "Settings",
         "manager": "Manage",
-        "activityRegister": "Activity Register"
+        "activityRegister": "Activity Register",
+        "sidebarError1": "An error occurred when consulting the",
+        "sidebarError2": "countries or retailers",
+        "sidebarError3": "to which you have access. Please try later."
     },
     "filters": {
         "country": "Country",
@@ -62,6 +65,14 @@
         "investment": "investment",
         "transactions": "transactions"
     },
+    "paginator": {
+        "itemsPerPage": "Items per page",
+        "nextPage": "Next page",
+        "previousPage": "Previous page",
+        "firstPage": "First page",
+        "lastPage": "Last page",
+        "ofCounter": "of"
+    },
     "general": {
         "coop": "COOP Program",
         "sector": "Sector",
@@ -77,7 +88,8 @@
         "others": "Others",
         "errorData": "Error getting data",
         "withoutData": "No data available",
-        "withoutData2": "Insufficient sample"
+        "withoutData2": "Insufficient sample",
+        "withoutData3": "No data found"
     },
     "others": {
         "by": "by",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -10,7 +10,39 @@
         "overviewCountry": "Country overview",
         "overviewRetailer": "Retailer overview",
         "otherTools": "Other tools",
-        "feelingsAnalysis": "Feelings Analysis Omnichat"
+        "feelingsAnalysis": "Feelings Analysis Omnichat",
+        "campaignComparator": "Campaign comparator",
+        "settings": "Settings",
+        "manager": "Manage",
+        "activityRegister": "Activity Register"
+    },
+    "filters": {
+        "country": "Country",
+        "countryPh": "Select a Country",
+        "countrySearchPh": "Search Country",
+        "countryError1": "Error when consulting countries",
+        "retailerPh": "Select a Retailer",
+        "retailerSearchPh": "Search Retailer",
+        "retailerError1": "Select at least one Retailer",
+        "retailerError2": "Error when consulting retailers",
+        "period": "Period",
+        "periodPh1": "Start date",
+        "periodPh2": "End date",
+        "periodError1": "Invalid start date",
+        "periodError2": "Invalid end date",
+        "sectorPh": "Select a sector",
+        "sectorError1": "Select at least one Sector",
+        "sectorError2": "Error when consulting sectors",
+        "categoryPh": "Select a Category",
+        "categoryError1": "Select at least one Category",
+        "categoryError2": "Error when consulting categories",
+        "campaignPh": "Select a campaign",
+        "campaignSearchPh": "Search Campaign",
+        "campaignError1": "There aren't campaigns for the selected Period, Sectors and Categories",
+        "campaignError2": "Error when consulting campaigns",
+        "sourcePh": "Select a Source",
+        "sourceError1": "Select at least one Source",
+        "filter": "Filter"
     },
     "overviewLatam": {
         "chart1CardTitle1": "Investment in ",
@@ -31,6 +63,7 @@
         "transactions": "transactions"
     },
     "general": {
+        "coop": "COOP Program",
         "sector": "Sector",
         "category": "Category",
         "source": "Source",
@@ -48,6 +81,15 @@
     },
     "others": {
         "by": "by",
-        "all": "all"
+        "all": "all",
+        "allPluralM": "all",
+        "allPluralF": "all",
+        "otherSingularM": "another",
+        "otherSingularF": "another",
+        "otherPluralM": "others",
+        "otherPluralF": "others",
+        "only": "only",
+        "men": "Men",
+        "women": "Women"
     }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -13,7 +13,41 @@
         "feelingsAnalysis": "Feelings Analysis Omnichat"
     },
     "overviewLatam": {
+        "chart1CardTitle1": "Investment in ",
+        "chart1CardTitle2": "Sectors",
+        "chart1CardTitle3": "Categories",
+        "chart1CardTitle4": " by Country",
+        "chart2CardTitle1": " by Devices",
+        "chart3CardTitle1": " by Gender",
+        "chart4CardTitle1": " by Age",
+        "chart5CardTitle1": " by Gender and Age",
+        "chart7CardTitle1": "Investment vs Revenue",
         "chart7ValueName1": "Investment",
-        "chart7ValueName2": "Revenue"
+        "chart7ValueName2": "Revenue",
+        "table1CardTitle1": "Top Products"
+    },
+    "kpis": {
+        "investment": "investment",
+        "transactions": "transactions"
+    },
+    "general": {
+        "sector": "Sector",
+        "category": "Category",
+        "source": "Source",
+        "traffic": "Traffic",
+        "sales": "Sales",
+        "users": "Users",
+        "ranking": "Ranking",
+        "product": "Product",
+        "amount": "Amount",
+        "institutional": "Institutional",
+        "others": "Others",
+        "errorData": "Error getting data",
+        "withoutData": "No data available",
+        "withoutData2": "Insufficient sample"
+    },
+    "others": {
+        "by": "by",
+        "all": "all"
     }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -14,7 +14,10 @@
         "campaignComparator": "Comparador de campaña",
         "settings": "Configuración",
         "manager": "Administrador",
-        "activityRegister": "Registro de actividad"
+        "activityRegister": "Registro de actividad",
+        "sidebarError1": "Ocurrió un error al consultar los",
+        "sidebarError2": "países o retailers",
+        "sidebarError3": "a los que tienes acceso. Intenta más tarde."
     },
     "filters": {
         "country": "País",
@@ -62,6 +65,14 @@
         "investment": "inversión",
         "transactions": "transacciones"
     },
+    "paginator": {
+        "itemsPerPage": "Registros por página",
+        "nextPage": "Siguiente",
+        "previousPage": "Anterior",
+        "firstPage": "Primera página",
+        "lastPage": "Última página",
+        "ofCounter": "de"
+    },
     "general": {
         "coop": "Programa COOP",
         "sector": "Sector",
@@ -78,7 +89,8 @@
         "others": "Otros",
         "errorData": "Error al consultar datos",
         "withoutData": "Sin datos disponibles",
-        "withoutData2": "Muestra insuficiente"
+        "withoutData2": "Muestra insuficiente",
+        "withoutData3": "No se encontraron datos"
     },
     "others": {
         "by": "por",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -13,7 +13,41 @@
         "feelingsAnalysis": "Análisis de sentimientos Omnichat"
     },
     "overviewLatam": {
+        "chart1CardTitle1": "Inversión en ",
+        "chart1CardTitle2": "Sectores",
+        "chart1CardTitle3": "Categorías",
+        "chart1CardTitle4": " por País",
+        "chart2CardTitle1": " por Dispositivos",
+        "chart3CardTitle1": " por Género",
+        "chart4CardTitle1": " por Edad",
+        "chart5CardTitle1": " por Género y Edad",
+        "chart7CardTitle1": "Inversión vs Revenue",
         "chart7ValueName1": "Inversión",
-        "chart7ValueName2": "Revenue"
+        "chart7ValueName2": "Revenue",
+        "table1CardTitle1": "Top Productos"
+    },
+    "kpis": {
+        "investment": "inversión",
+        "transactions": "transacciones"
+    },
+    "general": {
+        "sector": "Sector",
+        "category": "Categoría",
+        "source": "Medio",
+        "traffic": "Tráfico",
+        "sales": "Ventas",
+        "users": "Usuarios",
+        "ranking": "Ranking",
+        "product": "Producto",
+        "amount": "Catindad",
+        "institutional": "Institucional",
+        "others": "Otros",
+        "errorData": "Error al consultar datos",
+        "withoutData": "Sin datos disponibles",
+        "withoutData2": "Muestra insuficiente"
+    },
+    "others": {
+        "by": "por",
+        "all": "todo"
     }
 }

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -10,7 +10,39 @@
         "overviewCountry": "Visión general del país",
         "overviewRetailer": "Visión general del retailer",
         "otherTools": "Otras herramientas",
-        "feelingsAnalysis": "Análisis de sentimientos Omnichat"
+        "feelingsAnalysis": "Análisis de sentimientos Omnichat",
+        "campaignComparator": "Comparador de campaña",
+        "settings": "Configuración",
+        "manager": "Administrador",
+        "activityRegister": "Registro de actividad"
+    },
+    "filters": {
+        "country": "País",
+        "countryPh": "Selecciona un País",
+        "countrySearchPh": "Buscar País",
+        "countryError1": "Error al consultar países",
+        "retailerPh": "Selecciona un Retailer",
+        "retailerSearchPh": "Buscar Retailer",
+        "retailerError1": "Selecciona al menos un Retailer",
+        "retailerError2": "Error al consultar retailers",
+        "period": "Período",
+        "periodPh1": "Fecha inicio",
+        "periodPh2": "Fecha fin",
+        "periodError1": "Fecha inicio inválida",
+        "periodError2": "Fecha fin inválida",
+        "sectorPh": "Selecciona un Sector",
+        "sectorError1": "Selecciona al menos un Sector",
+        "sectorError2": "Error al consultar sectores",
+        "categoryPh": "Selecciona una Categoría",
+        "categoryError1": "Selecciona al menos una Categoría",
+        "categoryError2": "Error al consultar categorías",
+        "campaignPh": "Selecciona una Campaña",
+        "campaignSearchPh": "Buscar Campaña",
+        "campaignError1": "No existen campañas para el Periodo, Sectores y Categorías seleccionados",
+        "campaignError2": "Error al consultar campañas",
+        "sourcePh": "Selecciona una Fuente",
+        "sourceError1": "Selecciona al menos una Fuente",
+        "filter": "Filtrar"
     },
     "overviewLatam": {
         "chart1CardTitle1": "Inversión en ",
@@ -31,9 +63,11 @@
         "transactions": "transacciones"
     },
     "general": {
+        "coop": "Programa COOP",
         "sector": "Sector",
         "category": "Categoría",
-        "source": "Medio",
+        "source": "Fuente",
+        "campaign": "Campaña",
         "traffic": "Tráfico",
         "sales": "Ventas",
         "users": "Usuarios",
@@ -48,6 +82,15 @@
     },
     "others": {
         "by": "por",
-        "all": "todo"
+        "all": "todo",
+        "allPluralM": "todos",
+        "allPluralF": "todas",
+        "otherSingularM": "otro",
+        "otherSingularF": "otra",
+        "otherPluralM": "otros",
+        "otherPluralF": "otras",
+        "only": "solamente",
+        "men": "Hombres",
+        "women": "Mujeres"
     }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -14,7 +14,10 @@
         "campaignComparator": "Comparador de campanhas",
         "settings": "Definições",
         "manager": "Gerenciar",
-        "activityRegister": "Registro de atividades"
+        "activityRegister": "Registro de atividades",
+        "sidebarError1": "Ocorreu um erro ao consultar os",
+        "sidebarError2": "países ou retailers",
+        "sidebarError3": "aos quais você tem acesso. Por favor tente mais tarde."
     },
     "filters": {
         "country": "País",
@@ -62,6 +65,14 @@
         "investment": "investimento",
         "transactions": "transações"
     },
+    "paginator": {
+        "itemsPerPage": "Itens por página",
+        "nextPage": "Próximo",
+        "previousPage": "Anterior",
+        "firstPage": "Primeira página",
+        "lastPage": "Última página",
+        "ofCounter": "de"
+    },
     "general": {
         "coop": "Programa COOP",
         "sector": "Setor",
@@ -77,7 +88,8 @@
         "others": "Outros",
         "errorData": "Erro ao consultar dados",
         "withoutData": "Nenhum dado disponível",
-        "withoutData2": "Amostra insuficiente"
+        "withoutData2": "Amostra insuficiente",
+        "withoutData3": "Nenhum dado encontrado"
     },
     "others": {
         "by": "por",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -10,7 +10,39 @@
         "overviewCountry": "Visão geral do país",
         "overviewRetailer": "Visão geral do retailer",
         "otherTools": "Outras ferramentas",
-        "feelingsAnalysis": "Análise de sentimentos Omnichat"
+        "feelingsAnalysis": "Análise de sentimentos Omnichat",
+        "campaignComparator": "Comparador de campanhas",
+        "settings": "Definições",
+        "manager": "Gerenciar",
+        "activityRegister": "Registro de atividades"
+    },
+    "filters": {
+        "country": "País",
+        "countryPh": "Selecione um Pais",
+        "countrySearchPh": "Procure um país",
+        "countryError1": "Erro ao consultar países",
+        "retailerPh": "Selecione um Retailer",
+        "retailerSearchPh": "Procure um Retailer",
+        "retailerError1": "Selecione pelo menos um Retailer",
+        "retailerError2": "Erro ao consultar retailers",
+        "period": "Período",
+        "periodPh1": "Data de início",
+        "periodPh2": "Data de término",
+        "periodError1": "Data de início inválida",
+        "periodError2": "Data de término inválida",
+        "sectorPh": "Selecione um Setor",
+        "sectorError1": "Selecione pelo menos um Setor",
+        "sectorError2": "Erro ao consultar setores",
+        "categoryPh": "Selecione uma Categoría",
+        "categoryError1": "Selecione pelo menos uma Categoria",
+        "categoryError2": "Erro ao consultar categorias",
+        "campaignPh": "Selecione uma campanha",
+        "campaignSearchPh": "Procure uma Campaña",
+        "campaignError1": "Não há campanhas para o período, setores e categorias selecionados",
+        "campaignError2": "Erro ao consultar campanhas",
+        "sourcePh": "Selecione uma Fonte",
+        "sourceError1": "Selecione pelo menos uma Fonte",
+        "filter": "Filtro"
     },
     "overviewLatam": {
         "chart1CardTitle1": "Investimento em ",
@@ -31,6 +63,7 @@
         "transactions": "transações"
     },
     "general": {
+        "coop": "Programa COOP",
         "sector": "Setor",
         "category": "Categoria",
         "source": "Fonte",
@@ -48,6 +81,15 @@
     },
     "others": {
         "by": "por",
-        "all": "tudo"
+        "all": "tudo",
+        "allPluralM": "todos",
+        "allPluralF": "todas",
+        "otherSingularM": "outro",
+        "otherSingularF": "outra",
+        "otherPluralM": "outros",
+        "otherPluralF": "outras",
+        "only": "somente",
+        "men": "Hombres",
+        "women": "Mulheres"
     }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -13,7 +13,41 @@
         "feelingsAnalysis": "Análise de sentimentos Omnichat"
     },
     "overviewLatam": {
+        "chart1CardTitle1": "Investimento em ",
+        "chart1CardTitle2": "Setors",
+        "chart1CardTitle3": "Categorias",
+        "chart1CardTitle4": " por País",
+        "chart2CardTitle1": " por Dispositivos",
+        "chart3CardTitle1": " por Gênero",
+        "chart4CardTitle1": " por Idade",
+        "chart5CardTitle1": " por Gênero e Idade",
+        "chart7CardTitle1": "Investimento vs Revenue",
         "chart7ValueName1": "Investimento",
-        "chart7ValueName2": "Revenue"
+        "chart7ValueName2": "Revenue",
+        "table1CardTitle1": "Top Produtos"
+    },
+    "kpis": {
+        "investment": "investimento",
+        "transactions": "transações"
+    },
+    "general": {
+        "sector": "Setor",
+        "category": "Categoria",
+        "source": "Fonte",
+        "traffic": "Tráfego",
+        "sales": "Vendas",
+        "users": "Usuários",
+        "ranking": "Ranking",
+        "product": "Produtos",
+        "amount": "Quantidade",
+        "institutional": "Institucional",
+        "others": "Outros",
+        "errorData": "Erro ao consultar dados",
+        "withoutData": "Nenhum dado disponível",
+        "withoutData2": "Amostra insuficiente"
+    },
+    "others": {
+        "by": "por",
+        "all": "tudo"
     }
 }


### PR DESCRIPTION
# Problem Description
- Is necessary add i18n in English, Spanish and Portuguese, in this primer interaction is required translate sidebar, general-filters and latam-overview components

# Features
- Update i18n files
- Update the following components
   - sidebar
   - navbar
   - overview-latam
   - generic-table
   - chart-pyramid
   - chart-line-series

# Where this change will be used
- Where these components will be use in dashboard module

# More details
![image](https://user-images.githubusercontent.com/38545126/121459181-63a1cb80-c970-11eb-93b3-54a52746db5c.png)
![image](https://user-images.githubusercontent.com/38545126/121459201-6c929d00-c970-11eb-8247-ef170f29d516.png)
![image](https://user-images.githubusercontent.com/38545126/121459241-803e0380-c970-11eb-9f09-59990d05e1d2.png)
![image](https://user-images.githubusercontent.com/38545126/121459262-89c76b80-c970-11eb-834d-3a2278faf988.png)
