### PR TITLE
add dynamic content in other tools components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
@@ -128,7 +128,7 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit, OnDes
 
     // Cursor
     chart.cursor = new am4charts.XYCursor();
-    chart.responsive.enabled = true;
+    // chart.responsive.enabled = true;
   }
 
   loadChartData(chart) {

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.html
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.html
@@ -9,8 +9,8 @@
     </div>
 </div>
 
-<div class="row mt-5">
-    <div class="col-12">
+<div class="row mt-5" *ngIf="!retailerView">
+    <div class="col-12" *ngIf="latamView">
         <div class="pills-container">
             <ul class="nav nav-pills nav-fill">
                 <li class="nav-item">
@@ -27,10 +27,12 @@
     <div class="col-12 mt-4">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Sesiones por {{ selectedTab1 === 1 ? 'Países' : 'Retailers' }}</span>
+                <span class="h4" *ngIf="latamView">Sesiones por {{ selectedTab1 === 1 ? 'Países' : 'Retailers' }}</span>
+                <span class="h4" *ngIf="countryView">Sesiones por retailer</span>
             </div>
             <div class="card-body">
-                <app-chart-line-series [series]="sessions" name="indexed-sessions-by-retailer" yTitle="Sesiones">
+                <app-chart-line-series [series]="latamView ? sessions : sessionsByRetailer"
+                    name="indexed-sessions-by-retailer" yTitle="Sesiones">
                 </app-chart-line-series>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { AppStateService } from 'src/app/services/app-state.service';
 import { TableItem } from '../generic-table/generic-table.component';
 
 @Component({
@@ -444,6 +448,134 @@ export class IndexedWrapperComponent implements OnInit {
         { date: '2021-06-14', value: 1933 },
         { date: '2021-06-15', value: 1967 },
         { date: '2021-06-16', value: 820 }
+      ]
+    }
+  ]
+  sessionsByRetailerArg = [
+    {
+      name: 'AR - Carrefour',
+      serie: [
+        { date: '2021-06-01', value: 19749 },
+        { date: '2021-06-02', value: 16859 },
+        { date: '2021-06-03', value: 7344 },
+        { date: '2021-06-04', value: 5424 },
+        { date: '2021-06-05', value: 4909 },
+        { date: '2021-06-06', value: 4874 },
+        { date: '2021-06-07', value: 5544 },
+        { date: '2021-06-08', value: 5494 },
+        { date: '2021-06-09', value: 5990 },
+        { date: '2021-06-10', value: 6335 },
+        { date: '2021-06-11', value: 6012 },
+        { date: '2021-06-12', value: 5450 },
+        { date: '2021-06-13', value: 5537 },
+        { date: '2021-06-14', value: 6207 },
+        { date: '2021-06-15', value: 5912 },
+        { date: '2021-06-16', value: 2477 }
+      ]
+    },
+    {
+      name: 'AR - Compumundo',
+      serie: [
+        { date: '2021-06-01', value: 27038 },
+        { date: '2021-06-02', value: 25341 },
+        { date: '2021-06-03', value: 6189 },
+        { date: '2021-06-04', value: 4249 },
+        { date: '2021-06-05', value: 3939 },
+        { date: '2021-06-06', value: 3958 },
+        { date: '2021-06-07', value: 4048 },
+        { date: '2021-06-08', value: 3660 },
+        { date: '2021-06-09', value: 3486 },
+        { date: '2021-06-10', value: 3424 },
+        { date: '2021-06-11', value: 2662 },
+        { date: '2021-06-12', value: 3264 },
+        { date: '2021-06-13', value: 3442 },
+        { date: '2021-06-14', value: 3958 },
+        { date: '2021-06-15', value: 3615 },
+        { date: '2021-06-16', value: 1310 }
+      ],
+    },
+    {
+      name: 'AR - Fravega',
+      serie: [
+        { date: '2021-06-01', value: 2772 },
+        { date: '2021-06-02', value: 2614 },
+        { date: '2021-06-03', value: 2837 },
+        { date: '2021-06-04', value: 3416 },
+        { date: '2021-06-05', value: 2880 },
+        { date: '2021-06-06', value: 1639 },
+        { date: '2021-06-07', value: 2229 },
+        { date: '2021-06-08', value: 2334 },
+        { date: '2021-06-09', value: 2583 },
+        { date: '2021-06-10', value: 4305 },
+        { date: '2021-06-11', value: 4119 },
+        { date: '2021-06-12', value: 3939 },
+        { date: '2021-06-13', value: 4592 },
+        { date: '2021-06-14', value: 5467 },
+        { date: '2021-06-15', value: 4918 },
+        { date: '2021-06-16', value: 1821 }
+      ]
+    },
+    {
+      name: 'AR - Garbarino',
+      serie: [
+        { date: '2021-06-01', value: 2893 },
+        { date: '2021-06-02', value: 2667 },
+        { date: '2021-06-03', value: 2044 },
+        { date: '2021-06-04', value: 2380 },
+        { date: '2021-06-05', value: 1654 },
+        { date: '2021-06-06', value: 1707 },
+        { date: '2021-06-07', value: 3318 },
+        { date: '2021-06-08', value: 3421 },
+        { date: '2021-06-09', value: 3395 },
+        { date: '2021-06-10', value: 3164 },
+        { date: '2021-06-11', value: 2667 },
+        { date: '2021-06-12', value: 1721 },
+        { date: '2021-06-13', value: 1817 },
+        { date: '2021-06-14', value: 3079 },
+        { date: '2021-06-15', value: 3214 },
+        { date: '2021-06-16', value: 1816 }
+      ]
+    },
+    {
+      name: 'AR - Musimundo',
+      serie: [
+        { date: '2021-06-01', value: 2344 },
+        { date: '2021-06-02', value: 3185 },
+        { date: '2021-06-03', value: 2906 },
+        { date: '2021-06-04', value: 1996 },
+        { date: '2021-06-05', value: 1872 },
+        { date: '2021-06-06', value: 1881 },
+        { date: '2021-06-07', value: 1832 },
+        { date: '2021-06-08', value: 1600 },
+        { date: '2021-06-09', value: 1733 },
+        { date: '2021-06-10', value: 1671 },
+        { date: '2021-06-11', value: 1644 },
+        { date: '2021-06-12', value: 1465 },
+        { date: '2021-06-13', value: 1666 },
+        { date: '2021-06-14', value: 1676 },
+        { date: '2021-06-15', value: 1521 },
+        { date: '2021-06-16', value: 742 }
+      ]
+    },
+    {
+      name: 'AR - Walmart',
+      serie: [
+        { date: '2021-06-01', value: 2866 },
+        { date: '2021-06-02', value: 2462 },
+        { date: '2021-06-03', value: 2408 },
+        { date: '2021-06-04', value: 2165 },
+        { date: '2021-06-05', value: 1636 },
+        { date: '2021-06-06', value: 1474 },
+        { date: '2021-06-07', value: 2171 },
+        { date: '2021-06-08', value: 2222 },
+        { date: '2021-06-09', value: 2291 },
+        { date: '2021-06-10', value: 2143 },
+        { date: '2021-06-11', value: 1990 },
+        { date: '2021-06-12', value: 1534 },
+        { date: '2021-06-13', value: 1458 },
+        { date: '2021-06-14', value: 2868 },
+        { date: '2021-06-15', value: 2667 },
+        { date: '2021-06-16', value: 1487 }
       ]
     }
   ]
@@ -1508,9 +1640,71 @@ export class IndexedWrapperComponent implements OnInit {
 
   sessions = this.sessionsByCountry;
 
-  constructor() { }
+  countryID;
+  retailerID;
+
+  retailerView;
+  countryView;
+  latamView;
+
+  routeSub: Subscription;
+  retailerSub: Subscription;
+  countrySub: Subscription;
+
+  constructor(
+    private appStateService: AppStateService,
+    private router: Router) { }
 
   ngOnInit(): void {
+    this.countryID = this.appStateService.selectedCountry?.id;
+    this.retailerID = this.appStateService.selectedRetailer?.id;
+    this.latamView = this.router.url.includes('latam') ? true : false;
+
+    if (this.countryID || this.retailerID || this.latamView) {
+      this.getActiveView();
+      // this.getAllData();
+    }
+
+    this.routeSub = this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd)
+    )
+      .subscribe(event => {
+        if (event instanceof NavigationEnd)
+          this.latamView = this.router.url.includes('latam') ? true : false;
+        this.getActiveView();
+      });
+
+    this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
+      this.retailerID = retailer?.id;
+      this.getActiveView();
+    });
+
+    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
+      this.countryID = country?.id;
+      if (this.countryID) {
+        this.sessionsByRetailer = this.sessionsByRetailerArg;
+      }
+      this.getActiveView();
+    });
+  }
+
+  getActiveView() {
+    if (this.retailerID) {
+      this.retailerView = true;
+      this.countryView = false;
+      this.latamView = false;
+    } else if (this.countryID) {
+      this.countryView = true;
+      this.retailerView = false;
+      this.latamView = false;
+    } else if (this.latamView) {
+      this.countryView = false;
+      this.retailerView = false;
+    }
+
+    if (this.countryView) {
+      this.sessionsByRetailer = this.sessionsByRetailerArg;
+    }
   }
 
   getSessions(metric: string) {

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -16,11 +16,15 @@
             <ul class="nav nav-pills nav-fill">
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                        (click)="getDataByUsersAndRevenue('users');">Usuarios - Conversiones</a>
+                        (click)="getPerformanceData('users');">Usuarios - Conversiones</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                        (click)="getDataByUsersAndRevenue('revenue')">Revenue - AUP</a>
+                        (click)="getPerformanceData('investment')">Inversión - Revenue</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
+                        (click)="getPerformanceData('revenue')">Revenue - AUP</a>
                 </li>
             </ul>
         </div>
@@ -32,12 +36,13 @@
                 <span class="h4">{{ selectedTab1 === 1 ? 'Usuarios vs Conversiones' : 'Revenue vs AUP '}} </span>
             </div>
             <div class="card-body">
-                <app-chart-multiple-axes [data]="dataByUsersAndRevenue"
-                    [value1]="selectedTab1 === 1 ? 'conversions' : 'revenue'"
-                    [value2]="selectedTab1 === 1 ? 'traffic' : 'aup'"
-                    [valueName1]="selectedTab1 === 1 ? 'Conversiones' : 'Revenue'"
-                    [valueName2]="selectedTab1 === 1 ? 'Usuarios' : 'AUP'" [valueFormat1]="selectedTab1 === 2 && 'USD'"
-                    [valueFormat2]="selectedTab1 === 2 && 'USD'" name="omnichat-traffic-vs-conversions">
+                <app-chart-multiple-axes [data]="performanceData"
+                    [value1]="selectedTab1 === 1 ? 'conversions' : selectedTab1 === 2 ? 'revenue' : 'revenue'"
+                    [value2]="selectedTab1 === 1 ? 'traffic' : selectedTab1 === 2 ? 'investment': 'aup'"
+                    [valueName1]="selectedTab1 === 1 ? 'Conversiones' : selectedTab1 === 2 ? 'Revenue' :'Revenue'"
+                    [valueName2]="selectedTab1 === 1 ? 'Usuarios' : selectedTab1 === 2 ? 'Inversión' : 'AUP'"
+                    [valueFormat1]="selectedTab1 > 1 && 'USD'" [valueFormat2]="selectedTab1 > 1 && 'USD'"
+                    name="omnichat-traffic-vs-conversions">
                 </app-chart-multiple-axes>
             </div>
         </div>
@@ -57,11 +62,11 @@
             <ul class="nav nav-pills nav-fill">
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                        (click)="selectedTab2 = 1">Tráfico</a>
+                        (click)="getCountriesRetAndCat('traffic')">Tráfico</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                        (click)="selectedTab2 = 2">Conversiones</a>
+                        (click)="getCountriesRetAndCat('sales')">Conversiones</a>
                 </li>
             </ul>
         </div>
@@ -86,9 +91,8 @@
             </div>
             <div class="card-body retailers-chart-container">
                 <div class="superimposed">
-                    <app-chart-bar-horizontal [data]="chatsByRetailer" name="omnichat-chats-by-retailer"
-                        category="retailer" value="chats" [truncateLabels]="true" [singleColorBars]="true"
-                        height="600px">
+                    <app-chart-bar-horizontal [data]="retailers" name="omnichat-chats-by-retailer" category="retailer"
+                        value="chats" [truncateLabels]="true" [singleColorBars]="true" height="600px">
                     </app-chart-bar-horizontal>
                 </div>
 
@@ -116,7 +120,8 @@
                 <span class="h4" *ngIf="retailerView">Conversiones por categoría</span>
             </div>
             <div class="card-body">
-                <app-chart-pie [data]="chatsByCategories" name="omnichat-chats-by-category-2" legendPosition="bottom">
+                <app-chart-pie [data]="conversionsByCategories" name="omnichat-chats-by-category-2"
+                    legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -159,7 +164,7 @@
                         <span class="h4">Conversiones por producto</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar-horizontal [data]="transactionsByProduct" name="omnichat-transactions-by-product"
+                        <app-chart-bar-horizontal [data]="products" name="omnichat-transactions-by-product"
                             category="product" value="transactions" [singleColorBars]="true">
                         </app-chart-bar-horizontal>
                         <small class="text-muted mt-2 d-block d-sm-none">
@@ -346,11 +351,11 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
-                                (click)="getDataByTrafficAndSales2('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                                (click)="getAudiencesData('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
-                                (click)="getDataByTrafficAndSales2('sales'); chartsInitLoad = chartsInitLoad && false;">Conversiones</a>
+                                (click)="getAudiencesData('sales'); chartsInitLoad = chartsInitLoad && false;">Conversiones</a>
                         </li>
                     </ul>
                 </div>
@@ -368,10 +373,10 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-4"></div>
-                                        <div class="legend-label">Desktop {{ desktopAudiences[1].value }}%</div>
+                                        <div class="legend-label">Desktop {{ audiences?.desktop[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="desktopAudiences" name="omnichat-devices-desktop"
+                                <app-chart-pictorial [data]="audiences?.desktop" name="omnichat-devices-desktop"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -380,10 +385,10 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-5"></div>
-                                        <div class="legend-label">Mobile {{ mobileAudiences[1].value }}%</div>
+                                        <div class="legend-label">Mobile {{ audiences?.mobile[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="mobileAudiences" name="omnichat-devices-mobile"
+                                <app-chart-pictorial [data]="audiences?.mobile" name="omnichat-devices-mobile"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -405,10 +410,10 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-4"></div>
-                                        <div class="legend-label">Hombres {{ menAudiences[1].value }}%</div>
+                                        <div class="legend-label">Hombres {{ audiences?.men[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="menAudiences" name="omnichat-gender-man"
+                                <app-chart-pictorial [data]="audiences?.men" name="omnichat-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -418,10 +423,10 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container">
                                         <div class="legend-square on color-5"></div>
-                                        <div class="legend-label">Mujeres {{ womenAudiences[1].value }}%</div>
+                                        <div class="legend-label">Mujeres {{ audiences?.women[1].value }}%</div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="womenAudiences" name="omnichat-gender-woman"
+                                <app-chart-pictorial [data]="audiences?.women" name="omnichat-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
                                     height="280px">
                                 </app-chart-pictorial>
@@ -438,9 +443,8 @@
                         <span class="h4">{{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por Edad</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-lollipop [data]="trafficAndSales['age']" name="omnichat-age" category="age"
-                            [value]="selectedTab4 === 1 ? 'visits' : 'sales'" height="280px"
-                            [status]="trafficSalesReqStatus[2].reqStatus">
+                        <app-chart-lollipop [data]="audiences?.age" name="omnichat-age" category="age"
+                            [value]="selectedTab4 === 1 ? 'visits' : 'sales'" height="280px">
                         </app-chart-lollipop>
                     </div>
                 </div>
@@ -454,17 +458,16 @@
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
-                        <app-chart-loader *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus <= 1">
+                        <app-chart-loader *ngIf="chartsInitLoad && audiencesReqStatus[3].reqStatus <= 1">
                         </app-chart-loader>
 
                         <!-- ready -->
-                        <app-chart-pyramid *ngIf="trafficAndSales['genderByAge']?.length > 0"
-                            [data]="trafficAndSales['genderByAge']" name="omnichat-age-and-gender"
-                            [status]="trafficSalesReqStatus[3].reqStatus" height="280px">
+                        <app-chart-pyramid *ngIf="audiences?.genderByAge?.length > 0" [data]="audiences?.genderByAge"
+                            name="omnichat-age-and-gender" [status]="audiencesReqStatus[3].reqStatus" height="280px">
                         </app-chart-pyramid>
 
                         <!-- empty data -->
-                        <div *ngIf="trafficSalesReqStatus[3].reqStatus === 2 && trafficAndSales['genderByAge']?.length === 0"
+                        <div *ngIf="audiencesReqStatus[3].reqStatus === 2 && audiences?.genderByAge?.length === 0"
                             class="chart-error-container text-muted">
                             <p class="text-center">
                                 Sin datos disponibles <br>
@@ -473,7 +476,7 @@
                         </div>
 
                         <!-- error -->
-                        <div *ngIf="chartsInitLoad && trafficSalesReqStatus[3].reqStatus === 3"
+                        <div *ngIf="chartsInitLoad && audiencesReqStatus[3].reqStatus === 3"
                             class="chart-error-container text-muted">
                             <span>Error al consultar datos</span>
                         </div>
@@ -489,7 +492,7 @@
                             por día de la semana y hora del día</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-heat-map [data]="heatmapData" name="omnichat-weekday-sesions" height="100%">
+                        <app-chart-heat-map [data]="audiences?.sessions" name="omnichat-weekday-sesions" height="100%">
                         </app-chart-heat-map>
                     </div>
                 </div>
@@ -503,8 +506,8 @@
                             por día de la semana</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-bar-horizontal [data]="trafficByDay" name="omnichat-traffic-day" category='weekday'
-                            value='value' height="250px">
+                        <app-chart-bar-horizontal [data]="audiences?.weekday" name="omnichat-traffic-day"
+                            category='weekday' value='value' height="250px">
                         </app-chart-bar-horizontal>
                     </div>
                 </div>
@@ -516,7 +519,7 @@
                             por hora del día</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-lollipop [data]="trafficByHour" name="omnichat-traffic-hour" category="hour"
+                        <app-chart-lollipop [data]="audiences?.hour" name="omnichat-traffic-hour" category="hour"
                             value="visits" height="250px">
                         </app-chart-lollipop>
                     </div>

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -13,6 +13,8 @@ import { TableItem } from '../generic-table/generic-table.component';
   styleUrls: ['./omnichat-wrapper.component.scss']
 })
 export class OmnichatWrapperComponent implements OnInit, OnDestroy {
+  kpisReqStatus = 2;
+  chartsInitLoad: boolean = true;
 
   kpis: any[] = [
     {
@@ -86,9 +88,99 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     }
   ];
 
-  kpisReqStatus = 2;
+  trafficVsConversions = [{
+    date: '2021-03-15',
+    traffic: 1298,
+    conversions: 66,
+  }, {
+    date: '2021-03-16',
+    traffic: 816,
+    conversions: 39,
+  }, {
+    date: '2021-03-17',
+    traffic: 1963,
+    conversions: 43,
+  }, {
+    date: '2021-03-18',
+    traffic: 1809,
+    conversions: 29,
+  }, {
+    date: '2021-03-19',
+    traffic: 1434,
+    conversions: 36,
+  }, {
+    date: '2021-03-20',
+    traffic: 2359,
+    conversions: 16,
+  }, {
+    date: '2021-03-21',
+    traffic: 2114,
+    conversions: 66,
+  }];
 
-  chatsByCountry = [
+  investmentVsRevenue = [
+    {
+      date: '2021-03-15',
+      investment: 2816.232,
+      revenue: 25977.84,
+    }, {
+      date: '2021-03-16',
+      investment: 3517.643,
+      revenue: 1375.64,
+    }, {
+      date: '2021-03-17',
+      investment: 4923.765,
+      revenue: 35541.75,
+    }, {
+      date: '2021-03-18',
+      investment: 7205.837,
+      revenue: 58172.32,
+    }, {
+      date: '2021-03-19',
+      investment: 2121.599,
+      revenue: 23498.33,
+    }, {
+      date: '2021-03-20',
+      investment: 3585.788,
+      revenue: 13770.55,
+    }, {
+      date: '2021-03-21',
+      investment: 3850.785,
+      revenue: 40874.56,
+    }
+  ]
+
+  aupVsRevenue = [{
+    date: '2021-03-15',
+    revenue: 2816.232,
+    aup: 35977,
+  }, {
+    date: '2021-03-16',
+    revenue: 3517.643,
+    aup: 22677,
+  }, {
+    date: '2021-03-17',
+    revenue: 8923.765,
+    aup: 25541,
+  }, {
+    date: '2021-03-18',
+    revenue: 6205.837,
+    aup: 28172,
+  }, {
+    date: '2021-03-19',
+    revenue: 2326.599,
+    aup: 26498,
+  }, {
+    date: '2021-03-20',
+    revenue: 3585.788,
+    aup: 43770,
+  }, {
+    date: '2021-03-21',
+    revenue: 4850.785,
+    aup: 40874,
+  }];
+
+  trafficByCountry = [
     { country: 'Panama', chats: 18 },
     { country: 'Honduras', chats: 135 },
     { country: 'Guatemala', chats: 202 },
@@ -102,7 +194,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     { country: 'Chile', chats: 1300 },
   ];
 
-  chatsByRetailer = [
+  trafficByRetailer = [
     { retailer: 'MX - Pedidos', chats: 0 },
     { retailer: 'HN - Jestereo', chats: 0 },
     { retailer: 'HN - Office Depot', chats: 3 },
@@ -129,39 +221,108 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     { retailer: 'CL - Alkosto', chats: 750 },
   ];
 
-  chatsByDevices = [
-    { name: 'Desktop', value: 2500 },
-    { name: 'Mobile', value: 10500 }
-  ];
-
-  devicesReqStatus = 2;
-
-  chatsByCategories = [
+  trafficByCategories = [
     { category: 'PS', value: 3200 },
     { category: 'HW Print', value: 1200 },
     { category: 'Supplies', value: 400 }
+  ];
+
+  conversionsByCountry = [
+    { country: 'Panama', chats: 0 },
+    { country: 'Honduras', chats: 1 },
+    { country: 'Guatemala', chats: 2 },
+    { country: 'El Salvador', chats: 4 },
+    { country: 'Costa Rica', chats: 7 },
+    { country: 'Colombia', chats: 8 },
+    { country: 'Peru', chats: 11 },
+    { country: 'Chile', chats: 17 },
+    { country: 'Mexico', chats: 25 },
+    { country: 'Brasil', chats: 35 },
+    { country: 'Argentina', chats: 45 },
+  ];
+
+  conversionsByRetailer = [
+    { retailer: 'MX - Pedidos', chats: 0 },
+    { retailer: 'HN - Jestereo', chats: 0 },
+    { retailer: 'HN - Office Depot', chats: 0 },
+    { retailer: 'AR - Musimundo', chats: 0 },
+    { retailer: 'GT - Office Depot', chats: 0 },
+    { retailer: 'SV - Office Depot', chats: 1 },
+    { retailer: 'MX - Dusof', chats: 1 },
+    { retailer: 'CR - Unimart', chats: 1 },
+    { retailer: 'CR - Office Depot', chats: 1 },
+    { retailer: 'BR - Casas Bahia', chats: 1 },
+    { retailer: 'AR - Carrefour', chats: 2 },
+    { retailer: 'BR - Portinfo', chats: 3 },
+    { retailer: 'AR - Fravega', chats: 4 },
+    { retailer: 'BR - Kalunga', chats: 4 },
+    { retailer: 'AR - Garbarino', chats: 4 },
+    { retailer: 'BR - Portifino', chats: 5 },
+    { retailer: 'AR - Compumundo', chats: 6 },
+    { retailer: 'MX - Liverpool', chats: 6 },
+    { retailer: 'MX - Walmart', chats: 6 },
+    { retailer: 'PE - Rodelag', chats: 7 },
+    { retailer: 'PE - Hiroka', chats: 7 },
+    { retailer: 'PE - Riplay', chats: 8 },
+    { retailer: 'CL- PC Factory', chats: 8 },
+    { retailer: 'CL - Alkosto', chats: 9 },
+  ];
+
+  conversionsByCategories = [
+    { category: 'PS', value: 7 },
+    { category: 'HW Print', value: 24 },
+    { category: 'Supplies', value: 72 }
+  ];
+
+  productsPs = [
+    { product: 'Laptop HP 14-AX111LA 14" Intel Celeron 4 GB 64 GB SSD Azul', transactions: 1 },
+    { product: 'Laptop HP 15-GW0012LA 15.6" AMD Ryzen 5 12 GB RAM 256 GB Roja', transactions: 1 },
+    { product: 'Laptop HP 15-EF1007LA 15.6" AMD Ryzen 3 12 GB RAM 256 GB SSD Azul', transactions: 1 },
+    { product: 'Laptop HP 11A-NB0013DX 11.6" Intel Celeron 4 GB RAM 32 GB SSD Gris', transactions: 2 },
+    { product: 'Laptop HP 15-EN0002LA OMEN de 15.6" AMD Ryzen 7 16 GB512 GB Negro', transactions: 2 },
+    { product: 'Laptop HP 1N091UAABA 11.6" Intel Celeron 4 GB RAM 32 GB SSD Negra', transactions: 3 },
+
   ]
-  chartsInitLoad: boolean = true;
-  trafficAndSales = {
-    device: [
-      {
-        "name": "Desktop",
-        "value": 13000
-      },
-      {
-        "name": "Mobile",
-        "value": 10000
-      }
+
+  productsHwPrint = [
+    { product: 'Impresora Multifunción HP In 2', transactions: 7 },
+    { product: 'Impresora HP Ink Tank 115 - HP 2', transactions: 8 },
+    { product: 'Impresora Multifunción HP Ink 2', transactions: 10 },
+    { product: 'Impresora Láser HP 107W - HP 2', transactions: 20 },
+    { product: 'Impresora Multifunción HP Deskjet 2', transactions: 25 },
+    { product: 'Impresora HP Deskjet Ink Advance 2', transactions: 28 },
+    { product: 'Impresora Multifunción HP In', transactions: 30 },
+    { product: 'Impresora HP Ink Tank 115 - HP', transactions: 37 },
+    { product: 'Impresora Multifunción HP Ink', transactions: 41 },
+    { product: 'Impresora Láser HP 107W - HP', transactions: 41 },
+    { product: 'Impresora Multifunción HP Deskjet', transactions: 74 },
+    { product: 'Impresora HP Deskjet Ink Advance', transactions: 89 },
+  ]
+
+  productsSupplies = [
+    { product: 'Hp 65 Xl Tinta Negra Alto Rendimiento 65xl N9k04an', transactions: 2 },
+    { product: 'Pack Original De Tinta Negra Y Color Hp 664 Advantage', transactions: 3 },
+    { product: 'Pack de Ahorro de 3 Cartuchos de Tinta HP 711 Magenta DesignJet Original', transactions: 10 },
+    { product: 'Cartucho HP 964XL Alto Rendimiento Negro Original, 2000 Páginas', transactions: 18 },
+  ]
+
+
+  trafficAudiences = {
+    desktop: [
+      { name: 'empty', value: 70 },
+      { id: 1, name: 'Desktop', value: 30 },
     ],
-    gender: [
-      {
-        "name": "Hombre",
-        "value": 5500
-      },
-      {
-        "name": "Mujer",
-        "value": 7500
-      }
+    mobile: [
+      { name: 'empty', value: 30 },
+      { id: 1, name: 'Mobile', value: 70 },
+    ],
+    women: [
+      { name: 'empty', value: 55 },
+      { id: 1, name: 'woman', value: 45 },
+    ],
+    men: [
+      { name: 'empty', value: 45 },
+      { id: 1, name: 'men', value: 55 },
     ],
     age: [
       {
@@ -273,930 +434,1868 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         "male": -3.8,
         "female": 3.8
       }
+    ],
+    sessions: [
+      {
+        "hour": "12pm",
+        "weekday": "Lun",
+        "value": 3346
+      },
+      {
+        "hour": "1am",
+        "weekday": "Lun",
+        "value": 2725
+      },
+      {
+        "hour": "2am",
+        "weekday": "Lun",
+        "value": 3052
+      },
+      {
+        "hour": "3am",
+        "weekday": "Lun",
+        "value": 3876
+      },
+      {
+        "hour": "4am",
+        "weekday": "Lun",
+        "value": 4453
+      },
+      {
+        "hour": "5am",
+        "weekday": "Lun",
+        "value": 3972
+      },
+      {
+        "hour": "6am",
+        "weekday": "Lun",
+        "value": 4644
+      },
+      {
+        "hour": "7am",
+        "weekday": "Lun",
+        "value": 5715
+      },
+      {
+        "hour": "8am",
+        "weekday": "Lun",
+        "value": 7080
+      },
+      {
+        "hour": "9am",
+        "weekday": "Lun",
+        "value": 8022
+      },
+      {
+        "hour": "10am",
+        "weekday": "Lun",
+        "value": 8446
+      },
+      {
+        "hour": "11am",
+        "weekday": "Lun",
+        "value": 9313
+      },
+      {
+        "hour": "12am",
+        "weekday": "Lun",
+        "value": 9011
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Lun",
+        "value": 8508
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Lun",
+        "value": 8515
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Lun",
+        "value": 8399
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Lun",
+        "value": 8649
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Lun",
+        "value": 7869
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Lun",
+        "value": 6933
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Lun",
+        "value": 5969
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Lun",
+        "value": 5552
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Lun",
+        "value": 5434
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Lun",
+        "value": 5070
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Lun",
+        "value": 4851
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Mar",
+        "value": 4468
+      },
+      {
+        "hour": "1am",
+        "weekday": "Mar",
+        "value": 3306
+      },
+      {
+        "hour": "2am",
+        "weekday": "Mar",
+        "value": 3906
+      },
+      {
+        "hour": "3am",
+        "weekday": "Mar",
+        "value": 4413
+      },
+      {
+        "hour": "4am",
+        "weekday": "Mar",
+        "value": 4726
+      },
+      {
+        "hour": "5am",
+        "weekday": "Mar",
+        "value": 4584
+      },
+      {
+        "hour": "6am",
+        "weekday": "Mar",
+        "value": 5717
+      },
+      {
+        "hour": "7am",
+        "weekday": "Mar",
+        "value": 6504
+      },
+      {
+        "hour": "8am",
+        "weekday": "Mar",
+        "value": 8104
+      },
+      {
+        "hour": "9am",
+        "weekday": "Mar",
+        "value": 8813
+      },
+      {
+        "hour": "10am",
+        "weekday": "Mar",
+        "value": 9278
+      },
+      {
+        "hour": "11am",
+        "weekday": "Mar",
+        "value": 10425
+      },
+      {
+        "hour": "12am",
+        "weekday": "Mar",
+        "value": 10137
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Mar",
+        "value": 9290
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Mar",
+        "value": 9255
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Mar",
+        "value": 9614
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Mar",
+        "value": 9713
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Mar",
+        "value": 9667
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Mar",
+        "value": 8774
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Mar",
+        "value": 8649
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Mar",
+        "value": 9937
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Mar",
+        "value": 10286
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Mar",
+        "value": 9175
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Mar",
+        "value": 8581
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Mie",
+        "value": 8145
+      },
+      {
+        "hour": "1am",
+        "weekday": "Mie",
+        "value": 7177
+      },
+      {
+        "hour": "2am",
+        "weekday": "Mie",
+        "value": 5657
+      },
+      {
+        "hour": "3am",
+        "weekday": "Mie",
+        "value": 6802
+      },
+      {
+        "hour": "4am",
+        "weekday": "Mie",
+        "value": 8159
+      },
+      {
+        "hour": "5am",
+        "weekday": "Mie",
+        "value": 8449
+      },
+      {
+        "hour": "6am",
+        "weekday": "Mie",
+        "value": 9453
+      },
+      {
+        "hour": "7am",
+        "weekday": "Mie",
+        "value": 9947
+      },
+      {
+        "hour": "8am",
+        "weekday": "Mie",
+        "value": 11471
+      },
+      {
+        "hour": "9am",
+        "weekday": "Mie",
+        "value": 12492
+      },
+      {
+        "hour": "10am",
+        "weekday": "Mie",
+        "value": 9388
+      },
+      {
+        "hour": "11am",
+        "weekday": "Mie",
+        "value": 9928
+      },
+      {
+        "hour": "12am",
+        "weekday": "Mie",
+        "value": 9644
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Mie",
+        "value": 9034
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Mie",
+        "value": 8964
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Mie",
+        "value": 9069
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Mie",
+        "value": 8898
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Mie",
+        "value": 8322
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Mie",
+        "value": 6909
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Mie",
+        "value": 5810
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Mie",
+        "value": 5151
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Mie",
+        "value": 4911
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Mie",
+        "value": 4487
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Mie",
+        "value": 4118
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Jue",
+        "value": 3689
+      },
+      {
+        "hour": "1am",
+        "weekday": "Jue",
+        "value": 3081
+      },
+      {
+        "hour": "2am",
+        "weekday": "Jue",
+        "value": 6525
+      },
+      {
+        "hour": "3am",
+        "weekday": "Jue",
+        "value": 6228
+      },
+      {
+        "hour": "4am",
+        "weekday": "Jue",
+        "value": 6917
+      },
+      {
+        "hour": "5am",
+        "weekday": "Jue",
+        "value": 6568
+      },
+      {
+        "hour": "6am",
+        "weekday": "Jue",
+        "value": 6405
+      },
+      {
+        "hour": "7am",
+        "weekday": "Jue",
+        "value": 8106
+      },
+      {
+        "hour": "8am",
+        "weekday": "Jue",
+        "value": 8542
+      },
+      {
+        "hour": "9am",
+        "weekday": "Jue",
+        "value": 8501
+      },
+      {
+        "hour": "10am",
+        "weekday": "Jue",
+        "value": 8802
+      },
+      {
+        "hour": "11am",
+        "weekday": "Jue",
+        "value": 9420
+      },
+      {
+        "hour": "12am",
+        "weekday": "Jue",
+        "value": 8966
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Jue",
+        "value": 8135
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Jue",
+        "value": 8224
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Jue",
+        "value": 8387
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Jue",
+        "value": 8218
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Jue",
+        "value": 7641
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Jue",
+        "value": 6469
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Jue",
+        "value": 5441
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Jue",
+        "value": 4952
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Jue",
+        "value": 4643
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Jue",
+        "value": 4393
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Jue",
+        "value": 4017
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Vier",
+        "value": 4022
+      },
+      {
+        "hour": "1am",
+        "weekday": "Vier",
+        "value": 3063
+      },
+      {
+        "hour": "2am",
+        "weekday": "Vier",
+        "value": 3638
+      },
+      {
+        "hour": "3am",
+        "weekday": "Vier",
+        "value": 3968
+      },
+      {
+        "hour": "4am",
+        "weekday": "Vier",
+        "value": 4070
+      },
+      {
+        "hour": "5am",
+        "weekday": "Vier",
+        "value": 4019
+      },
+      {
+        "hour": "6am",
+        "weekday": "Vier",
+        "value": 4548
+      },
+      {
+        "hour": "7am",
+        "weekday": "Vier",
+        "value": 5465
+      },
+      {
+        "hour": "8am",
+        "weekday": "Vier",
+        "value": 6909
+      },
+      {
+        "hour": "9am",
+        "weekday": "Vier",
+        "value": 7706
+      },
+      {
+        "hour": "10am",
+        "weekday": "Vier",
+        "value": 7867
+      },
+      {
+        "hour": "11am",
+        "weekday": "Vier",
+        "value": 8615
+      },
+      {
+        "hour": "12am",
+        "weekday": "Vier",
+        "value": 8218
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Vier",
+        "value": 7604
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Vier",
+        "value": 7429
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Vier",
+        "value": 7488
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Vier",
+        "value": 7493
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Vier",
+        "value": 6998
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Vier",
+        "value": 5941
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Vier",
+        "value": 5068
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Vier",
+        "value": 4636
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Vier",
+        "value": 4241
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Vier",
+        "value": 3858
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Vier",
+        "value": 3833
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Sab",
+        "value": 3503
+      },
+      {
+        "hour": "1am",
+        "weekday": "Sab",
+        "value": 2842
+      },
+      {
+        "hour": "2am",
+        "weekday": "Sab",
+        "value": 2808
+      },
+      {
+        "hour": "3am",
+        "weekday": "Sab",
+        "value": 2399
+      },
+      {
+        "hour": "4am",
+        "weekday": "Sab",
+        "value": 2280
+      },
+      {
+        "hour": "5am",
+        "weekday": "Sab",
+        "value": 2139
+      },
+      {
+        "hour": "6am",
+        "weekday": "Sab",
+        "value": 2527
+      },
+      {
+        "hour": "7am",
+        "weekday": "Sab",
+        "value": 2940
+      },
+      {
+        "hour": "8am",
+        "weekday": "Sab",
+        "value": 3066
+      },
+      {
+        "hour": "9am",
+        "weekday": "Sab",
+        "value": 3494
+      },
+      {
+        "hour": "10am",
+        "weekday": "Sab",
+        "value": 3287
+      },
+      {
+        "hour": "11am",
+        "weekday": "Sab",
+        "value": 3416
+      },
+      {
+        "hour": "12am",
+        "weekday": "Sab",
+        "value": 3432
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Sab",
+        "value": 3523
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Sab",
+        "value": 3542
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Sab",
+        "value": 3347
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Sab",
+        "value": 3292
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Sab",
+        "value": 3416
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Sab",
+        "value": 3131
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Sab",
+        "value": 3057
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Sab",
+        "value": 3227
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Sab",
+        "value": 3060
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Sab",
+        "value": 2855
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Sab",
+        "value": 2625
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Dom",
+        "value": 2990
+      },
+      {
+        "hour": "1am",
+        "weekday": "Dom",
+        "value": 2520
+      },
+      {
+        "hour": "2am",
+        "weekday": "Dom",
+        "value": 2334
+      },
+      {
+        "hour": "3am",
+        "weekday": "Dom",
+        "value": 2230
+      },
+      {
+        "hour": "4am",
+        "weekday": "Dom",
+        "value": 2325
+      },
+      {
+        "hour": "5am",
+        "weekday": "Dom",
+        "value": 2019
+      },
+      {
+        "hour": "6am",
+        "weekday": "Dom",
+        "value": 2128
+      },
+      {
+        "hour": "7am",
+        "weekday": "Dom",
+        "value": 2246
+      },
+      {
+        "hour": "8am",
+        "weekday": "Dom",
+        "value": 2421
+      },
+      {
+        "hour": "9am",
+        "weekday": "Dom",
+        "value": 2788
+      },
+      {
+        "hour": "10am",
+        "weekday": "Dom",
+        "value": 2959
+      },
+      {
+        "hour": "11am",
+        "weekday": "Dom",
+        "value": 3018
+      },
+      {
+        "hour": "12am",
+        "weekday": "Dom",
+        "value": 3154
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Dom",
+        "value": 3172
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Dom",
+        "value": 3368
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Dom",
+        "value": 3464
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Dom",
+        "value": 3746
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Dom",
+        "value": 3656
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Dom",
+        "value": 3336
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Dom",
+        "value": 3292
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Dom",
+        "value": 3269
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Dom",
+        "value": 3300
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Dom",
+        "value": 3403
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Dom",
+        "value": 3323
+      }
+    ],
+    weekday: [
+      { weekday: 'Dom', value: 180 },
+      { weekday: 'Sab', value: 166 },
+      { weekday: 'Vier', value: 166 },
+      { weekday: 'Jue', value: 267 },
+      { weekday: 'Mier', value: 277 },
+      { weekday: 'Mar', value: 270 },
+      { weekday: 'Lun', value: 230 },
+    ],
+    hour: [
+      { hour: '12 AM', visits: 5 },
+      { hour: '3 AM', visits: 1 },
+      { hour: '6 AM', visits: 9 },
+      { hour: '9 AM', visits: 67 },
+      { hour: '12 PM', visits: 101 },
+      { hour: '3 PM', visits: 81 },
+      { hour: '6 PM', visits: 105 },
+      { hour: '9 PM', visits: 100 }
     ]
   }
 
-  trafficSalesReqStatus = [
+  conversionAudience = {
+    desktop: [
+      { name: 'empty', value: 80 },
+      { name: 'Desktop', value: 20 },
+    ],
+    mobile: [
+      { name: 'empty', value: 20 },
+      { name: 'Mobile', value: 80 },
+    ],
+    women: [
+      { name: 'empty', value: 40 },
+      { name: 'woman', value: 60 },
+    ],
+    men: [
+      { name: 'empty', value: 60 },
+      { name: 'men', value: 40 },
+    ],
+    age: [
+      {
+        "age": "15-19",
+        "sales": 2
+      }, {
+        "age": "20-24",
+        "sales": 4
+      }, {
+        "age": "25-29",
+        "sales": 8
+      }, {
+        "age": "30-34",
+        "sales": 12
+      }, {
+        "age": "35-39",
+        "sales": 0
+      }, {
+        "age": "40-44",
+        "sales": 14
+      }, {
+        "age": "45-49",
+        "sales": 3
+      }, {
+        "age": "50-54",
+        "sales": 0
+      }, {
+        "age": "55-59",
+        "sales": 0
+      }, {
+        "age": "60-64",
+        "sales": 1
+      }, {
+        "age": "65-69",
+        "sales": 0
+      }, {
+        "age": "70-74",
+        "sales": 0
+      }, {
+        "age": "75-79",
+        "sales": 0
+      }, {
+        "age": "80-54",
+        "sales": 0
+      }, {
+        "age": "85+",
+        "sales": 0
+      }
+    ],
+    genderByAge: [
+      {
+        "age": "85+",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "80-54",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "75-79",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "70-74",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "65-69",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "60-64",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "55-59",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "50-54",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "45-49",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "40-44",
+        "male": -10,
+        "female": 6
+      }, {
+        "age": "35-39",
+        "male": 0,
+        "female": 0
+      }, {
+        "age": "30-34",
+        "male": -4,
+        "female": 13
+      }, {
+        "age": "25-29",
+        "male": -4,
+        "female": 6
+      }, {
+        "age": "20-24",
+        "male": 0,
+        "female": 3
+      }, {
+        "age": "15-19",
+        "male": 0,
+        "female": 2
+      }
+    ],
+    sessions: [
+      {
+        "hour": "12pm",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "1am",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "2am",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "3am",
+        "weekday": "Lun",
+        "value": 2
+      },
+      {
+        "hour": "4am",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "7am",
+        "weekday": "Lun",
+        "value": 3
+      },
+      {
+        "hour": "8am",
+        "weekday": "Lun",
+        "value": 2
+      },
+      {
+        "hour": "9am",
+        "weekday": "Lun",
+        "value": 3
+      },
+      {
+        "hour": "10am",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "11am",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "12am",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Lun",
+        "value": 3
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Lun",
+        "value": 4
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Lun",
+        "value": 0
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Lun",
+        "value": 1
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Lun",
+        "value": 2
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Lun",
+        "value": 2
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Lun",
+        "value": 4
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Lun",
+        "value": 3
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Lun",
+        "value": 2
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Mar",
+        "value": 2
+      },
+      {
+        "hour": "1am",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "2am",
+        "weekday": "Mar",
+        "value": 0
+      },
+      {
+        "hour": "3am",
+        "weekday": "Mar",
+        "value": 0
+      },
+      {
+        "hour": "4am",
+        "weekday": "Mar",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Mar",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Mar",
+        "value": 0
+      },
+      {
+        "hour": "7am",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "8am",
+        "weekday": "Mar",
+        "value": 3
+      },
+      {
+        "hour": "9am",
+        "weekday": "Mar",
+        "value": 3
+      },
+      {
+        "hour": "10am",
+        "weekday": "Mar",
+        "value": 2
+      },
+      {
+        "hour": "11am",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "12am",
+        "weekday": "Mar",
+        "value": 4
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Mar",
+        "value": 5
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Mar",
+        "value": 7
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Mar",
+        "value": 3
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Mar",
+        "value": 4
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Mar",
+        "value": 1
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Mar",
+        "value": 3
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Mar",
+        "value": 3
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Mar",
+        "value": 2
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Mar",
+        "value": 2
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "1am",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "2am",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "3am",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "4am",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "7am",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "8am",
+        "weekday": "Mie",
+        "value": 2
+      },
+      {
+        "hour": "9am",
+        "weekday": "Mie",
+        "value": 3
+      },
+      {
+        "hour": "10am",
+        "weekday": "Mie",
+        "value": 2
+      },
+      {
+        "hour": "11am",
+        "weekday": "Mie",
+        "value": 2
+      },
+      {
+        "hour": "12am",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Mie",
+        "value": 3
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Mie",
+        "value": 5
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Mie",
+        "value": 2
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Mie",
+        "value": 1
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Mie",
+        "value": 0
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "1am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "2am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "3am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "4am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "7am",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "8am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "9am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "10am",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "11am",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "12am",
+        "weekday": "Jue",
+        "value": 3
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Jue",
+        "value": 2
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Jue",
+        "value": 0
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Jue",
+        "value": 3
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Jue",
+        "value": 2
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Jue",
+        "value": 1
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Jue",
+        "value": 2
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Jue",
+        "value": 4
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "1am",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "2am",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "3am",
+        "weekday": "Vier",
+        "value": 3
+      },
+      {
+        "hour": "4am",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "5am",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "7am",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "8am",
+        "weekday": "Vier",
+        "value": 4
+      },
+      {
+        "hour": "9am",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "10am",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "11am",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "12am",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Vier",
+        "value": 2
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Vier",
+        "value": 3
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Vier",
+        "value": 1
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Vier",
+        "value": 0
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "1am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "2am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "3am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "4am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "7am",
+        "weekday": "Sab",
+        "value": 1
+      },
+      {
+        "hour": "8am",
+        "weekday": "Sab",
+        "value": 3
+      },
+      {
+        "hour": "9am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "10am",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "11am",
+        "weekday": "Sab",
+        "value": 2
+      },
+      {
+        "hour": "12am",
+        "weekday": "Sab",
+        "value": 4
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Sab",
+        "value": 5
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Sab",
+        "value": 2
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Sab",
+        "value": 2
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Sab",
+        "value": 1
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Sab",
+        "value": 0
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Sab",
+        "value": 1
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Sab",
+        "value": 2
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Sab",
+        "value": 1
+      },
+      {
+        "hour": "12pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "1am",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "2am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "3am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "4am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "5am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "6am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "7am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "8am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "9am",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "10am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "11am",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "12am",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "1pm",
+        "weekday": "Dom",
+        "value": 0
+      },
+      {
+        "hour": "2pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "3pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "4pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "5pm",
+        "weekday": "Dom",
+        "value": 2
+      },
+      {
+        "hour": "6pm",
+        "weekday": "Dom",
+        "value": 2
+      },
+      {
+        "hour": "7pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "8pm",
+        "weekday": "Dom",
+        "value": 3
+      },
+      {
+        "hour": "9pm",
+        "weekday": "Dom",
+        "value": 4
+      },
+      {
+        "hour": "10pm",
+        "weekday": "Dom",
+        "value": 1
+      },
+      {
+        "hour": "11pm",
+        "weekday": "Dom",
+        "value": 2
+      }
+    ],
+    weekday: [
+      { weekday: 'Dom', value: 6 },
+      { weekday: 'Sab', value: 4 },
+      { weekday: 'Vier', value: 12 },
+      { weekday: 'Jue', value: 8 },
+      { weekday: 'Mier', value: 10 },
+      { weekday: 'Mar', value: 14 },
+      { weekday: 'Lun', value: 1 },
+    ],
+    hour: [
+      { hour: '12 AM', visits: 1 },
+      { hour: '3 AM', visits: 1 },
+      { hour: '6 AM', visits: 3 },
+      { hour: '9 AM', visits: 8 },
+      { hour: '12 PM', visits: 9 },
+      { hour: '3 PM', visits: 10 },
+      { hour: '6 PM', visits: 12 },
+      { hour: '9 PM', visits: 14 }
+    ]
+  }
+
+
+  audiencesReqStatus = [
     { name: 'device', reqStatus: 2 },
     { name: 'gender', reqStatus: 2 },
     { name: 'age', reqStatus: 2 },
     { name: 'gender-and-age', reqStatus: 2 }
   ];
-
-  heatmapData = [
-    {
-      "hour": "12pm",
-      "weekday": "Lun",
-      "value": 3346
-    },
-    {
-      "hour": "1am",
-      "weekday": "Lun",
-      "value": 2725
-    },
-    {
-      "hour": "2am",
-      "weekday": "Lun",
-      "value": 3052
-    },
-    {
-      "hour": "3am",
-      "weekday": "Lun",
-      "value": 3876
-    },
-    {
-      "hour": "4am",
-      "weekday": "Lun",
-      "value": 4453
-    },
-    {
-      "hour": "5am",
-      "weekday": "Lun",
-      "value": 3972
-    },
-    {
-      "hour": "6am",
-      "weekday": "Lun",
-      "value": 4644
-    },
-    {
-      "hour": "7am",
-      "weekday": "Lun",
-      "value": 5715
-    },
-    {
-      "hour": "8am",
-      "weekday": "Lun",
-      "value": 7080
-    },
-    {
-      "hour": "9am",
-      "weekday": "Lun",
-      "value": 8022
-    },
-    {
-      "hour": "10am",
-      "weekday": "Lun",
-      "value": 8446
-    },
-    {
-      "hour": "11am",
-      "weekday": "Lun",
-      "value": 9313
-    },
-    {
-      "hour": "12am",
-      "weekday": "Lun",
-      "value": 9011
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Lun",
-      "value": 8508
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Lun",
-      "value": 8515
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Lun",
-      "value": 8399
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Lun",
-      "value": 8649
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Lun",
-      "value": 7869
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Lun",
-      "value": 6933
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Lun",
-      "value": 5969
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Lun",
-      "value": 5552
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Lun",
-      "value": 5434
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Lun",
-      "value": 5070
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Lun",
-      "value": 4851
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Mar",
-      "value": 4468
-    },
-    {
-      "hour": "1am",
-      "weekday": "Mar",
-      "value": 3306
-    },
-    {
-      "hour": "2am",
-      "weekday": "Mar",
-      "value": 3906
-    },
-    {
-      "hour": "3am",
-      "weekday": "Mar",
-      "value": 4413
-    },
-    {
-      "hour": "4am",
-      "weekday": "Mar",
-      "value": 4726
-    },
-    {
-      "hour": "5am",
-      "weekday": "Mar",
-      "value": 4584
-    },
-    {
-      "hour": "6am",
-      "weekday": "Mar",
-      "value": 5717
-    },
-    {
-      "hour": "7am",
-      "weekday": "Mar",
-      "value": 6504
-    },
-    {
-      "hour": "8am",
-      "weekday": "Mar",
-      "value": 8104
-    },
-    {
-      "hour": "9am",
-      "weekday": "Mar",
-      "value": 8813
-    },
-    {
-      "hour": "10am",
-      "weekday": "Mar",
-      "value": 9278
-    },
-    {
-      "hour": "11am",
-      "weekday": "Mar",
-      "value": 10425
-    },
-    {
-      "hour": "12am",
-      "weekday": "Mar",
-      "value": 10137
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Mar",
-      "value": 9290
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Mar",
-      "value": 9255
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Mar",
-      "value": 9614
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Mar",
-      "value": 9713
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Mar",
-      "value": 9667
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Mar",
-      "value": 8774
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Mar",
-      "value": 8649
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Mar",
-      "value": 9937
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Mar",
-      "value": 10286
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Mar",
-      "value": 9175
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Mar",
-      "value": 8581
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Mie",
-      "value": 8145
-    },
-    {
-      "hour": "1am",
-      "weekday": "Mie",
-      "value": 7177
-    },
-    {
-      "hour": "2am",
-      "weekday": "Mie",
-      "value": 5657
-    },
-    {
-      "hour": "3am",
-      "weekday": "Mie",
-      "value": 6802
-    },
-    {
-      "hour": "4am",
-      "weekday": "Mie",
-      "value": 8159
-    },
-    {
-      "hour": "5am",
-      "weekday": "Mie",
-      "value": 8449
-    },
-    {
-      "hour": "6am",
-      "weekday": "Mie",
-      "value": 9453
-    },
-    {
-      "hour": "7am",
-      "weekday": "Mie",
-      "value": 9947
-    },
-    {
-      "hour": "8am",
-      "weekday": "Mie",
-      "value": 11471
-    },
-    {
-      "hour": "9am",
-      "weekday": "Mie",
-      "value": 12492
-    },
-    {
-      "hour": "10am",
-      "weekday": "Mie",
-      "value": 9388
-    },
-    {
-      "hour": "11am",
-      "weekday": "Mie",
-      "value": 9928
-    },
-    {
-      "hour": "12am",
-      "weekday": "Mie",
-      "value": 9644
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Mie",
-      "value": 9034
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Mie",
-      "value": 8964
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Mie",
-      "value": 9069
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Mie",
-      "value": 8898
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Mie",
-      "value": 8322
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Mie",
-      "value": 6909
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Mie",
-      "value": 5810
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Mie",
-      "value": 5151
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Mie",
-      "value": 4911
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Mie",
-      "value": 4487
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Mie",
-      "value": 4118
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Jue",
-      "value": 3689
-    },
-    {
-      "hour": "1am",
-      "weekday": "Jue",
-      "value": 3081
-    },
-    {
-      "hour": "2am",
-      "weekday": "Jue",
-      "value": 6525
-    },
-    {
-      "hour": "3am",
-      "weekday": "Jue",
-      "value": 6228
-    },
-    {
-      "hour": "4am",
-      "weekday": "Jue",
-      "value": 6917
-    },
-    {
-      "hour": "5am",
-      "weekday": "Jue",
-      "value": 6568
-    },
-    {
-      "hour": "6am",
-      "weekday": "Jue",
-      "value": 6405
-    },
-    {
-      "hour": "7am",
-      "weekday": "Jue",
-      "value": 8106
-    },
-    {
-      "hour": "8am",
-      "weekday": "Jue",
-      "value": 8542
-    },
-    {
-      "hour": "9am",
-      "weekday": "Jue",
-      "value": 8501
-    },
-    {
-      "hour": "10am",
-      "weekday": "Jue",
-      "value": 8802
-    },
-    {
-      "hour": "11am",
-      "weekday": "Jue",
-      "value": 9420
-    },
-    {
-      "hour": "12am",
-      "weekday": "Jue",
-      "value": 8966
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Jue",
-      "value": 8135
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Jue",
-      "value": 8224
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Jue",
-      "value": 8387
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Jue",
-      "value": 8218
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Jue",
-      "value": 7641
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Jue",
-      "value": 6469
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Jue",
-      "value": 5441
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Jue",
-      "value": 4952
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Jue",
-      "value": 4643
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Jue",
-      "value": 4393
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Jue",
-      "value": 4017
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Vier",
-      "value": 4022
-    },
-    {
-      "hour": "1am",
-      "weekday": "Vier",
-      "value": 3063
-    },
-    {
-      "hour": "2am",
-      "weekday": "Vier",
-      "value": 3638
-    },
-    {
-      "hour": "3am",
-      "weekday": "Vier",
-      "value": 3968
-    },
-    {
-      "hour": "4am",
-      "weekday": "Vier",
-      "value": 4070
-    },
-    {
-      "hour": "5am",
-      "weekday": "Vier",
-      "value": 4019
-    },
-    {
-      "hour": "6am",
-      "weekday": "Vier",
-      "value": 4548
-    },
-    {
-      "hour": "7am",
-      "weekday": "Vier",
-      "value": 5465
-    },
-    {
-      "hour": "8am",
-      "weekday": "Vier",
-      "value": 6909
-    },
-    {
-      "hour": "9am",
-      "weekday": "Vier",
-      "value": 7706
-    },
-    {
-      "hour": "10am",
-      "weekday": "Vier",
-      "value": 7867
-    },
-    {
-      "hour": "11am",
-      "weekday": "Vier",
-      "value": 8615
-    },
-    {
-      "hour": "12am",
-      "weekday": "Vier",
-      "value": 8218
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Vier",
-      "value": 7604
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Vier",
-      "value": 7429
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Vier",
-      "value": 7488
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Vier",
-      "value": 7493
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Vier",
-      "value": 6998
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Vier",
-      "value": 5941
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Vier",
-      "value": 5068
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Vier",
-      "value": 4636
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Vier",
-      "value": 4241
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Vier",
-      "value": 3858
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Vier",
-      "value": 3833
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Sab",
-      "value": 3503
-    },
-    {
-      "hour": "1am",
-      "weekday": "Sab",
-      "value": 2842
-    },
-    {
-      "hour": "2am",
-      "weekday": "Sab",
-      "value": 2808
-    },
-    {
-      "hour": "3am",
-      "weekday": "Sab",
-      "value": 2399
-    },
-    {
-      "hour": "4am",
-      "weekday": "Sab",
-      "value": 2280
-    },
-    {
-      "hour": "5am",
-      "weekday": "Sab",
-      "value": 2139
-    },
-    {
-      "hour": "6am",
-      "weekday": "Sab",
-      "value": 2527
-    },
-    {
-      "hour": "7am",
-      "weekday": "Sab",
-      "value": 2940
-    },
-    {
-      "hour": "8am",
-      "weekday": "Sab",
-      "value": 3066
-    },
-    {
-      "hour": "9am",
-      "weekday": "Sab",
-      "value": 3494
-    },
-    {
-      "hour": "10am",
-      "weekday": "Sab",
-      "value": 3287
-    },
-    {
-      "hour": "11am",
-      "weekday": "Sab",
-      "value": 3416
-    },
-    {
-      "hour": "12am",
-      "weekday": "Sab",
-      "value": 3432
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Sab",
-      "value": 3523
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Sab",
-      "value": 3542
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Sab",
-      "value": 3347
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Sab",
-      "value": 3292
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Sab",
-      "value": 3416
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Sab",
-      "value": 3131
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Sab",
-      "value": 3057
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Sab",
-      "value": 3227
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Sab",
-      "value": 3060
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Sab",
-      "value": 2855
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Sab",
-      "value": 2625
-    },
-    {
-      "hour": "12pm",
-      "weekday": "Dom",
-      "value": 2990
-    },
-    {
-      "hour": "1am",
-      "weekday": "Dom",
-      "value": 2520
-    },
-    {
-      "hour": "2am",
-      "weekday": "Dom",
-      "value": 2334
-    },
-    {
-      "hour": "3am",
-      "weekday": "Dom",
-      "value": 2230
-    },
-    {
-      "hour": "4am",
-      "weekday": "Dom",
-      "value": 2325
-    },
-    {
-      "hour": "5am",
-      "weekday": "Dom",
-      "value": 2019
-    },
-    {
-      "hour": "6am",
-      "weekday": "Dom",
-      "value": 2128
-    },
-    {
-      "hour": "7am",
-      "weekday": "Dom",
-      "value": 2246
-    },
-    {
-      "hour": "8am",
-      "weekday": "Dom",
-      "value": 2421
-    },
-    {
-      "hour": "9am",
-      "weekday": "Dom",
-      "value": 2788
-    },
-    {
-      "hour": "10am",
-      "weekday": "Dom",
-      "value": 2959
-    },
-    {
-      "hour": "11am",
-      "weekday": "Dom",
-      "value": 3018
-    },
-    {
-      "hour": "12am",
-      "weekday": "Dom",
-      "value": 3154
-    },
-    {
-      "hour": "1pm",
-      "weekday": "Dom",
-      "value": 3172
-    },
-    {
-      "hour": "2pm",
-      "weekday": "Dom",
-      "value": 3368
-    },
-    {
-      "hour": "3pm",
-      "weekday": "Dom",
-      "value": 3464
-    },
-    {
-      "hour": "4pm",
-      "weekday": "Dom",
-      "value": 3746
-    },
-    {
-      "hour": "5pm",
-      "weekday": "Dom",
-      "value": 3656
-    },
-    {
-      "hour": "6pm",
-      "weekday": "Dom",
-      "value": 3336
-    },
-    {
-      "hour": "7pm",
-      "weekday": "Dom",
-      "value": 3292
-    },
-    {
-      "hour": "8pm",
-      "weekday": "Dom",
-      "value": 3269
-    },
-    {
-      "hour": "9pm",
-      "weekday": "Dom",
-      "value": 3300
-    },
-    {
-      "hour": "10pm",
-      "weekday": "Dom",
-      "value": 3403
-    },
-    {
-      "hour": "11pm",
-      "weekday": "Dom",
-      "value": 3323
-    }
-  ];
-
-  trafficByDay = [
-    { weekday: 'Dom', value: 180 },
-    { weekday: 'Sab', value: 166 },
-    { weekday: 'Vier', value: 166 },
-    { weekday: 'Jue', value: 267 },
-    { weekday: 'Mier', value: 277 },
-    { weekday: 'Mar', value: 270 },
-    { weekday: 'Lun', value: 230 },
-  ]
-
-  trafficByHour = [
-    { hour: '12 AM', visits: 5 },
-    { hour: '3 AM', visits: 1 },
-    { hour: '6 AM', visits: 9 },
-    { hour: '9 AM', visits: 67 },
-    { hour: '12 PM', visits: 101 },
-    { hour: '3 PM', visits: 81 },
-    { hour: '6 PM', visits: 105 },
-    { hour: '9 PM', visits: 100 }
-  ]
-
-  transactionsData = [
-    {
-      metricTitle: 'usuarios *',
-      metricName: 'users',
-      metricValue: 173199,
-      metricFormat: 'integer'
-    },
-    {
-      metricTitle: 'transacciones',
-      metricName: 'transactions',
-      metricValue: 6695,
-      metricFormat: 'integer'
-    },
-    {
-      metricTitle: 'tasa de conversión',
-      metricName: 'transactions',
-      metricValue: 3.9,
-      metricFormat: 'percentage',
-    }
-  ]
-
-  trafficVsConversions = [{
-    date: '2021-03-15',
-    traffic: 1298,
-    conversions: 66,
-  }, {
-    date: '2021-03-16',
-    traffic: 816,
-    conversions: 39,
-  }, {
-    date: '2021-03-17',
-    traffic: 1963,
-    conversions: 43,
-  }, {
-    date: '2021-03-18',
-    traffic: 1809,
-    conversions: 29,
-  }, {
-    date: '2021-03-19',
-    traffic: 1434,
-    conversions: 36,
-  }, {
-    date: '2021-03-20',
-    traffic: 2359,
-    conversions: 16,
-  }, {
-    date: '2021-03-21',
-    traffic: 2114,
-    conversions: 66,
-  }];
 
   conversionByCategories = [
     {
@@ -1235,40 +2334,6 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
 
   ]
 
-  aupVsRevenue = [{
-    date: '2021-03-15',
-    revenue: 2816.232,
-    aup: 35977,
-  }, {
-    date: '2021-03-16',
-    revenue: 3517.643,
-    aup: 22677,
-  }, {
-    date: '2021-03-17',
-    revenue: 8923.765,
-    aup: 25541,
-  }, {
-    date: '2021-03-18',
-    revenue: 6205.837,
-    aup: 28172,
-  }, {
-    date: '2021-03-19',
-    revenue: 2326.599,
-    aup: 26498,
-  }, {
-    date: '2021-03-20',
-    revenue: 3585.788,
-    aup: 43770,
-  }, {
-    date: '2021-03-21',
-    revenue: 4850.785,
-    aup: 40874,
-  }];
-
-
-
-
-
   usersTransactionsConversion: any = {
     'Ene 21': {
       'users': 1517,
@@ -1291,28 +2356,6 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
       'conversion_rate': 9
     }
   }
-
-  desktopAudiences: any[] = [
-    { name: 'empty', value: 70 },
-    { id: 1, name: 'Desktop', value: 30 },
-  ];
-
-  mobileAudiences: any[] = [
-    { name: 'empty', value: 30 },
-    { id: 1, name: 'Mobile', value: 70 },
-  ];
-
-  womenAudiences: any[] = [
-    { name: 'empty', value: 55 },
-    { id: 1, name: 'woman', value: 45 },
-  ]
-
-  menAudiences: any[] = [
-    { name: 'empty', value: 45 },
-    { id: 1, name: 'men', value: 55 },
-  ];
-
-  dataByUsersAndRevenue: any[] = this.trafficVsConversions;
 
   // *************************
 
@@ -1339,10 +2382,12 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     categories: 2
   }
 
-  countries: any[] = this.chatsByCountry;
-  retailers: any[] = this.chatsByRetailer;
-  categories: any[] = this.chatsByCategories;
-
+  performanceData: any[] = this.trafficVsConversions;
+  countries: any[] = this.trafficByCountry;
+  retailers: any[] = this.trafficByRetailer;
+  categories: any[] = this.trafficByCategories;
+  products: any[] = this.productsPs;
+  audiences: any = this.trafficAudiences;
 
   categoriesAndUsersColumns: TableItem[] = [
     {
@@ -1418,7 +2463,6 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     reqStatus: 2
   }
 
-
   categoryAndUsersColumns: string[] = ['category', 'users', 'conversion_rate', 'conversion_rate_yoy', 'amount', 'amount_yoy', 'revenue', 'revenue_yoy', 'aup', 'aup_yoy'];
   private categoryAndUsers = [
     { category: 'PS', users: 5388, conversion_rate: 8, conversion_rate_yoy: 2, amount: 300, amount_yoy: -3, revenue: 3480, revenue_yoy: 6, aup: 10358, aup_yoy: -1 },
@@ -1467,38 +2511,46 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     });
   }
 
-  getAllData() {
-    this.getCountries('traffic');
-    this.getCategories('traffic');
-  }
+  getAllData() { }
 
+  getPerformanceData(metricType: string) {
+    switch (metricType) {
+      case 'users':
+        this.selectedTab1 = 1;
+        this.performanceData = this.trafficVsConversions;
+        break;
 
-  getDataByTrafficAndSales(metricType: string) {
-    this.selectedTab1 = metricType === 'traffic' ? 1 : 2;
-  }
+      case 'investment':
+        this.selectedTab1 = 2;
+        this.performanceData = this.investmentVsRevenue;
+        break;
 
-  getDataByTrafficAndSales2(metricType: string) {
-    this.selectedTab4 = metricType === 'traffic' ? 1 : 2;
-  }
-
-  getDataByUsersAndRevenue(metricType: string) {
-    this.selectedTab1 = metricType === 'users' ? 1 : 2;
-
-    if (metricType === 'users') {
-      this.dataByUsersAndRevenue = this.trafficVsConversions;
-    } else if (metricType === 'revenue') {
-      this.dataByUsersAndRevenue = this.aupVsRevenue;
+      case 'revenue':
+        this.selectedTab1 = 3;
+        this.performanceData = this.aupVsRevenue;
     }
   }
 
-  getDataByTrafficAndConversions(metricType: string) {
-    this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
+  getCountriesRetAndCat(metricType: string) {
+    if (metricType === 'traffic') {
+      this.countries = this.trafficByCountry;
+      this.retailers = this.trafficByRetailer;
+      this.categories = this.trafficByCategories;
+      this.selectedTab2 = 1;
+
+    } else if (metricType === 'sales') {
+      this.countries = this.conversionsByCountry;
+      this.retailers = this.conversionsByRetailer;
+      this.categories = this.conversionsByCategories;
+      this.selectedTab2 = 2;
+    }
   }
 
   getDataByCategory(category) {
     this.selectedTab3 = category;
 
     if (category === 1) {
+      this.products = this.productsPs;
       this.usersTransactionsConversion = {
         'Ene 21': {
           'users': 1517,
@@ -1523,6 +2575,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
       }
 
     } else if (category === 2) {
+      this.products = this.productsHwPrint;
       this.usersTransactionsConversion = {
         'Ene 21': {
           'users': 150,
@@ -1546,6 +2599,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         }
       }
     } else {
+      this.products = this.productsSupplies;
       this.usersTransactionsConversion = {
         'Ene 21': {
           'users': 4200,
@@ -1576,6 +2630,25 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     }
   }
 
+  getAudiencesData(metricType: string) {
+    this.selectedTab4 = metricType === 'traffic' ? 1 : 2;
+
+    if (metricType === 'traffic') {
+      this.audiences = this.trafficAudiences;
+    } else if (metricType === 'sales') {
+      this.audiences = this.conversionAudience;
+
+    }
+  }
+
+  getDataByTrafficAndConversions(metricType: string) {
+    this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
+  }
+
+  getDataByTrafficAndSales(metricType: string) {
+    this.selectedTab1 = metricType === 'traffic' ? 1 : 2;
+  }
+
   getActiveView() {
     if (this.retailerID) {
       this.retailerView = true;
@@ -1590,66 +2663,6 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
       this.retailerView = false;
     }
   }
-
-  // solo para latam
-  getCountries(metricType: string) {
-    this.chartsReqStatus.countries = 1;
-
-    this.omnichatService.getCountries(metricType).subscribe(
-      (resp: any[]) => {
-        console.log('countries', resp)
-        this.countries = resp;
-        this.chartsReqStatus.countries = 2;
-      },
-      error => {
-        const errorMsg = error?.error?.message ? error.error.message : error?.message;
-        console.error(`[omnichat.component]: ${errorMsg}`);
-        this.chartsReqStatus.countries = 3;
-      }
-    )
-
-    this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
-  }
-
-  // solo para latam y country
-  getRetailers(metricType: string) {
-    this.chartsReqStatus.retailers = 1;
-
-    this.omnichatService.getRetailers(this.latamView, metricType).subscribe(
-      (resp: any[]) => {
-        console.log('retailer', resp)
-        this.retailers = resp;
-        this.chartsReqStatus.retailers = 2;
-      },
-      error => {
-        const errorMsg = error?.error?.message ? error.error.message : error?.message;
-        console.error(`[omnichat.component]: ${errorMsg}`);
-        this.chartsReqStatus.retailers = 3;
-      }
-    )
-
-    this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
-  }
-
-  getCategories(metricType: string) {
-    this.chartsReqStatus.categories = 1;
-
-    this.omnichatService.getCategories(this.latamView, metricType).subscribe(
-      (resp: any[]) => {
-        console.log('categories', resp)
-        this.categories = resp;
-        this.chartsReqStatus.categories = 2;
-      },
-      error => {
-        const errorMsg = error?.error?.message ? error.error.message : error?.message;
-        console.error(`[omnichat.component]: ${errorMsg}`);
-        this.chartsReqStatus.categories = 3;
-      }
-    )
-
-    this.selectedTab2 = metricType === 'traffic' ? 1 : 2;
-  }
-
 
   ngOnDestroy() {
     this.routeSub?.unsubscribe();

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.html
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.html
@@ -91,7 +91,8 @@
             </div>
             <div class="card-body retailers-chart-container">
                 <app-chart-bar-horizontal [data]="retailers" name="pc-selector-chats-by-retailer" category="retailer"
-                    value="chats" [truncateLabels]="true" [singleColorBars]="true" height="900px">
+                    value="chats" [truncateLabels]="true" [singleColorBars]="true"
+                    [height]="latamView ? '900px' : '300px'">
                 </app-chart-bar-horizontal>
             </div>
         </div>
@@ -221,7 +222,7 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container">
+                                    <div class="legend-container" *ngIf="demographics?.desktop?.length > 0">
                                         <div class="legend-square on color-4"></div>
                                         <div class="legend-label">Desktop {{ demographics.desktop[1].value }}%
                                         </div>
@@ -234,7 +235,7 @@
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container">
+                                    <div class="legend-container" *ngIf="demographics?.mobile?.length > 0">
                                         <div class="legend-square on color-5"></div>
                                         <div class="legend-label">Mobile {{ demographics.mobile[1].value }}%</div>
                                     </div>
@@ -259,7 +260,7 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container">
+                                    <div class="legend-container" *ngIf="demographics?.men?.length > 0">
                                         <div class="legend-square on color-4"></div>
                                         <div class="legend-label">Hombres {{ demographics.men[1].value }}%</div>
                                     </div>
@@ -272,7 +273,7 @@
 
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container">
+                                    <div class="legend-container" *ngIf="demographics?.women?.length > 0">
                                         <div class="legend-square on color-5"></div>
                                         <div class="legend-label">Mujeres {{ demographics.women[1].value }}%</div>
                                     </div>

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -742,125 +742,10 @@ export class PcSelectorWrapperComponent implements OnInit {
       { name: 'empty', value: 30 },
       { name: 'Mobile', value: 70 },
     ],
-    women: [
-      { name: 'empty', value: 100 },
-      { name: 'woman', value: 0 },
-    ],
-    men: [
-      { name: 'empty', value: 100 },
-      { name: 'men', value: 0 },
-    ],
-    age: [
-      {
-        "age": "15-19",
-        "sales": 0
-      }, {
-        "age": "20-24",
-        "sales": 0
-      }, {
-        "age": "25-29",
-        "sales": 0
-      }, {
-        "age": "30-34",
-        "sales": 0
-      }, {
-        "age": "35-39",
-        "sales": 0
-      }, {
-        "age": "40-44",
-        "sales": 0
-      }, {
-        "age": "45-49",
-        "sales": 0
-      }, {
-        "age": "50-54",
-        "sales": 0
-      }, {
-        "age": "55-59",
-        "sales": 0
-      }, {
-        "age": "60-64",
-        "sales": 0
-      }, {
-        "age": "65-69",
-        "sales": 0
-      }, {
-        "age": "70-74",
-        "sales": 0
-      }, {
-        "age": "75-79",
-        "sales": 0
-      }, {
-        "age": "80-54",
-        "sales": 0
-      }, {
-        "age": "85+",
-        "sales": 0
-      }
-    ],
-    genderByAge: [
-      {
-        "age": "85+",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "80-54",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "75-79",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "70-74",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "65-69",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "60-64",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "55-59",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "50-54",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "45-49",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "40-44",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "35-39",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "30-34",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "25-29",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "20-24",
-        "male": 0,
-        "female": 0
-      }, {
-        "age": "15-19",
-        "male": 0,
-        "female": 0
-      }
-    ]
+    women: [],
+    men: [],
+    age: [],
+    genderByAge: []
   }
 
   // Tráfico por día de la semana y hora del día
@@ -1791,7 +1676,6 @@ export class PcSelectorWrapperComponent implements OnInit {
 
     if (this.countryID || this.retailerID || this.latamView) {
       this.getActiveView();
-      // this.getAllData();
     }
 
     this.routeSub = this.router.events.pipe(
@@ -1805,12 +1689,10 @@ export class PcSelectorWrapperComponent implements OnInit {
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
       this.retailerID = retailer?.id;
-      this.getActiveView();
     });
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
       this.countryID = country?.id;
-      this.getActiveView();
     });
   }
 
@@ -1826,6 +1708,12 @@ export class PcSelectorWrapperComponent implements OnInit {
     } else if (this.latamView) {
       this.countryView = false;
       this.retailerView = false;
+    }
+
+    if (this.countryView) {
+      this.retailers = this.retailers.filter(item => item.retailer.includes('MX'));
+    } else {
+      this.retailers = this.trafficByRetailer;
     }
   }
 
@@ -1848,6 +1736,12 @@ export class PcSelectorWrapperComponent implements OnInit {
     } else if (metricType === 'conversions') {
       this.countries = this.conversionsByCountry;
       this.retailers = this.conversionsByRetailer;
+    }
+
+    console.log('retailers', this.retailers)
+
+    if (this.countryView) {
+      this.retailers = this.retailers.filter(item => item.retailer.includes('MX'));
     }
   }
 

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -10,7 +10,7 @@
                 <span class="h2 py-2 ml-3 mr-3">OmniChat</span>
             </a>
         </li>
-        <li class="nav-item">
+        <li class="nav-item" *ngIf="latamView || (countryID === 9 && ! retailerID) || retailerID === 29">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}" (click)="activeTabView = 3">
                 <span class="h2 py-2 ml-3 mr-3">PC Selector</span>
             </a>

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -1,17 +1,56 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { AppStateService } from 'src/app/services/app-state.service';
 
 @Component({
   selector: 'app-other-tools',
   templateUrl: './other-tools.component.html',
   styleUrls: ['./other-tools.component.scss']
 })
-export class OtherToolsComponent implements OnInit {
+export class OtherToolsComponent implements OnInit, OnDestroy {
 
   activeTabView = 1;
 
-  constructor() { }
+  countryID: number;
+  retailerID: number;
+  latamView: boolean;
+
+  routeSub: Subscription;
+  countrySub: Subscription;
+  retailerSub: Subscription;
+
+  constructor(
+    private appStateService: AppStateService,
+    private router: Router,
+  ) { }
 
   ngOnInit(): void {
+    this.countryID = this.appStateService.selectedCountry?.id;
+    this.retailerID = this.appStateService.selectedRetailer?.id;
+    this.latamView = this.router.url.includes('latam') ? true : false;
+
+    this.routeSub = this.router.events.pipe(filter(event => event instanceof NavigationEnd))
+      .subscribe(event => {
+        if (event instanceof NavigationEnd)
+          this.latamView = this.router.url.includes('latam') ? true : false;
+      });
+
+    this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
+      this.retailerID = retailer?.id;
+    });
+
+    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
+      this.countryID = country?.id;
+    });
+
+  }
+
+  ngOnDestroy() {
+    this.routeSub?.unsubscribe();
+    this.countrySub?.unsubscribe();
+    this.retailerSub?.unsubscribe();
   }
 
 }


### PR DESCRIPTION
# Problem Description
- Is necessary show dynamic content in other tools components
   - Show different data whit tab selection 
   - Show different content and data in LATAM, country or retailer view
   - Show dynamic tabs based on selected country, retailer or LATAM view

# Features
- Show dynamic tabs in other-tools component
- Add dynamic content in indexed-wrapper component
- Add dynamic content in omnichat-wrapper component
- Show dynamc data in pc-selector-wrapper component

# Where this change will be used
- In LATAM/Countries/Retailers -> Other tools
