### PR TITLE
add functionality to audiences-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -1,4 +1,4 @@
-<!-- TRÁFICO, CONVERSIONES, AUP & BR -->
+<!-- TRAFFIC AND CONVERSIONS - DEMOGRAPHICS -->
 <ng-container>
     <div class="row mt-4">
         <div class="col-12">
@@ -11,19 +11,19 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="changeData('traffic', 1)">Tráfico</a>
+                            (click)="getDomographicsByMetric('traffic')">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="changeData('conversions', 2)">Conversiones</a>
+                            (click)="getDomographicsByMetric('conversions')">Conversiones</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                            (click)="changeData('aup', 3)">AUP</a>
+                            (click)="getDomographicsByMetric('aup')">AUP</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 4}"
-                            (click)="changeData('br', 4)">BR</a>
+                            (click)="getDomographicsByMetric('bouncerate')">BR</a>
                     </li>
                 </ul>
             </div>
@@ -43,8 +43,8 @@
                         <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial [data]="devices" name="devices" category="name" iconType="monitor"
-                            height="280px">
+                        <app-chart-pictorial name="aud-devices" [data]="demographics?.device"
+                            [status]="demoReqStatus[0].reqStatus" category="name" iconType="monitor" height="280px">
                         </app-chart-pictorial>
                     </div>
                 </div>
@@ -60,8 +60,8 @@
                         <span *ngSwitchCase="4" class="h4">BR por Género</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial [data]="gender" name="gender" category="name" iconType="man"
-                            height="280px">
+                        <app-chart-pictorial name="aud-gender" [data]="demographics?.gender"
+                            [status]="demoReqStatus[1].reqStatus" category="name" iconType="man" height="280px">
                         </app-chart-pictorial>
                     </div>
                 </div>
@@ -73,14 +73,12 @@
             <!-- devices -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por dispositivos</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por dispositivos</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por dispositivos</span>
-                        <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
+                    <div class="card-header">
+                        <span class="h4">AUP por dispositivos</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar [data]="devices" name="devices" valueFormat="USD" category="name" height="280px"
+                        <app-chart-bar name="aud-devices" [data]="demographics?.device"
+                            [status]="demoReqStatus[0].reqStatus" valueFormat="USD" category="name" height="280px"
                             [legendsByCategory]="true">
                         </app-chart-bar>
                     </div>
@@ -90,14 +88,12 @@
             <!-- gender -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por Género</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por Género</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por Género</span>
-                        <span *ngSwitchCase="4" class="h4">BR por Género</span>
+                    <div class="card-header">
+                        <span class="h4">AUP por Género</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar [data]="gender" name="gender" valueFormat="USD" category="name" height="280px"
+                        <app-chart-bar name="aud-gender" [data]="demographics?.gender"
+                            [status]="demoReqStatus[1].reqStatus" valueFormat="USD" category="name" height="280px"
                             [legendsByCategory]="true">
                         </app-chart-bar>
                     </div>
@@ -110,11 +106,8 @@
             <!-- devices -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por dispositivos</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por dispositivos</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por dispositivos</span>
-                        <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
+                    <div class="card-header">
+                        <span class="h4">BR por dispositivos</span>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -122,24 +115,26 @@
                                 <div class="chart-legend mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Desktop {{ desktopByBR[1].value }}%</div>
+                                        <div class="legend-label">Desktop {{ demographics?.deviceDesktop[1]?.value }}%
+                                        </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="desktopByBR" name="devices-desktop"
-                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
-                                    height="280px">
+                                <app-chart-pictorial name="aud-devices-desktop" [data]="demographics?.deviceDesktop"
+                                    [status]="demoReqStatus[0].reqStatus" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                    category="name" iconType="monitor" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mobile {{ mobileByBR[1].value }}%</div>
+                                        <div class="legend-label">Mobile {{ demographics?.deviceMobile[1]?.value }}%
+                                        </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="mobileByBR" name="devices-mobile"
-                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
-                                    height="280px">
+                                <app-chart-pictorial name="aud-devices-mobile" [data]="demographics?.deviceMobile"
+                                    [status]="demoReqStatus[0].reqStatus" [uniqueDimensionConf]="{color: '#6794DC'}"
+                                    category="name" iconType="cellphone" height="280px">
                                 </app-chart-pictorial>
                             </div>
                         </div>
@@ -150,11 +145,8 @@
             <!-- gender -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por Género</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por Género</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por Género</span>
-                        <span *ngSwitchCase="4" class="h4">BR por Género</span>
+                    <div class="card-header">
+                        <span class="h4">BR por Género</span>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -162,12 +154,12 @@
                                 <div class="chart-legend mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Hombres {{ menByBR[1].value }}%</div>
