### PR TITLE
add functionality to conversion-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.html
+++ b/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.html
@@ -25,7 +25,7 @@
     <div *ngFor="let sector of roasBySector" class="col-12 col-sm-4 mb-4">
         <app-card-stat [stat]="sector" [loader]="roasReqStatus <= 1" height="76px"></app-card-stat>
     </div>
-    <div class="col-12 mt--4" [hidden]="roasReqStatus !== 3">
+    <div class="col-12 mt--3 mt-xl-2" [hidden]="roasReqStatus !== 3">
         <p class="text-center text-muted mb-0">
             Error al consultar datos
         </p>

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.html
@@ -1,147 +1,54 @@
-<div class="conversion-wrapper">
-    <div class="row mt-4 mb-5">
-        <div class="col-12 col-md-4" *ngFor="let stat of stats">
-            <app-card-stat [stat]="stat" [height]="auto"></app-card-stat>
+<!-- KPIS PERFOMANCE -->
+<div class="row mt-4">
+    <div class="col-12 col-md-4" *ngFor="let kpi of kpis">
+        <app-card-stat [stat]="kpi" [height]="auto"></app-card-stat>
+    </div>
+    <div class="col-12 mt--3 mt-xl-2" [hidden]="kpisReqStatus !== 3">
+        <p class="text-center text-muted mb-0">
+            Error al consultar datos
+        </p>
+    </div>
+</div>
+
+<!-- PRODUCTS TABLE -->
+<div class="row mt-5">
+    <div class="col-12">
+        <app-generic-table [displayedColumns]="productsTableColumns" [tableData]="products"
+            [tableDataChange]="products.data">
+        </app-generic-table>
+    </div>
+</div>
+
+<!-- USERS VS TRANSACCIONS / CANTIDAD VS AUP -->
+<div class="row mt-5">
+    <div class="col-12">
+        <div class="pills-container">
+            <ul class="nav nav-pills nav-fill">
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 1}"
+                        (click)="getDataByMetric('conversions-vs-users')">Usuarios - Transacciones</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 2}"
+                        (click)="getDataByMetric('quantity-vs-aup')">Cantidad - AUP</a>
+                </li>
+            </ul>
         </div>
     </div>
