### PR TITLE
disaggregate data of pictorial charts using a generic function 

### DIFF
--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -32,10 +32,10 @@
 
     <div class="row">
         <!-- devices and gender in Traffic and Conversions -->
-        <ng-container *ngIf="selectedTab1 <= 2">
+        <ng-container *ngIf="selectedTab1 !== 3">
             <!-- devices -->
             <div class="col-12 col-md-6 mt-4">
-                <div class="card">
+                <div class="card height-fluid">
                     <div class="card-header" [ngSwitch]="selectedTab1">
                         <span *ngSwitchCase="1" class="h4">Tráfico por dispositivos</span>
                         <span *ngSwitchCase="2" class="h4">Conversiones por dispositivos</span>
@@ -43,16 +43,41 @@
                         <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial name="aud-devices" [data]="demographics?.device"
-                            [status]="demoReqStatus[0].reqStatus" category="name" iconType="monitor" height="280px">
-                        </app-chart-pictorial>
+                        <div class="row">
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="demographics?.desktop?.length > 0">
+                                        <div class="legend-square on color-1"></div>
+                                        <div class="legend-label">Desktop {{ demographics.desktop[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="demographics?.desktop" name="aud-devices-desktop"
+                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
+                                    [status]="demoReqStatus[0].reqStatus" height="280px">
+                                </app-chart-pictorial>
+                            </div>
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="demographics?.mobile?.length > 0">
+                                        <div class="legend-square on color-2"></div>
+                                        <div class="legend-label">Mobile {{ demographics.mobile[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="demographics?.mobile" name="aud-devices-mobile"
+                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
+                                    height="280px" [status]="demoReqStatus[0].reqStatus">
+                                </app-chart-pictorial>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
 
             <!-- gender -->
             <div class="col-12 col-md-6 mt-4">
-                <div class="card">
+                <div class="card height-fluid">
                     <div class="card-header" [ngSwitch]="selectedTab1">
                         <span *ngSwitchCase="1" class="h4">Tráfico por Género</span>
                         <span *ngSwitchCase="2" class="h4">Conversiones por Género</span>
@@ -60,9 +85,38 @@
                         <span *ngSwitchCase="4" class="h4">BR por Género</span>
                     </div>
                     <div class="card-body">
-                        <app-chart-pictorial name="aud-gender" [data]="demographics?.gender"
-                            [status]="demoReqStatus[1].reqStatus" category="name" iconType="man" height="280px">
-                        </app-chart-pictorial>
+                        <div class="row">
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="demographics?.men?.length > 0">
+                                        <div class="legend-square on color-1"></div>
+                                        <div class="legend-label">
+                                            {{ ('others.men'| translate) + ' '}}
+                                            {{ demographics.men[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="demographics?.men" name="aud-gender-man"
+                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
+                                    [status]="demoReqStatus[1].reqStatus" height="280px">
+                                </app-chart-pictorial>
+                            </div>
+                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
+                                <div class="chart-legend legend-center mt-0">
+                                    <div class="legend-container" *ngIf="demographics?.women?.length > 0">
+                                        <div class="legend-square on color-2"></div>
+                                        <div class="legend-label">
+                                            {{ ('others.women'| translate) + ' '}}
+                                            {{ demographics.women[1].value }}%
+                                        </div>
+                                    </div>
+                                </div>
+                                <app-chart-pictorial [data]="demographics?.women" name="aud-gender-woman"
+                                    [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
+                                    height="280px" [status]="demoReqStatus[1].reqStatus">
+                                </app-chart-pictorial>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -96,87 +150,6 @@
                             [status]="demoReqStatus[1].reqStatus" valueFormat="USD" category="name" height="280px"
                             [legendsByCategory]="true">
                         </app-chart-bar>
-                    </div>
-                </div>
-            </div>
-        </ng-container>
-
-        <!-- devices and gender in BR -->
-        <ng-container *ngIf="selectedTab1 === 4">
-            <!-- devices -->
-            <div class="col-12 col-md-6 mt-4">
-                <div class="card">
-                    <div class="card-header">
-                        <span class="h4">BR por dispositivos</span>
-                    </div>
-                    <div class="card-body">
-                        <div class="row">
-                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
-                                <div class="chart-legend mt-0">
-                                    <div class="legend-container">
-                                        <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Desktop {{ demographics?.deviceDesktop[1]?.value }}%
-                                        </div>
-                                    </div>
-                                </div>
-                                <app-chart-pictorial name="aud-devices-desktop" [data]="demographics?.deviceDesktop"
-                                    [status]="demoReqStatus[0].reqStatus" [uniqueDimensionConf]="{color: '#67B6DC'}"
-                                    category="name" iconType="monitor" height="280px">
-                                </app-chart-pictorial>
-                            </div>
-                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
-                                <div class="chart-legend mt-0">
-                                    <div class="legend-container">
-                                        <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mobile {{ demographics?.deviceMobile[1]?.value }}%
-                                        </div>
-                                    </div>
-                                </div>
-                                <app-chart-pictorial name="aud-devices-mobile" [data]="demographics?.deviceMobile"
-                                    [status]="demoReqStatus[0].reqStatus" [uniqueDimensionConf]="{color: '#6794DC'}"
-                                    category="name" iconType="cellphone" height="280px">
-                                </app-chart-pictorial>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- gender -->
-            <div class="col-12 col-md-6 mt-4">
-                <div class="card">
-                    <div class="card-header">
-                        <span class="h4">BR por Género</span>
-                    </div>
-                    <div class="card-body">
-                        <div class="row">
-                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
-                                <div class="chart-legend mt-0">
-                                    <div class="legend-container">
-                                        <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Hombres {{ demographics?.genderMan[0]?.value }}%</div>
-                                    </div>
-                                </div>
-                                <app-chart-pictorial name="aud-gender-man" [data]="demographics?.genderMan"
-                                    [status]="demoReqStatus[1].reqStatus" [uniqueDimensionConf]="{color: '#67B6DC'}"
-                                    category="name" iconType="man" height="280px">
-                                </app-chart-pictorial>
-                            </div>
-
-                            <div class="col-12 col-xl-6 mt-5 mt-xl-0">
-                                <div class="chart-legend mt-0">
-                                    <div class="legend-container">
-                                        <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mujeres {{ demographics?.genderWoman[1]?.value }}%
-                                        </div>
-                                    </div>
-                                </div>
-                                <app-chart-pictorial name="aud-gender-woman" [data]="demographics?.genderWoman"
-                                    [status]="demoReqStatus[1].reqStatus" [uniqueDimensionConf]="{color: '#6794DC'}"
-                                    category="name" iconType="woman" height="280px">
-                                </app-chart-pictorial>
-                            </div>
-                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
@@ -100,12 +100,7 @@ export class AudiencesWrapperComponent implements OnInit, OnDestroy {
             this.demographics[subMetricType] = resp;
           }
 
-          console.log('demographics', this.demographics)
-
           reqStatusObj.reqStatus = 2;
-
-          // process bounce rate data;
-          // this.addDemographicDataBr(subMetricType, resp);
         },
         error => {
           const errorMsg = error?.error?.message ? error.error.message : error?.message;
@@ -202,40 +197,6 @@ export class AudiencesWrapperComponent implements OnInit, OnDestroy {
         });
     }
   }
-
-  // addDemographicDataBr(subMetric: string, dataRaw: any[]) {
-  //   switch (subMetric) {
-  //     case 'device':
-  //       const desktop = dataRaw.find(item => item.name === 'Desktop');
-  //       const mobile = dataRaw.find(item => item.name === 'Mobile');
-
-  //       this.demographics['deviceDesktop'] = [
-  //         { name: 'empty', value: desktop ? 100 - desktop.value.toFixed(2) : 100 },
-  //         { name: 'Desktop', value: desktop ? desktop.value.toFixed(2) : 0 },
-  //       ];
-
-  //       this.demographics['deviceMobile'] = [
-  //         { name: 'empty', value: mobile ? 100 - mobile.value.toFixed(2) : 100 },
-  //         { name: 'Mobile', value: mobile ? mobile.value.toFixed(2) : 0 },
-  //       ];
-  //       break;
-
-  //     case 'gender':
-  //       const man = dataRaw.find(item => item.name === 'Hombre');
-  //       const woman = dataRaw.find(item => item.name === 'Mujer');
-
-  //       this.demographics['genderMan'] = [
-  //         { name: 'empty', value: man ? 100 - man.value.toFixed(2) : 100 },
-  //         { name: 'Hombre', value: man ? man.value.toFixed(2) : 0 },
-  //       ];
-
-  //       this.demographics['genderWoman'] = [
-  //         { name: 'empty', value: woman ? 100 - woman.value.toFixed(2) : 100 },
-  //         { name: 'Mujer', value: woman ? woman.value.toFixed(2) : 0 },
-  //       ];
-  //       break;
-  //   }
-  // }
 
   getSelectedMetricForDemo(metricType: string, selectedTab: number) {
     if (metricType) {

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -5,11 +5,13 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 import { Subscription } from 'rxjs';
 import { AppStateService } from 'src/app/services/app-state.service';
+import { DecimalPipe } from '@angular/common';
 
 @Component({
   selector: 'app-chart-pictorial',
   templateUrl: './chart-pictorial.component.html',
-  styleUrls: ['./chart-pictorial.component.scss']
+  styleUrls: ['./chart-pictorial.component.scss'],
+  providers: [DecimalPipe]
 })
 export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy {
 
@@ -50,7 +52,8 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy
   langSub: Subscription;
 
   constructor(
-    private appStateService: AppStateService
+    private appStateService: AppStateService,
+    private decimalPipe: DecimalPipe
   ) { }
 
   ngOnInit(): void {
@@ -116,11 +119,15 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy
       ];
 
       const valueFormat = this.valueFormat;
+      const decimalPipe = this.decimalPipe;
 
-      series.tooltip.label.adapter.add('text', function (text, target) {
+      series.tooltip.label.adapter.add('text', (text, target) => {
         if (target.dataItem._index === 0) return '';
-        const value = `${target.dataItem.values.value.value}% ${chart.data[1]?.rawValue ? ` (${chart.data[1].rawValue})` : ''} ${valueFormat ? valueFormat : ''}`;
-        return value;
+        const percentage = `${decimalPipe.transform(target.dataItem.values.value.value)}%`;
+        const value = `${chart.data[1]?.rawValue ? ` (${decimalPipe.transform(chart.data[1].rawValue)})` : ''}`
+
+        const result = `${percentage} ${value} ${valueFormat ? valueFormat : ''}`;
+        return result;
       });
     }
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -251,13 +251,13 @@
                     <div class="row">
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="trafficAndSales?.deviceDesktop?.length > 0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.desktop?.length > 0">
                                     <div class="legend-square on color-1"></div>
-                                    <div class="legend-label">Desktop {{ trafficAndSales.deviceDesktop[1].value }}%
+                                    <div class="legend-label">Desktop {{ trafficAndSales.desktop[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="trafficAndSales?.deviceDesktop"
+                            <app-chart-pictorial [data]="trafficAndSales?.desktop"
                                 [name]="selectedType + 'device-desktop'" [uniqueDimensionConf]="{color: '#67B6DC'}"
                                 category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus"
                                 height="280px">
@@ -265,13 +265,13 @@
                         </div>
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="trafficAndSales?.deviceMobile?.length > 0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.mobile?.length > 0">
                                     <div class="legend-square on color-2"></div>
-                                    <div class="legend-label">Mobile {{ trafficAndSales.deviceMobile[1].value }}%
+                                    <div class="legend-label">Mobile {{ trafficAndSales.mobile[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="trafficAndSales?.deviceMobile"
+                            <app-chart-pictorial [data]="trafficAndSales?.mobile"
                                 [name]="selectedType + 'device-mobile'" [uniqueDimensionConf]="{color: '#6794DC'}"
                                 category="name" iconType="cellphone" height="280px"
                                 [status]="trafficSalesReqStatus[0].reqStatus">
@@ -295,34 +295,32 @@
                     <div class="row">
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="trafficAndSales?.genderMan?.length > 0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.men?.length > 0">
                                     <div class="legend-square on color-1"></div>
                                     <div class="legend-label">
                                         {{ ('others.men'| translate) + ' '}}
-                                        {{ trafficAndSales.genderMan[1].value }}%
+                                        {{ trafficAndSales.men[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="trafficAndSales?.genderMan"
-                                [name]="selectedType + 'gender-man'" [uniqueDimensionConf]="{color: '#67B6DC'}"
-                                category="name" iconType="man" [status]="trafficSalesReqStatus[1].reqStatus"
-                                height="280px">
+                            <app-chart-pictorial [data]="trafficAndSales?.men" [name]="selectedType + 'gender-man'"
+                                [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
+                                [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                             </app-chart-pictorial>
                         </div>
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="trafficAndSales?.genderWoman?.length > 0">
+                                <div class="legend-container" *ngIf="trafficAndSales?.women?.length > 0">
                                     <div class="legend-square on color-2"></div>
                                     <div class="legend-label">
                                         {{ ('others.women'| translate) + ' '}}
-                                        {{ trafficAndSales.genderWoman[1].value }}%
+                                        {{ trafficAndSales.women[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="trafficAndSales?.genderWoman"
-                                [name]="selectedType + 'gender-woman'" [uniqueDimensionConf]="{color: '#6794DC'}"
-                                category="name" iconType="woman" height="280px"
-                                [status]="trafficSalesReqStatus[1].reqStatus">
+                            <app-chart-pictorial [data]="trafficAndSales?.women" [name]="selectedType + 'gender-woman'"
+                                [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
+                                height="280px" [status]="trafficSalesReqStatus[1].reqStatus">
                             </app-chart-pictorial>
                         </div>
                     </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -246,30 +246,30 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.man?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.men?.length > 0">
                                         <div class="legend-square on color-1"></div>
                                         <div class="legend-label">
                                             {{ ('others.men'| translate) + ' '}}
-                                            {{ trafficAndSales.man[1].value }}%
+                                            {{ trafficAndSales.men[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.man" name="latam-gender-man"
+                                <app-chart-pictorial [data]="trafficAndSales?.men" name="latam-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
                                     [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.woman?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.women?.length > 0">
                                         <div class="legend-square on color-2"></div>
                                         <div class="legend-label">
                                             {{ ('others.women'| translate) + ' '}}
-                                            {{ trafficAndSales.woman[1].value }}%
+                                            {{ trafficAndSales.women[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.woman" name="latam-gender-woman"
+                                <app-chart-pictorial [data]="trafficAndSales?.women" name="latam-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
                                     height="280px" [status]="trafficSalesReqStatus[1].reqStatus">
                                 </app-chart-pictorial>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -204,27 +204,26 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.deviceDesktop?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.desktop?.length > 0">
                                         <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Desktop {{ trafficAndSales.deviceDesktop[1].value }}%
+                                        <div class="legend-label">Desktop {{ trafficAndSales.desktop[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.deviceDesktop"
-                                    name="latam-devices-desktop" [uniqueDimensionConf]="{color: '#67B6DC'}"
-                                    category="name" iconType="monitor" [status]="trafficSalesReqStatus[0].reqStatus"
-                                    height="280px">
+                                <app-chart-pictorial [data]="trafficAndSales?.desktop" name="latam-devices-desktop"
+                                    [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
+                                    [status]="trafficSalesReqStatus[0].reqStatus" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.deviceMobile?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.mobile?.length > 0">
                                         <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mobile {{ trafficAndSales.deviceMobile[1].value }}%
+                                        <div class="legend-label">Mobile {{ trafficAndSales.mobile[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.deviceMobile" name="latam-devices-mobile"
+                                <app-chart-pictorial [data]="trafficAndSales?.mobile" name="latam-devices-mobile"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
                                     height="280px" [status]="trafficSalesReqStatus[0].reqStatus">
                                 </app-chart-pictorial>
@@ -247,30 +246,30 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.genderMan?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.man?.length > 0">
                                         <div class="legend-square on color-1"></div>
                                         <div class="legend-label">
                                             {{ ('others.men'| translate) + ' '}}
-                                            {{ trafficAndSales.genderMan[1].value }}%
+                                            {{ trafficAndSales.man[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.genderMan" name="latam-gender-man"
+                                <app-chart-pictorial [data]="trafficAndSales?.man" name="latam-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
                                     [status]="trafficSalesReqStatus[1].reqStatus" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="trafficAndSales?.genderWoman?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficAndSales?.woman?.length > 0">
                                         <div class="legend-square on color-2"></div>
                                         <div class="legend-label">
                                             {{ ('others.women'| translate) + ' '}}
-                                            {{ trafficAndSales.genderWoman[1].value }}%
+                                            {{ trafficAndSales.woman[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="trafficAndSales?.genderWoman" name="latam-gender-woman"
+                                <app-chart-pictorial [data]="trafficAndSales?.woman" name="latam-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
                                     height="280px" [status]="trafficSalesReqStatus[1].reqStatus">
                                 </app-chart-pictorial>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -343,7 +343,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       this.kpis[0].metricTitle = this.translate.instant('kpis.investment');
       this.kpis[2].subMetricTitle = this.translate.instant('general.users');
       this.kpis[3].metricTitle = this.translate.instant('kpis.transactions');
-      this.kpis[3].metricTitle = this.translate.instant('kpis.transactions');
 
       this.topProductsColumns[0].title = this.translate.instant('general.ranking');
       this.topProductsColumns[1].title = this.translate.instant('general.product');
@@ -353,13 +352,13 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       this.usersAndSalesMetrics[1] = this.translate.instant('general.category').toLowerCase();
       this.usersAndSalesMetrics[2] = this.translate.instant('general.source').toLowerCase();
 
-      this.trafficAndSales['gender'] = this.trafficAndSales['gender']?.map(item => {
-        if (item.id === 1) {
-          return { ...item, name: this.translate.instant('others.women') }
-        } else if (item.id === 2) {
-          return { ...item, name: this.translate.instant('others.men') }
-        }
-      });
+      if (this.trafficAndSales['men']?.length > 0) {
+        this.trafficAndSales['men'][1].name = this.translate.instant('others.men');
+      }
+
+      if (this.trafficAndSales['women']?.length > 0) {
+        this.trafficAndSales['women'][1].name = this.translate.instant('others.women');
+      }
     });
   }
 
@@ -465,19 +464,15 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
           } else if (subMetricType === 'gender') {
             const { hombre, mujer }: any = disaggregatePictorialData('Hombre', 'Mujer', resp);
-            this.trafficAndSales = { ...this.trafficAndSales, man: hombre, woman: mujer };
+
+            hombre[1].name = this.translate.instant('others.men');
+            mujer[1].name = this.translate.instant('others.women');
+
+            this.trafficAndSales = { ...this.trafficAndSales, men: hombre, women: mujer };
 
           } else if (subMetricType === 'gender-and-age') {
             this.trafficAndSales['genderByAge'] = resp;
 
-            // } else if (subMetricType === 'gender') {
-            //   this.trafficAndSales['gender'] = resp.map(item => {
-            //     if (item.name.toLowerCase() == 'mujer') {
-            //       return { id: 1, name: this.translate.instant('others.women'), value: item.value }
-            //     } else if (item.name.toLowerCase() == 'hombre') {
-            //       return { id: 2, name: this.translate.instant('others.men'), value: item.value }
-            //     }
-            //   });
           } else {
             this.trafficAndSales[subMetricType] = resp;
           }

--- a/src/app/tools/functions/chart-data.ts
+++ b/src/app/tools/functions/chart-data.ts
@@ -3,26 +3,39 @@
  * @param metricName1 name property (value) to to distinguish the first metric
  * @param metricName2 name property (value) to to distinguish the second metric
  * @param dataRaw array with two metrics (objects)
+ * @param usePercentage by default returns value property in percentage otherwise use original value
  * @returns an object with 2 objetcs (disaggregated metric1 and metric2 data)
  */
-export function disaggregatePictorialData(metricName1: string, metricName2: string, dataRaw: any[]): {} {
+
+export function disaggregatePictorialData(metricName1: string, metricName2: string, dataRaw: any[], usePercentage: boolean = true): {} {
     let disMetric1;
     let disMetric2;
 
     const metric1 = dataRaw.find(item => item.name === metricName1);
     const metric2 = dataRaw.find(item => item.name === metricName2);
 
-    let devicePerc = getPercentageValues(metric1?.value, metric2?.value);
+    let value1: any;
+    let value2: any;
+
+    if (usePercentage) {
+        const percValues = getPercentageValues(metric1?.value, metric2?.value);
+        value1 = percValues.perc1;
+        value2 = percValues.perc2;
+    } else {
+        value1 = metric1.value.toFixed(2);
+        value2 = metric2.value.toFixed(2);
+    }
 
     if (metric1) {
         disMetric1 = [
             {
                 name: 'empty',
-                value: devicePerc.perc1 ? +(100 - (+devicePerc.perc1)).toFixed(2) : 100
+                value: value1 ? +(100 - (+value1)).toFixed(2) : 100
             },
             {
                 name: metricName1,
-                value: devicePerc.perc1 ? +devicePerc.perc1 : 0, rawValue: metric1.value
+                value: value1 ? +value1 : 0,
+                rawValue: usePercentage ? metric1.value.toFixed(2) : undefined
             },
         ];
     } else {
@@ -33,18 +46,17 @@ export function disaggregatePictorialData(metricName1: string, metricName2: stri
         disMetric2 = [
             {
                 name: 'empty',
-                value: devicePerc.perc2 ? +(100 - (+devicePerc.perc2)).toFixed(2) : 100
+                value: value2 ? +(100 - (+value2)).toFixed(2) : 100
             },
             {
                 name: metricName2,
-                value: devicePerc.perc2 ? +devicePerc.perc2 : 0, rawValue: metric2.value
+                value: value2 ? +value2 : 0,
+                rawValue: usePercentage ? metric2.value.toFixed(2) : undefined
             },
         ];
     } else {
         disMetric2 = [];
     }
-
-    console.log('res',)
 
     return {
         [metricName1.toLowerCase()]: disMetric1,

--- a/src/app/tools/functions/chart-data.ts
+++ b/src/app/tools/functions/chart-data.ts
@@ -1,0 +1,60 @@
+/**
+ * Disaggregates data to pictorial chart
+ * @param metricName1 name property (value) to to distinguish the first metric
+ * @param metricName2 name property (value) to to distinguish the second metric
+ * @param dataRaw array with two metrics (objects)
+ * @returns an object with 2 objetcs (disaggregated metric1 and metric2 data)
+ */
+export function disaggregatePictorialData(metricName1: string, metricName2: string, dataRaw: any[]): {} {
+    let disMetric1;
+    let disMetric2;
+
+    const metric1 = dataRaw.find(item => item.name === metricName1);
+    const metric2 = dataRaw.find(item => item.name === metricName2);
+
+    let devicePerc = getPercentageValues(metric1?.value, metric2?.value);
+
+    if (metric1) {
+        disMetric1 = [
+            {
+                name: 'empty',
+                value: devicePerc.perc1 ? +(100 - (+devicePerc.perc1)).toFixed(2) : 100
+            },
+            {
+                name: metricName1,
+                value: devicePerc.perc1 ? +devicePerc.perc1 : 0, rawValue: metric1.value
+            },
+        ];
+    } else {
+        disMetric1 = [];
+    }
+
+    if (metric2) {
+        disMetric2 = [
+            {
+                name: 'empty',
+                value: devicePerc.perc2 ? +(100 - (+devicePerc.perc2)).toFixed(2) : 100
+            },
+            {
+                name: metricName2,
+                value: devicePerc.perc2 ? +devicePerc.perc2 : 0, rawValue: metric2.value
+            },
+        ];
+    } else {
+        disMetric2 = [];
+    }
+
+    console.log('res',)
+
+    return {
+        [metricName1.toLowerCase()]: disMetric1,
+        [metricName2.toLowerCase()]: disMetric2
+    };
+}
+
+function getPercentageValues(value1: any, value2: any) {
+    let total = value1 + value2;
+    let perc1 = ((value1 * 100) / total).toFixed(2);
+    let perc2 = ((value2 * 100) / total).toFixed(2);
+    return { perc1, perc2 };
+}

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -115,7 +115,7 @@
         "otherPluralM": "outros",
         "otherPluralF": "outras",
         "only": "somente",
-        "men": "Hombres",
-        "women": "Mulheres"
+        "men": "Masculino",
+        "women": "Feminino"
     }
 }


### PR DESCRIPTION
# Problem Description
- For all pirctorial charts (which display devices and gender metrics) is necessary to disaggregate data to convert one chart in two charts using:
  - Desktop and Mobile charts to represent devices
  - Woman and Man charts to represent gener

# Features
- Add disaggregatePictorialData generic function in `/tools/functions/chart-data.ts` file
- Use disaggregatePictorialData in the following components:
   - latam-overview
   - overview-wrapper
   - adiences-wrapper
  
- Other implications:
   - Use decimalPipe in chart-pictorial component
   - Update translations for "women" and "men" copys in portuguese (`/i18n/pt.json` file)

# Where this change will be used
- In dashboard module in LATAM/Country/Retailer overview and Retailer> Campaign in retail> Audiences

# More details
![image](https://user-images.githubusercontent.com/38545126/122976764-59150800-d35a-11eb-9088-ccc0664c5786.png)
