### PR TITLE
fix errors generated by some charts components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.html
@@ -3,16 +3,9 @@
     <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [ngClass]="{'chart-hidden': status !== 2 || chart?.data?.length < 1}" [id]="chartID" style="height: 100%">
+    <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%">
     </div>
 
-    <!-- empty data -->
-    <div [hidden]="status !== 2 || chart?.data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
-            {{ 'general.withoutData' | translate }} <br>
-            {{ 'general.withoutData2' | translate }}
-        </p>
-    </div>
     <!-- error -->
     <div [hidden]="status !== 3" class="chart-error-container text-muted">
         <span [hidden]="!errorLegend">{{ errorLegend }}</span>

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.html
@@ -3,15 +3,7 @@
     <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
-
-    <!-- empty data -->
-    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
-            {{ 'general.withoutData' | translate }} <br>
-            {{ 'general.withoutData2' | translate }}
-        </p>
-    </div>
+    <div [hidden]="status !== 2" [id]="chartID" style="height: 100%"></div>
 
     <!-- error -->
     <div [hidden]="status !== 3" class="chart-error-container text-muted">

--- a/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-line-series/chart-line-series.component.html
@@ -3,16 +3,7 @@
     <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [ngClass]="{'chart-hidden': status !== 2 || chart?.series?.values.length < 1}" [id]="chartID"
-        style="height: 100%">
-    </div>
-
-    <!-- empty data -->
-    <div [hidden]="status !== 2 || chart?.series?.values.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
-            {{ 'general.withoutData' | translate }} <br>
-            {{ 'general.withoutData2' | translate }}
-        </p>
+    <div [ngClass]="{'chart-hidden': status !== 2}" [id]="chartID" style="height: 100%">
     </div>
 
     <!-- error -->

--- a/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-multiple-axes/chart-multiple-axes.component.html
@@ -3,7 +3,7 @@
     <app-chart-loader [hidden]="status > 1"></app-chart-loader>
 
     <!-- ready -->
-    <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
+    <div [ngClass]="{'chart-hidden': status !== 2 || data?.length < 1 }" [id]="chartID" style="height: 100%"></div>
 
     <!-- empty data -->
     <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">


### PR DESCRIPTION
# Problem Description
- There are some errors in charts when is used a directive structure (hidden) to show or hide dymanic content when the method ngAfterViewInit is used in the chart component

# Bug Fixes
- Remove variables which generate conflicts in directive structure in the following components
 - chart-bar-group
 - chart-column-line-mix
 - chart-line-series
 - chart-multiple-axes

# Where this change will be used
- Where this charts will be used in dashboard module