-
-    <div class="row mb-5">
-        <div class="col-12">
-            <div class="adaptable-container">
-                <table mat-table [dataSource]="dataSource">
-                    <!-- category column -->
-                    <ng-container matColumnDef="category">
-                        <th mat-header-cell *matHeaderCellDef> Categoría </th>
-                        <td mat-cell *matCellDef="let element"> {{element.category}} </td>
-                    </ng-container>
-
-                    <!-- product column -->
-                    <ng-container matColumnDef="product">
-                        <th mat-header-cell *matHeaderCellDef [style.width.%]="30"> Producto </th>
-                        <td mat-cell *matCellDef="let element">
-                            <div class="lg-container">
-                                <span #tooltip="matTooltip" md-raised-button [matTooltip]="element.product"
-                                    matTooltipPosition="right" matTooltipClass="custom-tooltip">
-                                    {{element.product}}
-                                </span>
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <!-- amount -->
-                    <ng-container matColumnDef="amount">
-                        <th mat-header-cell *matHeaderCellDef> Cantidad</th>
-                        <td mat-cell *matCellDef="let element"> {{element.amount}} </td>
-                    </ng-container>
-
-                    <!-- yoy_amount -->
-                    <ng-container matColumnDef="yoy_amount">
-                        <th mat-header-cell *matHeaderCellDef> %YoY</th>
-                        <td mat-cell *matCellDef="let element">
-                            <div class="value-container">
-                                <span>{{element.yoy_amount}}%</span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.yoy_amount > element.yoy_amount_before"></i>
-                                <i class="fas fa-equals text-warning"
-                                    *ngIf="element.yoy_amount === element.yoy_amount_before"></i>
-                                <i class="fas fa-arrow-down text-danger"
-                                    *ngIf="element.yoy_amount < element.yoy_amount_before"></i>
-                            </div>
-                        </td>
-
-                    </ng-container>
-
-                    <!-- product_revenue -->
-                    <ng-container matColumnDef="product_revenue">
-                        <th mat-header-cell *matHeaderCellDef> Revenue del producto</th>
-                        <td mat-cell *matCellDef="let element"> {{element.product_revenue}} </td>
-                    </ng-container>
-
-                    <!-- yoy_product_revenue -->
-                    <ng-container matColumnDef="yoy_product_revenue">
-                        <th mat-header-cell *matHeaderCellDef> %YoY</th>
-                        <td mat-cell *matCellDef="let element">
-                            <div class="value-container">
-                                <span>{{element.yoy_product_revenue}}% </span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.yoy_product_revenue > element.yoy_product_revenue_before"></i>
-                                <i class="fas fa-equals text-warning"
-                                    *ngIf="element.yoy_product_revenue === element.yoy_product_revenue_before"></i>
-                                <i class="fas fa-arrow-down text-danger"
-                                    *ngIf="element.yoy_product_revenue < element.yoy_product_revenue_before"></i>
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <!-- aup -->
-                    <ng-container matColumnDef="aup">
-                        <th mat-header-cell *matHeaderCellDef> AUP</th>
-                        <td mat-cell *matCellDef="let element"> {{element.aup}} </td>
-                    </ng-container>
-
-                    <!-- yoy_aup -->
-                    <ng-container matColumnDef="yoy_aup">
-                        <th mat-header-cell *matHeaderCellDef> %YoY</th>
-                        <td mat-cell *matCellDef="let element">
-                            <div class="value-container">
-                                <span>{{element.yoy_aup}}%</span>
-                                <i class="fas fa-arrow-up text-success"
-                                    *ngIf="element.yoy_aup > element.yoy_aup_before"></i>
-                                <i class="fas fa-equals text-warning"
-                                    *ngIf="element.yoy_aup === element.yoy_aup_before"></i>
-                                <i class="fas fa-arrow-down text-danger"
-                                    *ngIf="element.yoy_aup < element.yoy_aup_before"></i>
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <!-- disclaimer column -->
-                    <ng-container matColumnDef="disclaimer">
-                        <td mat-footer-cell *matFooterCellDef colspan="3">
-                            <div class="text-danger text-center" *ngIf="getReqStatus === 3">
-                                Ocurrió un error al consultar los usuarios
-                            </div>
-                        </td>
-                    </ng-container>
-
-                    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-                    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-                    <tr mat-footer-row *matFooterRowDef="['disclaimer']" class="example-second-footer-row"
-                        [hidden]="getReqStatus !== 3"></tr>
-                </table>
+    <div class="col-12 mt-4">
+        <div class="card">
+            <div class="card-header">
+                <span class="h4" [hidden]="selectedTab === 2">Usuarios vs Transacciones</span>
+                <span class="h4" [hidden]="selectedTab === 1">Cantidad vs AUP</span>
             </div>