+                                        <div class="legend-label">Hombres {{ demographics?.genderMan[0]?.value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="menByBR" name="gender-man"
-                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
-                                    height="280px">
+                                <app-chart-pictorial name="aud-gender-man" [data]="demographics?.genderMan"
+                                    [status]="demoReqStatus[1].reqStatus" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                    category="name" iconType="man" height="280px">
                                 </app-chart-pictorial>
                             </div>
 
@@ -175,12 +167,13 @@
                                 <div class="chart-legend mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mujeres {{ womenByBR[1].value }}%</div>
+                                        <div class="legend-label">Mujeres {{ demographics?.genderWoman[1]?.value }}%
+                                        </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="womenByBR" name="gender-woman"
-                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
-                                    height="280px">
+                                <app-chart-pictorial name="aud-gender-woman" [data]="demographics?.genderWoman"
+                                    [status]="demoReqStatus[1].reqStatus" [uniqueDimensionConf]="{color: '#6794DC'}"
+                                    category="name" iconType="woman" height="280px">
                                 </app-chart-pictorial>
                             </div>
                         </div>
@@ -199,8 +192,10 @@
                     <span *ngSwitchCase="4" class="h4">BR por Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="age" name="age" category="age"
-                        [valueFormat]="selectedTab1 !== 3 ? '%' : 'USD'" height="280px">
+                    <app-chart-lollipop name="aud-age" [data]="demographics?.age" category="age"
+                        [value]="selectedTab1 === 1 ? 'visits' : selectedTab1 === 2 ? 'sales' : selectedTab1 === 3 ? 'aup' : 'value'"
+                        [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
+                        height="280px" [status]="demoReqStatus[2].reqStatus">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -215,23 +210,39 @@
                     <span *ngSwitchCase="3" class="h4">AUP por Género y Edad</span>
                     <span *ngSwitchCase="4" class="h4">BR por Género y Edad</span>
                 </div>
-                <div class="card-body">
-                    <ng-container *ngIf="selectedTab1 !== 3">
-                        <app-chart-pyramid [data]="ageByGender" name="age-and-gender" valueFormat="%" height="280px">
-                        </app-chart-pyramid>
-                    </ng-container>
-                    <ng-container *ngIf="selectedTab1 === 3">
-                        <app-chart-pyramid [data]="ageByGender" name="age-and-gender-2" height="280px"
-                            valueFormat="USD">
-                        </app-chart-pyramid>
-                    </ng-container>
+                <div class="card-body" style="height: 328px">
+                    <!-- loader -->
+                    <app-chart-loader *ngIf="chartsInitLoad && demoReqStatus[3].reqStatus <= 1">
+                    </app-chart-loader>
+
+                    <!-- ready -->
+                    <app-chart-pyramid *ngIf="demographics?.genderByAge?.length > 0" name="aud-age-and-gender"
+                        [data]="demographics?.genderByAge" [status]="demoReqStatus[3].reqStatus"
+                        [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
+                        height="280px">
+                    </app-chart-pyramid>
+
+                    <!-- empty data -->
+                    <div *ngIf="demoReqStatus[3].reqStatus === 2 && demographics?.genderByAge?.length === 0"
+                        class="chart-error-container text-muted">
+                        <p class="text-center">
+                            {{ 'general.withoutData' | translate }} <br>
+                            {{ 'general.withoutData2' | translate }}
+                        </p>
+                    </div>
+
+                    <!-- error -->
+                    <div *ngIf="chartsInitLoad && demoReqStatus[3].reqStatus === 3"
+                        class="chart-error-container text-muted">
+                        <span> {{ 'general.errorData' | translate }}</span>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 </ng-container>
 
-<!-- TRAFICO Y CONVERSIONES POR DIA Y HORA -->
+<!-- TRAFFIC AND CONVERSIONS - WEEKDAYS / HOURS -->
 <ng-container>
     <div class="row mt-5">
         <div class="col-12">
@@ -244,11 +255,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="selectedTab2 = 1">Tráfico</a>
+                            (click)="getWeekdaysAndHoursByMetric('traffic')">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="selectedTab2 = 2">Conversiones</a>
+                            (click)="getWeekdaysAndHoursByMetric('conversions')">Conversiones</a>
                     </li>
                 </ul>
             </div>
@@ -263,7 +274,8 @@
                         por día de la semana y hora del día</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-heat-map [data]="heatmapData" name="weekday-sesions" height="100%">
+                    <app-chart-heat-map name="aud-weekday-sesions" [data]="weekDaysAndHours?.weekdayAndHour"
+                        [status]="weekDaysAndHoursReqStatus[0].reqStatus" categoryX="weekdayName" height="100%">
                     </app-chart-heat-map>
                 </div>
             </div>
@@ -275,7 +287,8 @@
                         por día de la semana</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-bar-horizontal [data]="trafficByDay" name="traffic-day" category='weekday' value='value'
+                    <app-chart-bar-horizontal name="aud-traffic-day" [data]="weekDaysAndHours?.weekday"
+                        [status]="weekDaysAndHoursReqStatus[1].reqStatus" category='weekdayName' value='value'
                         height="250px">
                     </app-chart-bar-horizontal>
                 </div>
@@ -287,8 +300,8 @@
                         por hora del día</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="trafficByHour" name="traffic-hour" category="hour" value="visits"
-                        height="250px">
+                    <app-chart-lollipop name="aud-traffic-hour" [data]="weekDaysAndHours?.hour"
+                        [status]="weekDaysAndHoursReqStatus[2].reqStatus" category="hour" height="250px">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -303,12 +316,18 @@
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">Conversiones y tráfico por día</span>
+                    <span class="h4">Conversiones y tráfico por día de la semana</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-line-comparison [data]="conversionsTrafficPerDay" name="conv-tra-day"
-                        valueName1="Conversiones" valueName2="Tráfico">
-                    </app-chart-line-comparison>
+                    <!-- <app-chart-multiple-axes name="aud-conv-tra-day" category="weekday" value1="conversions" value2="visits"
+                    valueName1="Conversiones" valueName2="Tráfico"
+                    [data]="conversionsVsTraffic?.weekday" [status]="conversionsVsTrafficReqStatus[0].reqStatus">
+                    </app-chart-multiple-axes> -->
+
+                    <app-chart-column-line-mix name="aud-conv-tra-day" [data]="conversionsVsTraffic?.weekday"
+                        [status]="conversionsVsTrafficReqStatus[0].reqStatus" category="weekdayName"
+                        columnValue="visits" lineValue="conversions" columnName="Tráfico" lineName="Conversiones">
+                    </app-chart-column-line-mix>
                 </div>
             </div>
         </div>
@@ -318,44 +337,79 @@
                     <span class="h4">Conversiones y tráfico por hora del día</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-line-comparison [data]="conversionsTrafficPerHour" name="conv-tra-hour"
-                        valueName1="Conversiones" valueName2="Tráfico" inputDateFormat="HH:mm">
-                    </app-chart-line-comparison>
+                    <!-- <app-chart-multiple-axes name="aud-conv-tra-hour" category="hour" value1="conversions" value2="visits"
+                        valueName1="Conversiones" valueName2="Tráfico"
+                        [data]="conversionsVsTraffic?.hour" [status]="conversionsVsTrafficReqStatus[1].reqStatus" inputDateFormat="HH:mm">
+                    </app-chart-multiple-axes> -->
+
+                    <app-chart-column-line-mix name="aud-conv-tra-hour" [data]="conversionsVsTraffic?.hour"
+                        [status]="conversionsVsTrafficReqStatus[1].reqStatus" category="hour" columnValue="visits"
+                        lineValue="conversions" columnName="Tráfico" lineName="Conversiones" joinTextInTooltip="a las">
+                    </app-chart-column-line-mix>
                 </div>
             </div>
         </div>
     </div>
 </ng-container>
 
-<!-- AUDIENCIAS -->
-<ng-container>
-    <div class="row mt-5">
-        <div class="col-12">
-            <span class="h3">Audiencias - Afinidad y Mercado</span>
-        </div>
-        <div class="col-12 col-lg-6 mt-4">
-            <div class="card">
-                <div class="card-header">
-                    <span class="h4">Categoría de afinidad (cobertura)</span>
-                </div>
-                <div class="card-body">
-                    <p class="text-center text-muted">
-                        Work in progress...
-                    </p>
+<!-- INTERESTS -->
+<div class="row mt-5">
+    <div class="col-12">
+        <span class="h3">Audiencias - Afinidad y Mercado</span>
+    </div>
+    <div class="col-12 col-xl-6 mt-4">
+        <div class="card height-fluid">
+            <div class="card-header header-info">
+                <span class="h4 mr-2 mb-0">Categoría de afinidad</span>
+                <div class="info-popover" ngbDropdown>
+                    <a ngbDropdownToggle>
+                        <i class="fas fa-info-circle"></i>
+                    </a>
+                    <div class="content" ngbDropdownMenu>
+                        <p>
+                            Las categorías de afinidad se utilizan para llegar a clientes potenciales, para que conozcan
+                            la marca o producto. Estos son usuarios que se encuentran más arriba en el embudo de compra,
+                            cerca del comienzo del proceso.
+                        </p>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div class="col-12 col-lg-6 mt-4">
-            <div class="card">
-                <div class="card-header">
-                    <span class="h4">Segmento de mercado</span>
-                </div>
-                <div class="card-body">
-                    <p class="text-center text-muted">
-                        Work in progress...
-                    </p>
-                </div>
+            <div class="card-body sm-chart-container">
+                <app-chart-bar-horizontal name="aud-interests-affinity-category" [data]="interests?.affinityCategory"
+                    [status]="interestsReqStatus[0].reqStatus" value="users" [singleColorBars]="true">
+                </app-chart-bar-horizontal>
+
+                <small class="text-muted mt-2 d-block d-sm-none">
+                    Para mejor visualización usar la versión de <strong>Escritorio</strong>
+                </small>
             </div>
         </div>
     </div>
-</ng-container>
+    <div class="col-12 col-xl-6 mt-4">
+        <div class="card height-fluid">
+            <div class="card-header header-info">
+                <span class="h4 mr-2 mb-0">Segmento de mercado</span>
+                <div class="info-popover" ngbDropdown>
+                    <a ngbDropdownToggle>
+                        <i class="fas fa-info-circle"></i>
+                    </a>
+                    <div class="content" ngbDropdownMenu>
+                        <p>
+                            Es más probable que los usuarios de estos segmentos estén listos para comprar productos o
+                            servicios en la categoría especificada. Estos son los usuarios que se encuentran más abajo
+                            en el embudo de compra, cerca del final del proceso.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="card-body sm-chart-container">
+                <app-chart-bar-horizontal name="aud-interests-market-segment" [data]="interests?.marketSegment"
+                    [status]="interestsReqStatus[1].reqStatus" value="users" [singleColorBars]="true">
+                </app-chart-bar-horizontal>
+                <small class="text-muted mt-2 d-block d-sm-none">
+                    Para mejor visualización usar la versión de <strong>Escritorio</strong>
+                </small>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.scss
@@ -46,3 +46,40 @@
         }
     }
 }
+
+.card-header.header-info {
+    align-items: center;
+    display: flex;
+
+    .info-popover {
+        i {
+            color: #c7c7c7;
+            cursor: pointer;
+            font-size: 18px;
+        }
+
+        .content {
+            padding: 12px;
+           
+            p {
+                font-size: 12.5px;
+                line-height: 18px;
+                color: #000000;
+                margin: 0;
+
+                @media screen and (min-width: 600px) {
+                    width: 250px;
+                }
+            }
+        }
+    }
+}
+
+.sm-chart-container {
+    max-height: 350px;
+    overflow-y: auto;
+}
+
+::-webkit-scrollbar {
+    width: 4px;
+}

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
 import { FiltersStateService } from '../../services/filters-state.service';
 
@@ -10,1282 +11,39 @@ import { FiltersStateService } from '../../services/filters-state.service';
 })
 export class AudiencesWrapperComponent implements OnInit, OnDestroy {
 
-  devicesByTraffic: any[] = [
-    { id: 1, name: 'Desktop', value: 2500 },
-    { id: 2, name: 'Mobile', value: 10500 },
-  ]
-
-  devicesByConversions: any[] = [
-    { id: 1, name: 'Desktop', value: 300 },
-    { id: 2, name: 'Mobile', value: 450 },
-  ]
-
-  desktopByBR: any[] = [
-    { name: 'empty', value: 55 },
-    { id: 1, name: 'Desktop', value: 45 },
-  ]
-
-  mobileByBR: any[] = [
-    { name: 'empty', value: 20 },
-    { id: 1, name: 'Mobile', value: 80 },
-  ]
-
-  womenByBR: any[] = [
-    { name: 'empty', value: 55 },
-    { id: 1, name: 'woman', value: 45 },
-  ]
-
-  menByBR: any[] = [
-    { name: 'empty', value: 30 },
-    { id: 1, name: 'men', value: 70 },
-  ]
-
-
-  genderByTraffic: any[] = [
-    { id: 1, name: 'Hombre', value: 5500 },
-    { id: 2, name: 'Mujer', value: 7500 },
-  ]
-
-  genderByConversions: any[] = [
-    { id: 1, name: 'Hombre', value: 1200 },
-    { id: 2, name: 'Mujer', value: 12800 },
-  ]
-
-  ageByTraffic: any[] = [
-    {
-      'age': '15-19',
-      'value': 3.8
-    }, {
-      'age': '20-24',
-      'value': 5.1
-    }, {
-      'age': '25-29',
-      'value': 5.1
-    }, {
-      'age': '30-34',
-      'value': 4.8
-    }, {
-      'age': '35-39',
-      'value': 4.1
-    }, {
-      'age': '40-44',
-      'value': 3.6
-    }, {
-      'age': '45-49',
-      'value': 3.0
-    }, {
-      'age': '50-54',
-      'value': 2.5
-    }, {
-      'age': '55-59',
-      'value': 1.9
-    }, {
-      'age': '60-64',
-      'value': 1.3
-    }, {
-      'age': '65-69',
-      'value': 1.0
-    }, {
-      'age': '70-74',
-      'value': 0.8
-    }, {
-      'age': '75-79',
-      'value': 0.6
-    }, {
-      'age': '80-54',
-      'value': 0.3
-    }, {
-      'age': '85+',
-      'value': 0.3
-    }
-  ]
-
-  ageByConversions: any[] = [
-    {
-      'age': '15-19',
-      'value': 1.8
-    }, {
-      'age': '20-24',
-      'value': 7.5
-    }, {
-      'age': '25-29',
-      'value': 8.1
-    }, {
-      'age': '30-34',
-      'value': 6.8
-    }, {
-      'age': '35-39',
-      'value': 5.1
-    }, {
-      'age': '40-44',
-      'value': 4.6
-    }, {
-      'age': '45-49',
-      'value': 3.0
-    }, {
-      'age': '50-54',
-      'value': 2.8
-    }, {
-      'age': '55-59',
-      'value': 2.0
-    }, {
-      'age': '60-64',
-      'value': 1.6
-    }, {
-      'age': '65-69',
-      'value': 1.2
-    }, {
-      'age': '70-74',
-      'value': 0.5
-    }, {
-      'age': '75-79',
-      'value': 0.4
-    }, {
-      'age': '80-54',
-      'value': 0.3
-    }, {
-      'age': '85+',
-      'value': 0.1
-    }
-  ]
-
-  ageByAup: any[] = [
-    {
-      'age': '15-19',
-      'value': 150
-    }, {
-      'age': '20-24',
-      'value': 560
-    }, {
-      'age': '25-29',
-      'value': 750
-    }, {
-      'age': '30-34',
-      'value': 780
-    }, {
-      'age': '35-39',
-      'value': 640
-    }, {
-      'age': '40-44',
-      'value': 600
-    }, {
-      'age': '45-49',
-      'value': 420
-    }, {
-      'age': '50-54',
-      'value': 415
-    }, {
-      'age': '55-59',
-      'value': 350
-    }, {
-      'age': '60-64',
-      'value': 300
-    }, {
-      'age': '65-69',
-      'value': 300
-    }, {
-      'age': '70-74',
-      'value': 250
-    }, {
-      'age': '75-79',
-      'value': 230
-    }, {
-      'age': '80-54',
-      'value': 200
-    }, {
-      'age': '85+',
-      'value': 185
-    }
-  ]
-
-  ageByGenderTraffic: any[] = [
-    {
-      'age': '85+',
-      'male': -0.1,
-      'female': 0.3
-    }, {
-      'age': '80-54',
-      'male': -0.2,
-      'female': 0.3
-    }, {
-      'age': '75-79',
-      'male': -0.3,
-      'female': 0.6
-    }, {
-      'age': '70-74',
-      'male': -0.5,
-      'female': 0.8
-    }, {
-      'age': '65-69',
-      'male': -0.8,
-      'female': 1.0
-    }, {
-      'age': '60-64',
-      'male': -1.1,
-      'female': 1.3
-    }, {
-      'age': '55-59',
-      'male': -1.7,
-      'female': 1.9
-    }, {
-      'age': '50-54',
-      'male': -2.2,
-      'female': 2.5
-    }, {
-      'age': '45-49',
-      'male': -2.8,
-      'female': 3.0
-    }, {
-      'age': '40-44',
-      'male': -3.4,
-      'female': 3.6
-    }, {
-      'age': '35-39',
-      'male': -4.2,
-      'female': 4.1
-    }, {
-      'age': '30-34',
-      'male': -5.2,
-      'female': 4.8
-    }, {
-      'age': '25-29',
-      'male': -5.6,
-      'female': 5.1
-    }, {
-      'age': '20-24',
-      'male': -5.1,
-      'female': 5.1
-    }, {
-      'age': '15-19',
-      'male': -3.8,
-      'female': 3.8
-    }
-  ]
-
-  ageByGenderConversions: any[] = [
-    {
-      'age': '85+',
-      'male': -0.1,
-      'female': 0.0
-    }, {
-      'age': '80-54',
-      'male': -0.2,
-      'female': 0.1
-    }, {
-      'age': '75-79',
-      'male': -0.2,
-      'female': 0.4
-    }, {
-      'age': '70-74',
-      'male': -0.4,
-      'female': 0.6
-    }, {
-      'age': '65-69',
-      'male': -0.7,
-      'female': 1.3
-    }, {
-      'age': '60-64',
-      'male': -1.8,
-      'female': 2.3
-    }, {
-      'age': '55-59',
-      'male': -2.7,
-      'female': 2.1
-    }, {
-      'age': '50-54',
-      'male': -3.0,
-      'female': 2.9
-    }, {
-      'age': '45-49',
-      'male': -3.4,
-      'female': 3.0
-    }, {
-      'age': '40-44',
-      'male': -4.8,
-      'female': 3.6
-    }, {
-      'age': '35-39',
-      'male': -5.2,
-      'female': 4.1
-    }, {
-      'age': '30-34',
-      'male': -6.1,
-      'female': 4.8
-    }, {
-      'age': '25-29',
-      'male': -8.3,
-      'female': 7.5
-    }, {
-      'age': '20-24',
-      'male': -8.8,
-      'female': 9.0
-    }, {
-      'age': '15-19',
-      'male': -3.8,
-      'female': 3.4
-    }
-  ]
-
-  ageByGenderByAup: any[] = [
-    {
-      'age': '85+',
-      'male': -70,
-      'female': 75
-    }, {
-      'age': '80-54',
-      'male': -80,
-      'female': 85
-    }, {
-      'age': '75-79',
-      'male': -95,
-      'female': 105
-    }, {
-      'age': '70-74',
-      'male': -115,
-      'female': 100
-    }, {
-      'age': '65-69',
-      'male': -120,
-      'female': 135
-    }, {
-      'age': '60-64',
-      'male': -126,
-      'female': 155
-    }, {
-      'age': '55-59',
-      'male': -180,
-      'female': 185
-    }, {
-      'age': '50-54',
-      'male': -250,
-      'female': 280
-    }, {
-      'age': '45-49',
-      'male': -265,
-      'female': 265
-    }, {
-      'age': '40-44',
-      'male': -320,
-      'female': 300
-    }, {
-      'age': '35-39',
-      'male': -350,
-      'female': 370
-    }, {
-      'age': '30-34',
-      'male': -450,
-      'female': 480
-    }, {
-      'age': '25-29',
-      'male': -650,
-      'female': 700
-    }, {
-      'age': '20-24',
-      'male': -750,
-      'female': 720
-    }, {
-      'age': '15-19',
-      'male': -250,
-      'female': 280
-    }
-  ]
-
-  devices: any[] = this.devicesByTraffic;
-  gender: any[] = this.genderByTraffic;
-  age: any[] = this.ageByTraffic;
-  ageByGender: any[] = this.ageByGenderTraffic;
-
-  selectedTab1: number = 1;
-  selectedTab2: number = 1;
-
-  heatmapData = [
-    {
-      "hour": "12pm",
-      "weekday": "Lun",
-      "value": 3346
-    },
-    {
-      "hour": "1am",
-      "weekday": "Lun",
-      "value": 2725
-    },
-    {
-      "hour": "2am",
-      "weekday": "Lun",
-      "value": 3052
-    },
-    {
-      "hour": "3am",
-      "weekday": "Lun",
-      "value": 3876
-    },
-    {
-      "hour": "4am",
-      "weekday": "Lun",
-      "value": 4453
-    },
-    {
-      "hour": "5am",
-      "weekday": "Lun",
-      "value": 3972
-    },
-    {
-      "hour": "6am",
-      "weekday": "Lun",
-      "value": 4644
-    },
-    {
-      "hour": "7am",
-      "weekday": "Lun",
-      "value": 5715
-    },
-    {
-      "hour": "8am",
-      "weekday": "Lun",
-      "value": 7080
-    },
-    {
-      "hour": "9am",
-      "weekday": "Lun",
-      "value": 8022
-    },
-    {
-      "hour": "10am",
-      "weekday": "Lun",
-      "value": 8446
-    },
-    {
-      "hour": "11am",
-      "weekday": "Lun",
-      "value": 9313
-    },
-    {
-      "hour": "12am",
-      "weekday": "Lun",
-      "value": 9011
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Lun",
-      "value": 8508
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Lun",
-      "value": 8515
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Lun",
-      "value": 8399
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Lun",
-      "value": 8649
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Lun",
-      "value": 7869
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Lun",
-      "value": 6933
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Lun",
-      "value": 5969
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Lun",
-      "value": 5552
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Lun",
-      "value": 5434
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Lun",
-      "value": 5070
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Lun",
-      "value": 4851
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Mar",
-      "value": 4468
-    },
-    {
-      "hour": "1am",
-      "weekday": "Mar",
-      "value": 3306
-    },
-    {
-      "hour": "2am",
-      "weekday": "Mar",
-      "value": 3906
-    },
-    {
-      "hour": "3am",
-      "weekday": "Mar",
-      "value": 4413
-    },
-    {
-      "hour": "4am",
-      "weekday": "Mar",
-      "value": 4726
-    },
-    {
-      "hour": "5am",
-      "weekday": "Mar",
-      "value": 4584
-    },
-    {
-      "hour": "6am",
-      "weekday": "Mar",
-      "value": 5717
-    },
-    {
-      "hour": "7am",
-      "weekday": "Mar",
-      "value": 6504
-    },
-    {
-      "hour": "8am",
-      "weekday": "Mar",
-      "value": 8104
-    },
-    {
-      "hour": "9am",
-      "weekday": "Mar",
-      "value": 8813
-    },
-    {
-      "hour": "10am",
-      "weekday": "Mar",
-      "value": 9278
-    },
-    {
-      "hour": "11am",
-      "weekday": "Mar",
-      "value": 10425
-    },
-    {
-      "hour": "12am",
-      "weekday": "Mar",
-      "value": 10137
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Mar",
-      "value": 9290
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Mar",
-      "value": 9255
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Mar",
-      "value": 9614
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Mar",
-      "value": 9713
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Mar",
-      "value": 9667
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Mar",
-      "value": 8774
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Mar",
-      "value": 8649
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Mar",
-      "value": 9937
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Mar",
-      "value": 10286
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Mar",
-      "value": 9175
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Mar",
-      "value": 8581
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Mie",
-      "value": 8145
-    },
-    {
-      "hour": "1am",
-      "weekday": "Mie",
-      "value": 7177
-    },
-    {
-      "hour": "2am",
-      "weekday": "Mie",
-      "value": 5657
-    },
-    {
-      "hour": "3am",
-      "weekday": "Mie",
-      "value": 6802
-    },
-    {
-      "hour": "4am",
-      "weekday": "Mie",
-      "value": 8159
-    },
-    {
-      "hour": "5am",
-      "weekday": "Mie",
-      "value": 8449
-    },
-    {
-      "hour": "6am",
-      "weekday": "Mie",
-      "value": 9453
-    },
-    {
-      "hour": "7am",
-      "weekday": "Mie",
-      "value": 9947
-    },
-    {
-      "hour": "8am",
-      "weekday": "Mie",
-      "value": 11471
-    },
-    {
-      "hour": "9am",
-      "weekday": "Mie",
-      "value": 12492
-    },
-    {
-      "hour": "10am",
-      "weekday": "Mie",
-      "value": 9388
-    },
-    {
-      "hour": "11am",
-      "weekday": "Mie",
-      "value": 9928
-    },
-    {
-      "hour": "12am",
-      "weekday": "Mie",
-      "value": 9644
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Mie",
-      "value": 9034
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Mie",
-      "value": 8964
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Mie",
-      "value": 9069
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Mie",
-      "value": 8898
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Mie",
-      "value": 8322
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Mie",
-      "value": 6909
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Mie",
-      "value": 5810
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Mie",
-      "value": 5151
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Mie",
-      "value": 4911
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Mie",
-      "value": 4487
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Mie",
-      "value": 4118
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Jue",
-      "value": 3689
-    },
-    {
-      "hour": "1am",
-      "weekday": "Jue",
-      "value": 3081
-    },
-    {
-      "hour": "2am",
-      "weekday": "Jue",
-      "value": 6525
-    },
-    {
-      "hour": "3am",
-      "weekday": "Jue",
-      "value": 6228
-    },
-    {
-      "hour": "4am",
-      "weekday": "Jue",
-      "value": 6917
-    },
-    {
-      "hour": "5am",
-      "weekday": "Jue",
-      "value": 6568
-    },
-    {
-      "hour": "6am",
-      "weekday": "Jue",
-      "value": 6405
-    },
-    {
-      "hour": "7am",
-      "weekday": "Jue",
-      "value": 8106
-    },
-    {
-      "hour": "8am",
-      "weekday": "Jue",
-      "value": 8542
-    },
-    {
-      "hour": "9am",
-      "weekday": "Jue",
-      "value": 8501
-    },
-    {
-      "hour": "10am",
-      "weekday": "Jue",
-      "value": 8802
-    },
-    {
-      "hour": "11am",
-      "weekday": "Jue",
-      "value": 9420
-    },
-    {
-      "hour": "12am",
-      "weekday": "Jue",
-      "value": 8966
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Jue",
-      "value": 8135
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Jue",
-      "value": 8224
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Jue",
-      "value": 8387
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Jue",
-      "value": 8218
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Jue",
-      "value": 7641
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Jue",
-      "value": 6469
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Jue",
-      "value": 5441
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Jue",
-      "value": 4952
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Jue",
-      "value": 4643
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Jue",
-      "value": 4393
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Jue",
-      "value": 4017
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Vier",
-      "value": 4022
-    },
-    {
-      "hour": "1am",
-      "weekday": "Vier",
-      "value": 3063
-    },
-    {
-      "hour": "2am",
-      "weekday": "Vier",
-      "value": 3638
-    },
-    {
-      "hour": "3am",
-      "weekday": "Vier",
-      "value": 3968
-    },
-    {
-      "hour": "4am",
-      "weekday": "Vier",
-      "value": 4070
-    },
-    {
-      "hour": "5am",
-      "weekday": "Vier",
-      "value": 4019
-    },
-    {
-      "hour": "6am",
-      "weekday": "Vier",
-      "value": 4548
-    },
-    {
-      "hour": "7am",
-      "weekday": "Vier",
-      "value": 5465
-    },
-    {
-      "hour": "8am",
-      "weekday": "Vier",
-      "value": 6909
-    },
-    {
-      "hour": "9am",
-      "weekday": "Vier",
-      "value": 7706
-    },
-    {
-      "hour": "10am",
-      "weekday": "Vier",
-      "value": 7867
-    },
-    {
-      "hour": "11am",
-      "weekday": "Vier",
-      "value": 8615
-    },
-    {
-      "hour": "12am",
-      "weekday": "Vier",
-      "value": 8218
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Vier",
-      "value": 7604
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Vier",
-      "value": 7429
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Vier",
-      "value": 7488
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Vier",
-      "value": 7493
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Vier",
-      "value": 6998
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Vier",
-      "value": 5941
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Vier",
-      "value": 5068
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Vier",
-      "value": 4636
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Vier",
-      "value": 4241
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Vier",
-      "value": 3858
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Vier",
-      "value": 3833
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Sab",
-      "value": 3503
-    },
-    {
-      "hour": "1am",
-      "weekday": "Sab",
-      "value": 2842
-    },
-    {
-      "hour": "2am",
-      "weekday": "Sab",
-      "value": 2808
-    },
-    {
-      "hour": "3am",
-      "weekday": "Sab",
-      "value": 2399
-    },
-    {
-      "hour": "4am",
-      "weekday": "Sab",
-      "value": 2280
-    },
-    {
-      "hour": "5am",
-      "weekday": "Sab",
-      "value": 2139
-    },
-    {
-      "hour": "6am",
-      "weekday": "Sab",
-      "value": 2527
-    },
-    {
-      "hour": "7am",
-      "weekday": "Sab",
-      "value": 2940
-    },
-    {
-      "hour": "8am",
-      "weekday": "Sab",
-      "value": 3066
-    },
-    {
-      "hour": "9am",
-      "weekday": "Sab",
-      "value": 3494
-    },
-    {
-      "hour": "10am",
-      "weekday": "Sab",
-      "value": 3287
-    },
-    {
-      "hour": "11am",
-      "weekday": "Sab",
-      "value": 3416
-    },
-    {
-      "hour": "12am",
-      "weekday": "Sab",
-      "value": 3432
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Sab",
-      "value": 3523
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Sab",
-      "value": 3542
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Sab",
-      "value": 3347
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Sab",
-      "value": 3292
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Sab",
-      "value": 3416
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Sab",
-      "value": 3131
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Sab",
-      "value": 3057
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Sab",
-      "value": 3227
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Sab",
-      "value": 3060
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Sab",
-      "value": 2855
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Sab",
-      "value": 2625
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Dom",
-      "value": 2990
-    },
-    {
-      "hour": "1am",
-      "weekday": "Dom",
-      "value": 2520
-    },
-    {
-      "hour": "2am",
-      "weekday": "Dom",
-      "value": 2334
-    },
-    {
-      "hour": "3am",
-      "weekday": "Dom",
-      "value": 2230
-    },
-    {
-      "hour": "4am",
-      "weekday": "Dom",
-      "value": 2325
-    },
-    {
-      "hour": "5am",
-      "weekday": "Dom",
-      "value": 2019
-    },
-    {
-      "hour": "6am",
-      "weekday": "Dom",
-      "value": 2128
-    },
-    {
-      "hour": "7am",
-      "weekday": "Dom",
-      "value": 2246
-    },
-    {
-      "hour": "8am",
-      "weekday": "Dom",
-      "value": 2421
-    },
-    {
-      "hour": "9am",
-      "weekday": "Dom",
-      "value": 2788
-    },
-    {
-      "hour": "10am",
-      "weekday": "Dom",
-      "value": 2959
-    },
-    {
-      "hour": "11am",
-      "weekday": "Dom",
-      "value": 3018
-    },
-    {
-      "hour": "12am",
-      "weekday": "Dom",
-      "value": 3154
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Dom",
-      "value": 3172
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Dom",
-      "value": 3368
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Dom",
-      "value": 3464
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Dom",
-      "value": 3746
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Dom",
-      "value": 3656
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Dom",
-      "value": 3336
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Dom",
-      "value": 3292
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Dom",
-      "value": 3269
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Dom",
-      "value": 3300
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Dom",
-      "value": 3403
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Dom",
-      "value": 3323
-    }
+  demographics = {}; // for devices, gender, age and age-gender data
+  demoReqStatus = [
+    { name: 'device', reqStatus: 0 },
+    { name: 'gender', reqStatus: 0 },
+    { name: 'age', reqStatus: 0 },
+    { name: 'gender-and-age', reqStatus: 0 }
   ];
 
-  trafficByDay = [
-    { weekday: 'Dom', value: 180 },
-    { weekday: 'Sab', value: 166 },
-    { weekday: 'Vier', value: 166 },
-    { weekday: 'Jue', value: 267 },
-    { weekday: 'Mier', value: 277 },
-    { weekday: 'Mar', value: 270 },
-    { weekday: 'Lun', value: 230 },
-  ]
+  weekDaysAndHours = {}; // for weekday, weekday and hour, and hour
+  weekDaysAndHoursReqStatus = [
+    { name: 'weekday-and-hour', reqStatus: 0 },
+    { name: 'weekday', reqStatus: 0 },
+    { name: 'hour', reqStatus: 0 },
+  ];
 
-  trafficByHour = [
-    { hour: '12 AM', visits: 5 },
-    { hour: '3 AM', visits: 1 },
-    { hour: '6 AM', visits: 9 },
-    { hour: '9 AM', visits: 67 },
-    { hour: '12 PM', visits: 101 },
-    { hour: '3 PM', visits: 81 },
-    { hour: '6 PM', visits: 105 },
-    { hour: '9 PM', visits: 100 }
-  ]
+  conversionsVsTraffic = {}; // by day and by hour
+  conversionsVsTrafficReqStatus = [
+    { name: 'weekday', reqStatus: 0 },
+    { name: 'hour', reqStatus: 0 },
+  ];
 
-  conversionsTrafficPerDay = [
-    { date: new Date(2021, 3, 15), value1: 150, value2: 280, },
-    { date: new Date(2021, 3, 16), value1: 280, value2: 550 },
-    { date: new Date(2021, 3, 17), value1: 130, value2: 430 },
-    { date: new Date(2021, 3, 18), value1: 140, value2: 470 },
-    { date: new Date(2021, 3, 19), value1: 160, value2: 500 },
-    { date: new Date(2021, 3, 20), value1: 80, value2: 750 },
-    { date: new Date(2021, 3, 21), value1: 88, value2: 650 }
-  ]
+  interests = {}; // for affinity category and market-segment
+  interestsReqStatus = [
+    { name: 'affinity-category', reqStatus: 0 },
+    { name: 'market-segment', reqStatus: 0 },
+  ];
 
-  conversionsTrafficPerHour = [
-    { date: '07:00', value1: 2, value2: 16 },
-    { date: '09:00', value1: 9, value2: 45 },
-    { date: '12:00', value1: 13, value2: 30 },
-    { date: '15:00', value1: 10, value2: 18 },
-    { date: '18:00', value1: 16, value2: 50 },
-    { date: '20:00', value1: 6, value2: 16 },
-    { date: '22:00', value1: 3, value2: 60 },
-    { date: '23:00', value1: 9, value2: 14 }
-  ]
+  selectedTab1: any = 1;
+  selectedTab2: any = 1;
 
-  // *************************************************
-
-  filtersSub: Subscription;
+  chartsInitLoad: boolean = true;
+  generalFiltersSub: Subscription;
+  retailFiltersSub: Subscription;
 
   constructor(
     private filtersStateService: FiltersStateService,
@@ -1295,51 +53,218 @@ export class AudiencesWrapperComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.getAllData();
 
-    this.filtersSub = this.filtersStateService.retailFiltersChange$.subscribe(() => {
+    this.generalFiltersSub = this.filtersStateService.filtersChange$.subscribe(() => {
+      this.getAllData();
+    })
+
+    this.retailFiltersSub = this.filtersStateService.retailFiltersChange$.subscribe(() => {
       this.getAllData();
     });
   }
 
   getAllData() {
-    console.log('getAllData')
+    this.getDomographicsByMetric(this.getSelectedMetricForDemo(null, this.selectedTab1));
+    this.getWeekdaysAndHoursByMetric(this.selectedTab2 === 1 ? 'traffic' : 'conversions');
+    this.getConversionsVsTraffic();
+    this.getInterests();
+
+    this.chartsInitLoad = true;
   }
 
-  changeData(category, selectedTab) {
+  getDomographicsByMetric(metricType: any) {
+    const requiredData = ['device', 'gender', 'age', 'gender-and-age'];
 
-    switch (category) {
-      case 'traffic':
-        this.devices = this.devicesByTraffic;
-        this.gender = this.genderByTraffic;
-        this.age = this.ageByTraffic;
-        this.ageByGender = this.ageByGenderTraffic;
-        break;
+    for (let subMetricType of requiredData) {
+      const reqStatusObj = this.demoReqStatus.find(item => item.name === subMetricType);
+      reqStatusObj.reqStatus = 1;
+      this.campInRetailService.getAudiencesByMetric(metricType, subMetricType).subscribe(
+        (resp: any[]) => {
+          if (subMetricType === 'gender-and-age') {
+            this.demographics['genderByAge'] = resp;
+          } else {
+            this.demographics[subMetricType] = resp;
+          }
 
-      case 'conversions':
-        this.devices = this.devicesByConversions;
-        this.gender = this.genderByConversions;
-        this.age = this.ageByConversions;
-        this.ageByGender = this.ageByGenderConversions;
-        break;
+          reqStatusObj.reqStatus = 2;
 
-      case 'aup':
-        this.devices = this.devicesByConversions;
-        this.gender = this.genderByConversions;
-        this.age = this.ageByAup;
-        this.ageByGender = this.ageByGenderByAup;
-        break;
+          // process bounce rate data;
+          if (metricType === 'bouncerate' && (subMetricType === 'device' || subMetricType === 'gender')) {
+            this.addDemographicDataBr(subMetricType, resp);
+          };
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[audiences-wrapper.component]: ${errorMsg}`);
+          reqStatusObj.reqStatus = 3;
+        });
 
-      case 'br':
-        this.devices = this.devicesByTraffic;
-        this.gender = this.genderByTraffic;
-        this.age = this.ageByTraffic;
-        this.ageByGender = this.ageByGenderTraffic;
-        break;
-
+      this.selectedTab1 = this.getSelectedMetricForDemo(metricType, null);
     }
-    this.selectedTab1 = selectedTab;
+  }
+
+  getWeekdaysAndHoursByMetric(metricType: string) {
+    const requiredData = ['weekday-and-hour', 'weekday', 'hour'];
+
+    for (let subMetricType of requiredData) {
+      const reqStatusObj = this.weekDaysAndHoursReqStatus.find(item => item.name === subMetricType);
+      reqStatusObj.reqStatus = 1;
+      this.campInRetailService.getAudiencesByMetric(metricType, subMetricType).subscribe(
+        (resp: any[]) => {
+          if (subMetricType === 'weekday-and-hour') {
+            this.weekDaysAndHours['weekdayAndHour'] = resp.map(item => {
+              return { ...item, weekdayName: convertWeekdayToString(item.weekday) }
+            });
+
+          } else if (subMetricType === 'weekday') {
+            resp = resp.sort((a, b) => (a.weekday > b.weekday ? -1 : 1));
+            this.weekDaysAndHours[subMetricType] = resp.map(item => {
+              return { ...item, weekdayName: convertWeekdayToString(item.weekday) }
+            });
+
+          } else {
+            this.weekDaysAndHours[subMetricType] = resp;
+          }
+
+          reqStatusObj.reqStatus = 2;
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[audiences-wrapper.component]: ${errorMsg}`);
+          reqStatusObj.reqStatus = 3;
+        });
+
+      this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
+    }
+  }
+
+  getConversionsVsTraffic() {
+    const requiredData = ['weekday', 'hour'];
+
+    for (let subMetricType of requiredData) {
+      const reqStatusObj = this.conversionsVsTrafficReqStatus.find(item => item.name === subMetricType);
+      reqStatusObj.reqStatus = 1;
+      this.campInRetailService.getAudiencesByMetric('conversions-vs-traffic', subMetricType).subscribe(
+        (resp: any[]) => {
+          if (subMetricType === 'weekday') {
+            this.conversionsVsTraffic[subMetricType] = resp.map(item => {
+              return { ...item, weekdayName: convertWeekdayToString(item.weekday) }
+            });
+          } else {
+            this.conversionsVsTraffic[subMetricType] = resp;
+          }
+
+          reqStatusObj.reqStatus = 2;
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[audiences-wrapper.component]: ${errorMsg}`);
+          reqStatusObj.reqStatus = 3;
+        });
+    }
+  }
+
+  getInterests() {
+    const requiredData = ['affinity-category', 'market-segment'];
+    for (let subMetricType of requiredData) {
+      const reqStatusObj = this.interestsReqStatus.find(item => item.name === subMetricType);
+      reqStatusObj.reqStatus = 1;
+      this.campInRetailService.getAudiencesByMetric('interests', subMetricType).subscribe(
+        (resp: any[]) => {
+          resp = resp.sort((a, b) => (a.users < b.users ? -1 : 1));
+
+          if (subMetricType === 'affinity-category') {
+            this.interests['affinityCategory'] = resp;
+          } else {
+            this.interests['marketSegment'] = resp;
+          }
+
+          reqStatusObj.reqStatus = 2;
+        },
+        error => {
+          const errorMsg = error?.error?.message ? error.error.message : error?.message;
+          console.error(`[audiences-wrapper.component]: ${errorMsg}`);
+          reqStatusObj.reqStatus = 3;
+        });
+    }
+  }
+
+  addDemographicDataBr(subMetric: string, dataRaw: any[]) {
+    switch (subMetric) {
+      case 'device':
+        const desktop = dataRaw.find(item => item.name === 'Desktop');
+        const mobile = dataRaw.find(item => item.name === 'Mobile');
+
+        this.demographics['deviceDesktop'] = [
+          { name: 'empty', value: desktop ? 100 - desktop.value.toFixed(2) : 100 },
+          { name: 'Desktop', value: desktop ? desktop.value.toFixed(2) : 0 },
+        ];
+
+        this.demographics['deviceMobile'] = [
+          { name: 'empty', value: mobile ? 100 - mobile.value.toFixed(2) : 100 },
+          { name: 'Mobile', value: mobile ? mobile.value.toFixed(2) : 0 },
+        ];
+        break;
+
+      case 'gender':
+        const man = dataRaw.find(item => item.name === 'Hombre');
+        const woman = dataRaw.find(item => item.name === 'Mujer');
+
+        this.demographics['genderMan'] = [
+          { name: 'empty', value: man ? 100 - man.value.toFixed(2) : 100 },
+          { name: 'Hombre', value: man ? man.value.toFixed(2) : 0 },
+        ];
+
+        this.demographics['genderWoman'] = [
+          { name: 'empty', value: woman ? 100 - woman.value.toFixed(2) : 100 },
+          { name: 'Mujer', value: woman ? woman.value.toFixed(2) : 0 },
+        ];
+        break;
+    }
+  }
+
+  getSelectedMetricForDemo(metricType: string, selectedTab: number) {
+    if (metricType) {
+      switch (metricType) {
+        case 'traffic':
+          return 1;
+
+        case 'conversions':
+          return 2;
+
+        case 'aup':
+          return 3;
+
+        case 'bouncerate':
+          return 4;
+
+        default:
+          return;
+      }
+    } else if (selectedTab) {
+      switch (selectedTab) {
+        case 1:
+          return 'traffic'
+          break;
+
+        case 2:
+          return 'conversions'
+
+        case 3:
+          return 'aup'
+
+        case 4:
+          return 'bouncerate'
+
+        default:
+          return;
+      }
+    }
+
   }
 
   ngOnDestroy() {
-    this.filtersSub?.unsubscribe();
+    this.generalFiltersSub?.unsubscribe();
+    this.retailFiltersSub?.unsubscribe();
   }
 }
+

--- a/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
@@ -143,6 +143,7 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
       (resp: any[]) => {
 
         if (resp?.length < 1) {
+          this.kpisReqStatus = 2;
           return;
         }
 
@@ -172,6 +173,7 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
     this.campInRetailService.getRoasBySector().subscribe(
       (resp: any[]) => {
         if (resp?.length < 1) {
+          this.roasReqStatus = 2;
           return;
         }
 

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -116,7 +116,7 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy
 
       series.tooltip.label.adapter.add('text', function (text, target) {
         if (target.dataItem._index === 0) return '';
-        const percent = Math.round(target.dataItem.values.value.value);
+        const percent = target.dataItem.values.value.value;
         return `${percent}%`;
       });
     }

--- a/src/app/modules/dashboard/services/campaign-in-retail.service.ts
+++ b/src/app/modules/dashboard/services/campaign-in-retail.service.ts
@@ -53,7 +53,7 @@ export class CampaignInRetailService {
 
   getKpis() {
     if (!this.retailerID) {
-      return throwError('[campaign-in-retail.service]: not retailerID or countryID provided');
+      return throwError('[campaign-in-retail.service]: not retailerID provided');
     }
 
     let queryParams = this.concatedQueryParams();
@@ -64,12 +64,28 @@ export class CampaignInRetailService {
 
   getRoasBySector() {
     if (!this.retailerID) {
-      return throwError('[campaign-in-retail.service]: not retailerID or countryID provided');
+      return throwError('[campaign-in-retail.service]: not retailerID provided');
     }
 
     let queryParams = this.concatedQueryParams();
     let queryParamsR = this.concatedRetailerQueryParams();
 
     return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/in-retail/roas?${queryParams}&${queryParamsR}`);
+  }
+
+
+  /**** AUDIENCES SECTION
+  * audiences endpoints
+  * ****/
+
+  getAudiencesByMetric(metricType: string, subMetricType: string) {
+    if (!this.retailerID) {
+      return throwError('[campaign-in-retail.service]: not retailerID provided');
+    }
+
+    let queryParams = this.concatedQueryParams();
+    let queryParamsR = this.concatedRetailerQueryParams();
+
+    return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/in-retail/${metricType}/${subMetricType}?${queryParams}&${queryParamsR}`);
   }
 }

--- a/src/app/tools/functions/data-convert.ts
+++ b/src/app/tools/functions/data-convert.ts
@@ -1,0 +1,28 @@
+export function convertWeekdayToString(weekday: number): string {
+    let weekdayName;
+    switch (weekday) {
+        case 1:
+            weekdayName = 'Lun';
+            break;
+        case 2:
+            weekdayName = 'Mar';
+            break;
+        case 3:
+            weekdayName = 'Mier';
+            break;
+        case 4:
+            weekdayName = 'Jue';
+            break;
+        case 5:
+            weekdayName = 'Vie';
+            break;
+        case 6:
+            weekdayName = 'Sab';
+            break;
+        case 7:
+            weekdayName = 'Dom';
+            break;
+    }
+
+    return weekdayName;
+}


### PR DESCRIPTION
# Problem Description
- Add GET request to the API to show real data in retailer > campaña en el retail > audiences section

# Features
- Add audiences enpoint to **campaign-in-retail service**
- Update **audiences-wrapper** component
- Other implications:
  - Update chart-column-line-mix component
  - Update chart-pictorial component
  - Add data-convert file to app functions

# Bug Fixes
- Validate data in responses of campaign-in-retail-wrapper component

# Where this change will be used
- In Retailer view in Campaña en el retail > Audiences section at 

# More details
![image](https://user-images.githubusercontent.com/38545126/121785002-df706380-cb7c-11eb-9868-86d5bafda22b.png)
