### PR TITLE
update retailer component to show or hide google my business tab

### DIFF
--- a/src/app/modules/dashboard/pages/retailer/retailer.component.html
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.html
@@ -15,7 +15,8 @@
                 <span class="h2 py-2 ml-3 mr-3">Campaña en el retail</span>
             </a>
         </li>
-        <li class="nav-item">
+        <!-- only visible for Brazil (id 2) and Mexico (id 9) -->
+        <li class="nav-item" *ngIf="countryID === 2 || countryID === 9">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 4}" (click)="activeTabView = 4">
                 <span class="h2 py-2 ml-3 mr-3">Google My Business</span>
             </a>

--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -18,16 +18,18 @@ export class RetailerComponent implements OnInit, OnDestroy {
   activeTabView: number = 1;
 
   retailerID: number;
+  countryID: number;
 
   filtersSub: Subscription;
   retailerSub: Subscription;
+  countrySub: Subscription;
 
   private requestInfoSource = new Subject<boolean>();
   requestInfoChange$ = this.requestInfoSource.asObservable();
 
   constructor(
     private appStateService: AppStateService,
-    private filtersStateService: FiltersStateService,
+    private filtersStateService: FiltersStateService
   ) { }
 
   ngOnInit(): void {
@@ -40,6 +42,10 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
       this.requestInfoSource.next(manualChange);
+    });
+
+    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
+      this.countryID = country?.id
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
@@ -62,6 +68,7 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.retailerSub?.unsubscribe();
+    this.countrySub?.unsubscribe();
     this.filtersSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
# Problem Description
- Google My Business tab will be only visible for retailers in Brazil or Mexico countries

# Features
- Add a subscrption to selected country in retailer component
- Add directive in retailer content template to show or hide this tab based on selected retailer ID

# Where this change will be used
- In retailer page > Google My Business tab at 
`/dashboard/retailer?country={country-name}&retailer={retailer-name}`

# More details
- View of retailer component for Brazil and Mexico countries:
![image](https://user-images.githubusercontent.com/38545126/121974967-37a69180-cd46-11eb-8f16-89926f60ba37.png)

- View for retailers in other countries:
![image](https://user-images.githubusercontent.com/38545126/121975031-573dba00-cd46-11eb-823f-7662cdf78f58.png)