-            <mat-paginator [pageSizeOptions]="[5, 10, 20]" showFirstLastButtons></mat-paginator>
-        </div>
-    </div>
-
-    <div class="row mb-5">
-        <div class="col-12">
-            <div class="pills-container">
-                <ul class="nav nav-pills nav-fill">
-                    <li class="nav-item">
-                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 1}"
-                            (click)="changeData('users', 1)">Usuarios - Transacciones</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab === 2}"
-                            (click)="changeData('amount_aup', 2)">Cantidad - AUP</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        <div class="col-12 mt-4">
-            <div class="card">
-                <div class="card-header">
-                    <span class="h4" [hidden]="selectedTab === 2">Usuarios vs Transacciones</span>
-                    <span class="h4" [hidden]="selectedTab === 1">Cantidad vs AUP</span>
-                </div>
-                <div class="card-body">
-                    <app-chart-line-comparison [data]="data" name="users-vs-transaccions"
-                        [valueName1]="selectedTab === 1 ? 'Usuarios' : 'Cantidad'"
-                        [valueName2]="selectedTab === 1 ? 'Transacciones' : 'AUP'"
-                        [valueFormat2]="selectedTab === 2 && 'USD'" height="250px">
-                    </app-chart-line-comparison>
-                </div>
+            <div class="card-body">
+                <app-chart-multiple-axes name="conv-users-amount" [value1]="selectedTab === 1 ? 'users' : 'quantity'"
+                    [valueName1]="selectedTab === 1 ? 'Usuarios' : 'Cantidad'"
+                    [value2]="selectedTab === 1 ? 'transactions' : 'aup'"
+                    [valueName2]="selectedTab === 1 ? 'Transacciones' : 'AUP'"
+                    [valueFormat2]="selectedTab === 2 && 'USD'" [data]="usersAndAmount"
+                    [status]="usersAndAmountReqStatus">
+                </app-chart-multiple-axes>
             </div>
         </div>
     </div>

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.scss
@@ -1,37 +1,3 @@
-.conversion-wrapper {
-    table {
-        width: 100%;
-    
-        th:nth-of-type(n + 3),
-        td:nth-of-type(n + 3) {
-            text-align: center;
-        }
-    }
-    
-    .adaptable-container {
-        overflow: auto;
-    }
-    
-    .lg-container {
-        max-width: 27rem;
-        span {
-            text-overflow: ellipsis;
-            overflow: hidden;
-            white-space: nowrap;
-            max-width: inherit;
-            display: inline-block;
-        }
-    }
-
-    .value-container {
-        align-items: center;
-        display: grid;
-        grid-template-columns: 40px 30px;
-        gap: 8px;
-        justify-content: center;
-    }
-}
-
 .pills-container {
     width: 60%;
 

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -1,111 +1,192 @@
-import { AfterViewInit, Component, OnInit, ViewChild } from '@angular/core';
-import { MatPaginator } from '@angular/material/paginator';
-import { MatTableDataSource } from '@angular/material/table';
+import { Component, OnInit } from '@angular/core';
 import * as moment from 'moment';
+import { Subscription } from 'rxjs';
+import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
+import { FiltersStateService } from '../../services/filters-state.service';
+import { TableItem } from '../generic-table/generic-table.component';
 
 @Component({
   selector: 'app-conversion-wrapper',
   templateUrl: './conversion-wrapper.component.html',
   styleUrls: ['./conversion-wrapper.component.scss']
 })
-export class ConversionWrapperComponent implements OnInit, AfterViewInit {
+export class ConversionWrapperComponent implements OnInit {
 
-  stats: any[] = [
+  // kpis
+  kpis: any[] = [
     {
-      metricTitle: 'Cantidad',
-      metricValue: '000',
+      metricTitle: 'cantidad',
+      metricName: 'quantity',
+      metricValue: 0,
+      metricFormat: 'integer',
       icon: 'fas fa-chart-line',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'Revenue',
-      metricValue: '0000',
+      metricTitle: 'revenue',
+      metricName: 'revenue',
+      metricValue: 0,
+      metricFormat: 'currency',
       icon: 'fas fa-hand-holding-usd',
       iconBg: '#2f9998'
-
     },
     {
-      metricTitle: 'AUP',
-      metricValue: '0%',
+      metricTitle: 'aup',
+      metricName: 'aup',
+      metricValue: 0,
+      metricFormat: 'currency',
       icon: 'fas fa-file-invoice-dollar',
       iconBg: '#a77dcc'
     }
   ];
+  kpisReqStatus: number = 0;
 
-  displayedColumns: string[] = ['category', 'product', 'amount', 'yoy_amount', 'product_revenue', 'yoy_product_revenue', 'aup', 'yoy_aup'];
-  private categories = [
-    { category: 'Category 1', product: 'Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1 Product 1', amount: 12, yoy_amount: 12, yoy_amount_before: 10, product_revenue: 50000, yoy_product_revenue: 15, yoy_product_revenue_before: 17, aup: 820, yoy_aup: 8, yoy_aup_before: 8 },
-    { category: 'Category 2', product: 'Product 2', amount: 8, yoy_amount: 4, yoy_amount_before: 6, product_revenue: 20000, yoy_product_revenue: 7, yoy_product_revenue_before: 17, aup: 650, yoy_aup: 4, yoy_aup_before: 6 },
-    { category: 'Category 3', product: 'Product 3', amount: 4, yoy_amount: -4, yoy_amount_before: -2, product_revenue: 10000, yoy_product_revenue: -2, yoy_product_revenue_before: -2, aup: 350, yoy_aup: -1, yoy_aup_before: -2 }
-  ]
-  dataSource = new MatTableDataSource<any>(this.categories);
+  // products
+  productsTableColumns: TableItem[] = [
+    {
+      name: 'category',
+      title: 'Categoría'
+    },
+    {
+      name: 'product',
+      title: 'Producto',
+      tooltip: true,
+      maxWidthTdPercentage: 25,
+      maxWidthSpan: '400px',
+    },
+    {
+      name: 'amount',
+      title: 'Cantidad',
+      textAlign: 'center',
+      formatValue: 'integer'
+    },
+    {
+      name: 'yoy_amount',
+      title: '%YoY',
+      textAlign: 'center',
+      // formatValue: 'percentage'
+    },
+    {
+      name: 'product_revenue',
+      title: 'Revenue del producto',
+      textAlign: 'center',
+      formatValue: 'currency'
+    },
+    {
+      name: 'yoy_product_revenue',
+      title: '%YoY',
+      textAlign: 'center',
+      // formatValue: 'percentage'
+    },
+    {
+      name: 'aup',
+      title: 'AUP',
+      textAlign: 'center',
+      formatValue: 'currency'
+    },
+    {
+      name: 'yoy_aup',
+      title: '%YoY',
+      textAlign: 'center',
+      // formatValue: 'percentage'
+    }
+  ];
+  products = {
+    data: [],
+    reqStatus: 0
+  };
 
-  @ViewChild(MatPaginator) paginator: MatPaginator;
-
-  usersVsTransacctions = [
-    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 200 },
-    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 230 },
-    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 180 },
-    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 80 },
-    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 60 },
-    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 110 },
-    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 120 }
-  ]
-
-  amountVsAUP = [
-    { date: moment(new Date(2021, 3, 15)).format('MMM DD'), value1: 1200, value2: 400 },
-    { date: moment(new Date(2021, 3, 16)).format('MMM DD'), value1: 1600, value2: 810 },
-    { date: moment(new Date(2021, 3, 17)).format('MMM DD'), value1: 1400, value2: 320 },
-    { date: moment(new Date(2021, 3, 18)).format('MMM DD'), value1: 1250, value2: 120 },
-    { date: moment(new Date(2021, 3, 19)).format('MMM DD'), value1: 800, value2: 345 },
-    { date: moment(new Date(2021, 3, 20)).format('MMM DD'), value1: 1000, value2: 850 },
-    { date: moment(new Date(2021, 3, 21)).format('MMM DD'), value1: 1100, value2: 900 }
-  ]
-
-  data: any[] = this.usersVsTransacctions;
-
+  // users vs transactions & amount vs aup
+  usersAndAmount: any[] = [];
+  usersAndAmountReqStatus: number = 0;
   selectedTab: number = 1;
 
