### PR TITLE
disaggregate pictorial charts in overview components

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -13,8 +13,9 @@ import { AppStateService } from 'src/app/services/app-state.service';
 })
 export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy {
 
-  @Input() value: string = 'value';
   @Input() category: string = 'category';
+  @Input() value: string = 'value';
+  @Input() valueFormat: string;
   @Input() iconPath: string; // an svg icon path. If isnt't provide is necessary to use "iconType" input
   @Input() iconType: string;
   @Input() height: string = '350px'; // height property value valid in css
@@ -114,10 +115,12 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy
         am4core.color(this.uniqueDimensionConf.color),
       ];
 
+      const valueFormat = this.valueFormat;
+
       series.tooltip.label.adapter.add('text', function (text, target) {
         if (target.dataItem._index === 0) return '';
-        const percent = target.dataItem.values.value.value;
-        return `${percent}%`;
+        const value = `${target.dataItem.values.value.value}% ${chart.data[1]?.rawValue ? ` (${chart.data[1].rawValue})` : ''} ${valueFormat ? valueFormat : ''}`;
+        return value;
       });
     }
 

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -585,19 +585,19 @@ export class IndexedWrapperComponent implements OnInit {
   trafficDemographics = {
     desktop: [
       { name: 'empty', value: 59 },
-      { id: 1, name: 'Desktop', value: 41 },
+      { id: 1, name: 'Desktop', value: 41, rawValue: 3800 },
     ],
     mobile: [
-      { name: 'empty', value: 59 },
-      { id: 1, name: 'Mobile', value: 41 },
+      { name: 'empty', value: 41 },
+      { id: 1, name: 'Mobile', value: 59, rawValue: 4200 },
     ],
     women: [
       { name: 'empty', value: 46 },
-      { id: 1, name: 'woman', value: 54 },
+      { id: 1, name: 'woman', value: 54, rawValue: 3300 },
     ],
     men: [
       { name: 'empty', value: 54 },
-      { id: 1, name: 'men', value: 46 },
+      { id: 1, name: 'men', value: 46, rawValue: 2500 },
     ],
     age: [
       {

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -405,20 +405,20 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
 
   trafficAudiences = {
     desktop: [
-      { name: 'empty', value: 70 },
-      { id: 1, name: 'Desktop', value: 30 },
+      { name: 'empty', value: 59 },
+      { id: 1, name: 'Desktop', value: 41, rawValue: 3800 },
     ],
     mobile: [
-      { name: 'empty', value: 30 },
-      { id: 1, name: 'Mobile', value: 70 },
+      { name: 'empty', value: 41 },
+      { id: 1, name: 'Mobile', value: 59, rawValue: 4200 },
     ],
     women: [
-      { name: 'empty', value: 55 },
-      { id: 1, name: 'woman', value: 45 },
+      { name: 'empty', value: 46 },
+      { id: 1, name: 'woman', value: 54, rawValue: 3300 },
     ],
     men: [
-      { name: 'empty', value: 45 },
-      { id: 1, name: 'men', value: 55 },
+      { name: 'empty', value: 54 },
+      { id: 1, name: 'men', value: 46, rawValue: 2500 },
     ],
     age: [
       {
@@ -1397,19 +1397,19 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
   conversionAudience = {
     desktop: [
       { name: 'empty', value: 80 },
-      { name: 'Desktop', value: 20 },
+      { name: 'Desktop', value: 20, rawValue: 2 },
     ],
     mobile: [
       { name: 'empty', value: 20 },
-      { name: 'Mobile', value: 80 },
+      { name: 'Mobile', value: 80, rawValue: 8 },
     ],
     women: [
       { name: 'empty', value: 40 },
-      { name: 'woman', value: 60 },
+      { name: 'woman', value: 60, rawValue: 6 },
     ],
     men: [
       { name: 'empty', value: 60 },
-      { name: 'men', value: 40 },
+      { name: 'men', value: 40, rawValue: 4 },
     ],
     age: [
       {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -37,11 +37,11 @@
                 </div>
                 <div class="card-body">
                     <div class="chart-legend mt-0 mb-2">
-                        <div class="legend-container">
+                        <div class="legend-container-hp">
                             <div class="legend-square on"></div>
                             <div class="legend-label">Activas</div>
                         </div>
-                        <div class="legend-container ml-3">
+                        <div class="legend-container-hp ml-3">
                             <div class="legend-square off"></div>
                             <div class="legend-label">Inactivas</div>
                         </div>
@@ -124,7 +124,7 @@
         </div>
 
         <!-- devices -->
-        <div class="col-12 col-md-6 mt-4">
+        <!-- <div class="col-12 col-md-6 mt-4">
             <div class="card">
                 <div class="card-header">
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por dispositivos</span>
@@ -135,10 +135,53 @@
                     </app-chart-pictorial>
                 </div>
             </div>
+        </div> -->
+
+        <div class="col-12 col-md-6 mt-4">
+            <div class="card height-fluid">
+                <div class="card-header">
+                    <span class="h4">
+                        {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                        ('overviewLatam.chart2CardTitle1' | translate) }}
+                    </span>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                            <div class="chart-legend legend-center mt-0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.deviceDesktop?.length > 0">
+                                    <div class="legend-square on color-1"></div>
+                                    <div class="legend-label">Desktop {{ trafficAndSales.deviceDesktop[1].value }}%
+                                    </div>
+                                </div>
+                            </div>
+                            <app-chart-pictorial [data]="trafficAndSales?.deviceDesktop"
+                                [name]="selectedType + 'device-desktop'" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus"
+                                height="280px">
+                            </app-chart-pictorial>
+                        </div>
+                        <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                            <div class="chart-legend legend-center mt-0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.deviceMobile?.length > 0">
+                                    <div class="legend-square on color-2"></div>
+                                    <div class="legend-label">Mobile {{ trafficAndSales.deviceMobile[1].value }}%
+                                    </div>
+                                </div>
+                            </div>
+                            <app-chart-pictorial [data]="trafficAndSales?.deviceMobile"
+                                [name]="selectedType + 'device-mobile'" [uniqueDimensionConf]="{color: '#6794DC'}"
+                                category="name" iconType="cellphone" height="280px"
+                                [status]="trafficSalesReqStatus[0].reqStatus">
+                            </app-chart-pictorial>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
 
         <!-- gender -->
-        <div class="col-12 col-md-6 mt-4">
+        <!-- <div class="col-12 col-md-6 mt-4">
             <div class="card">
                 <div class="card-header">
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Ventas'}} por Género</span>
@@ -149,7 +192,55 @@
                     </app-chart-pictorial>
                 </div>
             </div>
+        </div> -->
+
+        <div class="col-12 col-md-6 mt-4">
+            <div class="card height-fluid">
+                <div class="card-header">
+                    <span class="h4">
+                        {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                        ('overviewLatam.chart3CardTitle1' | translate) }}
+                    </span>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                            <div class="chart-legend legend-center mt-0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.genderMan?.length > 0">
+                                    <div class="legend-square on color-1"></div>
+                                    <div class="legend-label">
+                                        {{ ('others.men'| translate) + ' '}}
+                                        {{ trafficAndSales.genderMan[1].value }}%
+                                    </div>
+                                </div>
+                            </div>
+                            <app-chart-pictorial [data]="trafficAndSales?.genderMan"
+                                [name]="selectedType + 'gender-man'" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                category="name" iconType="man" [status]="trafficSalesReqStatus[1].reqStatus"
+                                height="280px">
+                            </app-chart-pictorial>
+                        </div>
+                        <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                            <div class="chart-legend legend-center mt-0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.genderWoman?.length > 0">
+                                    <div class="legend-square on color-2"></div>
+                                    <div class="legend-label">
+                                        {{ ('others.women'| translate) + ' '}}
+                                        {{ trafficAndSales.genderWoman[1].value }}%
+                                    </div>
+                                </div>
+                            </div>
+                            <app-chart-pictorial [data]="trafficAndSales?.genderWoman"
+                                [name]="selectedType + 'gender-woman'" [uniqueDimensionConf]="{color: '#6794DC'}"
+                                category="name" iconType="woman" height="280px"
+                                [status]="trafficSalesReqStatus[1].reqStatus">
+                            </app-chart-pictorial>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
+
 
         <!-- age -->
         <div class="col-12 col-md-6 mt-4">

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.scss
@@ -42,7 +42,15 @@
     justify-content: flex-end;
     padding: 0 15px;
 
-    .legend-container {
+    &.legend-right {
+        justify-content: flex-end;
+    }
+
+    &.legend-center {
+        justify-content: center;
+    }
+
+    .legend-container-hp {
         align-items: center;
         display: flex;
        
@@ -58,6 +66,31 @@
 
             &.off {
                 background-color: #e9e9e9;
+            }
+        }
+
+        .legend-label {
+            color: #000000;
+            font-size: 12px;
+        }
+    }
+
+    .legend-container {
+        align-items: center;
+        display: flex;
+
+        .legend-square {
+            border-radius: 4px;
+            height: 16px;
+            margin-right: 4px;
+            width: 16px;
+
+            &.color-1 {
+                background-color: #67B6DC;
+            }
+
+            &.color-2 {
+                background-color: #6794DC;
             }
         }
 

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -605,11 +605,11 @@ export class PcSelectorWrapperComponent implements OnInit {
   trafficDemographic = {
     desktop: [
       { name: 'empty', value: 12.5 },
-      { name: 'Desktop', value: 87.5 },
+      { name: 'Desktop', value: 87.5, rawValue: 36 },
     ],
     mobile: [
       { name: 'empty', value: 87.5 },
-      { name: 'Mobile', value: 12.5 },
+      { name: 'Mobile', value: 12.5, rawValue: 92 },
     ],
     women: [
       { name: 'empty', value: 55 },
@@ -735,12 +735,12 @@ export class PcSelectorWrapperComponent implements OnInit {
   // Conversiones - Demográficos
   conversionsDemographic = {
     desktop: [
-      { name: 'empty', value: 70 },
-      { name: 'Desktop', value: 30 },
+      { name: 'empty', value: 50 },
+      { name: 'Desktop', value: 50, rawValue: 1 },
     ],
     mobile: [
-      { name: 'empty', value: 30 },
-      { name: 'Mobile', value: 70 },
+      { name: 'empty', value: 50 },
+      { name: 'Mobile', value: 50, rawValue: 1 },
     ],
     women: [],
     men: [],

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -222,7 +222,7 @@
             </div>
 
             <!-- devices -->
-            <div class="col-12 col-md-6 mt-4">
+            <!-- <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
                         <span class="h4">
@@ -236,10 +236,52 @@
                         </app-chart-pictorial>
                     </div>
                 </div>
+            </div> -->
+
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card height-fluid">
+                    <div class="card-header">
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart2CardTitle1' | translate) }}
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.deviceDesktop?.length > 0">
+                                        <div class="legend-square on color-1"></div>
+                                        <div class="legend-label">Desktop {{ trafficAndSales.deviceDesktop[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="trafficAndSales?.deviceDesktop"
+                                    name="latam-devices-desktop" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                    category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus"
+                                    height="280px">
+                                </app-chart-pictorial>
+                            </div>
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.deviceMobile?.length > 0">
+                                        <div class="legend-square on color-2"></div>
+                                        <div class="legend-label">Mobile {{ trafficAndSales.deviceMobile[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="trafficAndSales?.deviceMobile" name="latam-devices-mobile"
+                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
+                                    height="280px" [status]="trafficSalesReqStatus[0].reqStatus">
+                                </app-chart-pictorial>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- gender -->
-            <div class="col-12 col-md-6 mt-4">
+            <!-- <div class="col-12 col-md-6 mt-4">
                 <div class="card">
                     <div class="card-header">
                         <span class="h4">
@@ -251,6 +293,51 @@
                         <app-chart-pictorial [data]="trafficAndSales['gender']" name="latam-gender" category="name"
                             iconType="man" [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                         </app-chart-pictorial>
+                    </div>
+                </div>
+            </div> -->
+
+            <div class="col-12 col-md-6 mt-4">
+                <div class="card height-fluid">
+                    <div class="card-header">
+                        <span class="h4">
+                            {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.sales') | translate) +
+                            ('overviewLatam.chart3CardTitle1' | translate) }}
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.genderMan?.length > 0">
+                                        <div class="legend-square on color-1"></div>
+                                        <div class="legend-label">
+                                            {{ ('others.men'| translate) + ' '}}
+                                            {{ trafficAndSales.genderMan[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="trafficAndSales?.genderMan" name="latam-gender-man"
+                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
+                                    [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
+                                </app-chart-pictorial>
+                            </div>
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.genderWoman?.length > 0">
+                                        <div class="legend-square on color-2"></div>
+                                        <div class="legend-label">
+                                            {{ ('others.women'| translate) + ' '}}
+                                            {{ trafficAndSales.genderWoman[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="trafficAndSales?.genderWoman" name="latam-gender-woman"
+                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
+                                    height="280px" [status]="trafficSalesReqStatus[1].reqStatus">
+                                </app-chart-pictorial>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.scss
@@ -89,3 +89,42 @@
         }
     }
 }
+
+
+.chart-legend {
+    display: flex;
+    padding: 0 15px;
+
+    &.legend-right {
+        justify-content: flex-end;
+    }
+
+    &.legend-center {
+        justify-content: center;
+    }
+
+    .legend-container {
+        align-items: center;
+        display: flex;
+
+        .legend-square {
+            border-radius: 4px;
+            height: 16px;
+            margin-right: 4px;
+            width: 16px;
+
+            &.color-1 {
+                background-color: #67B6DC;
+            }
+
+            &.color-2 {
+                background-color: #6794DC;
+            }
+        }
+
+        .legend-label {
+            color: #000000;
+            font-size: 12px;
+        }
+    }
+}

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -332,7 +332,9 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       reqStatusObj.reqStatus = 1;
       this.overviewService.getTrafficAndSalesLatam(metricType, subMetricType).subscribe(
         (resp: any[]) => {
-          if (subMetricType === 'gender-and-age') {
+          if (subMetricType === 'device' || subMetricType === 'gender') {
+            this.disaggregateMetric(subMetricType, resp);
+          } else if (subMetricType === 'gender-and-age') {
             this.trafficAndSales['genderByAge'] = resp;
 
           } else if (subMetricType === 'gender') {
@@ -343,7 +345,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
                 return { id: 2, name: this.translate.instant('others.men'), value: item.value }
               }
             });
-
           } else {
             this.trafficAndSales[subMetricType] = resp;
           }
@@ -426,6 +427,70 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     this.selectedCategoryTab1 && delete this.selectedCategoryTab1;
     this.selectedSourceTab && delete this.selectedSourceTab;
   }
+
+  disaggregateMetric(subMetric: string, dataRaw: any[]) {
+    switch (subMetric) {
+      case 'device':
+        const desktop = dataRaw.find(item => item.name === 'Desktop');
+        const mobile = dataRaw.find(item => item.name === 'Mobile');
+
+        let devicePerc = this.getPercentages(desktop?.value, mobile?.value);
+
+        if (desktop) {
+          this.trafficAndSales['deviceDesktop'] = [
+            { name: 'empty', value: devicePerc.perc1 ? 100 - (+devicePerc.perc1) : 100 },
+            { name: 'Desktop', value: devicePerc.perc1 ? devicePerc.perc1 : 0, rawValue: desktop.value },
+          ];
+        } else {
+          this.trafficAndSales['deviceDesktop'] = [];
+        }
+
+        if (mobile) {
+          this.trafficAndSales['deviceMobile'] = [
+            { name: 'empty', value: devicePerc.perc2 ? 100 - (+devicePerc.perc2) : 100 },
+            { name: 'Mobile', value: devicePerc.perc2 ? devicePerc.perc2 : 0, rawValue: mobile.value },
+          ];
+        } else {
+          this.trafficAndSales['deviceMobile'] = [];
+        }
+
+        break;
+
+      case 'gender':
+        const man = dataRaw.find(item => item.name === 'Hombre');
+        const woman = dataRaw.find(item => item.name === 'Mujer');
+
+        let genderPerc = this.getPercentages(man?.value, woman?.value);
+
+        if (man) {
+          this.trafficAndSales['genderMan'] = [
+            { name: 'empty', value: genderPerc.perc1 ? 100 - (+genderPerc.perc1) : 100 },
+            { name: 'Hombre', value: genderPerc.perc1 ? genderPerc.perc1 : 0, rawValue: man.value },
+          ];
+        } else {
+          this.trafficAndSales['genderMan'] = [];
+        }
+
+        if (woman) {
+          this.trafficAndSales['genderWoman'] = [
+            { name: 'empty', value: genderPerc.perc2 ? 100 - (+genderPerc.perc2) : 100 },
+            { name: 'Mujer', value: genderPerc.perc2 ? genderPerc.perc2 : 0, rawValue: woman.value },
+          ];
+        } else {
+          this.trafficAndSales['genderWoman'] = [];
+        }
+
+        break;
+    }
+  }
+
+  getPercentages(value1: any, value2: any) {
+    let total = value1 + value2;
+    let perc1 = ((value1 * 100) / total).toFixed(2);
+    let perc2 = ((value2 * 100) / total).toFixed(2);
+    return { perc1, perc2 };
+  }
+
 
   ngOnDestroy() {
     this.filtersSub?.unsubscribe();


### PR DESCRIPTION
# Problem Description
- According with required changes is necessary to disaggregate pictorial charts in overview components for device and gender metrics (traffic and sales)

# Features
- Update tooltip in chart-pictorial component to show percentage and raw data
- Update chart pictorial data in the followings components:
   - indexed-wrapper
   - pc-selector-wrapper
   - omnichat-wrapper
 
- Disaggregate charts in overview-latam component
- Disaggregate charts in overview-wrapper component

# Where this change will be used
- In LATAM/country/retailer view 

# More details
![image](https://user-images.githubusercontent.com/38545126/122385684-b7914f00-cf32-11eb-8200-6d9421dff871.png)