-  constructor() { }
+  generalFiltersSub: Subscription;
+  retailFiltersSub: Subscription;
+
+  constructor(
+    private filtersStateService: FiltersStateService,
+    private campInRetailService: CampaignInRetailService
+  ) { }
 
   ngOnInit(): void {
+    this.getAllData();
+
+    this.generalFiltersSub = this.filtersStateService.filtersChange$.subscribe(() => {
+      this.getAllData();
+    })
+
+    this.retailFiltersSub = this.filtersStateService.retailFiltersChange$.subscribe(() => {
+      this.getAllData();
+    });
   }
 
-  ngAfterViewInit() {
-    this.loadPaginator();
+  getAllData() {
+    this.getKpis();
+    this.getProducts();
+    this.getDataByMetric(this.selectedTab === 1 ? 'conversions-vs-users' : 'quantity-vs-aup');
   }
 
-  loadPaginator() {
-    // paginator setup
-    this.dataSource.paginator = this.paginator;
-    this.paginator._intl.itemsPerPageLabel = 'Registros por página';
-    this.paginator._intl.nextPageLabel = 'Siguiente';
-    this.paginator._intl.previousPageLabel = 'Anterior';
-    this.paginator._intl.getRangeLabel = (page: number, pageSize: number, length: number) => {
-      if (length == 0 || pageSize == 0) { return `0 de ${length}`; }
+  getKpis() {
+    this.kpisReqStatus = 1;
+    this.campInRetailService.getDataByMetric('conversions', 'performance').subscribe(
+      (resp: any[]) => {
+        if (resp?.length < 1) {
+          this.kpisReqStatus = 2;
+          return;
+        }
 
-      length = Math.max(length, 0);
+        for (let i = 0; i < this.kpis.length; i++) {
+          const baseObj = resp.find(item => item.name === this.kpis[i].metricName);
+          this.kpis[i].metricValue = baseObj.value;
+        }
 
-      const startIndex = page * pageSize;
-
-      // If the start index exceeds the list length, do not try and fix the end index to the end.
-      const endIndex = startIndex < length ?
-        Math.min(startIndex + pageSize, length) :
-        startIndex + pageSize;
-
-      return `${startIndex + 1} - ${endIndex} de ${length}`;
-    }
+        this.kpisReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[conversion-wrapper.component]: ${errorMsg}`);
+        this.kpisReqStatus = 3;
+      });
   }
 
+  getProducts() {
+    this.products.reqStatus = 1;
+    this.campInRetailService.getDataByMetric('conversions', 'products').subscribe(
+      (products: any[]) => {
+        // provisional until data exists
+        this.products.data = products.map(item => {
+          return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-' };
+        });
 
-  changeData(category, selectedTab) {
-    if (category === 'users') {
-      this.data = this.usersVsTransacctions
-    } else if (category === 'amount_aup') {
-      this.data = this.amountVsAUP;
-    }
-
-    this.selectedTab = selectedTab;
+        this.products.reqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[conversion-wrapper.component]: ${errorMsg}`);
+        this.products.reqStatus = 3;
+      });
   }
 
+  getDataByMetric(metricType: string) {
+    this.usersAndAmountReqStatus = 1;
+    this.campInRetailService.getDataByMetric(metricType).subscribe(
+      (resp: any[]) => {
+        this.usersAndAmount = resp;
+
+        this.usersAndAmountReqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[conversion-wrapper.component]: ${errorMsg}`);
+        this.usersAndAmountReqStatus = 3;
+      });
+
+    this.selectedTab = metricType === 'conversions-vs-users' ? 1 : 2
+  }
+
+  ngOnDestroy() {
+    this.generalFiltersSub?.unsubscribe();
+    this.retailFiltersSub?.unsubscribe();
+  }
 }

--- a/src/app/modules/dashboard/components/generic-table/generic-table.component.html
+++ b/src/app/modules/dashboard/components/generic-table/generic-table.component.html
@@ -3,8 +3,6 @@
         <mat-spinner></mat-spinner>
     </div>
 
-    colums{{displayedColumns?.length}}
-
     <table mat-table [dataSource]="dataSource">
         <ng-container *ngFor="let column of displayedColumns">
             <ng-container [matColumnDef]="column.name">


### PR DESCRIPTION
# Problem Description
- Add GET request to the API to show real data in retailer > campaña en el retail > conversion section

# Features
- Update conversion-wrapper component to use get requests to the API

# Bug Fixes
- Fix a margin in campaign-in-retail-wrapper component
- Remove a copy in generic-table component

# Where this change will be used
- In retailer view > Campaña en el retail > Conversion section at
`/dashboard/retailer?country={country-name}&retailer={retailer-name}` path

# More details
![image](https://user-images.githubusercontent.com/38545126/121792035-ec5d7900-cbb5-11eb-8bf9-9442d1028304.png)

