### PR TITLE
fix responsive view in pages of auth module 

### DIFF
--- a/src/app/modules/auth/pages/create-access/create-access.component.html
+++ b/src/app/modules/auth/pages/create-access/create-access.component.html
@@ -1,4 +1,4 @@
-<div class="container pb-4 pt-5 pb-md-7 pt-md-9">
+<div class="container">
   <div class="row justify-content-start">
     <div class="col-lg-5 col-md-7">
       <div class="card shadow border-0">

--- a/src/app/modules/auth/pages/create-access/create-access.component.scss
+++ b/src/app/modules/auth/pages/create-access/create-access.component.scss
@@ -1,3 +1,19 @@
-.logo-container img {
-    width: 80px;
+.container {
+    height: 100%;
+    min-height: 100vh;
+
+    @media screen and (max-height: 690px) {
+        margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .justify-content-start {
+        align-items: center;
+        height: 100%;
+        min-height: 100vh;
+    }
+
+    .logo-container img {
+        width: 80px;
+    }
 }

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.html
@@ -1,4 +1,4 @@
-<div class="container pb-4 pt-5 pb-md-7 pt-md-9">
+<div class="container">
   <div class="row justify-content-start">
     <div class="col-lg-5 col-md-7">
       <div class="card shadow border-0">

--- a/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.scss
+++ b/src/app/modules/auth/pages/forgot-psw/forgot-psw.component.scss
@@ -1,3 +1,19 @@
-.logo-container img {
-    width: 80px;
+.container {
+    height: 100%;
+    min-height: 100vh;
+
+    @media screen and (max-height: 690px) {
+        margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .justify-content-start {
+        align-items: center;
+        height: 100%;
+        min-height: 100vh;
+    }
+
+    .logo-container img {
+        width: 80px;
+    }
 }

--- a/src/app/modules/auth/pages/login/login.component.html
+++ b/src/app/modules/auth/pages/login/login.component.html
@@ -1,4 +1,4 @@
-<div class="container pb-4 pt-5 pb-md-7 pt-md-9">
+<div class="container">
   <div class="row justify-content-start">
     <div class="col-lg-5 col-md-7">
       <div class="card shadow border-0">

--- a/src/app/modules/auth/pages/login/login.component.scss
+++ b/src/app/modules/auth/pages/login/login.component.scss
@@ -1,3 +1,19 @@
+.container {
+    height: 100%;
+    min-height: 100vh;
+
+    @media screen and (max-height: 690px) {
+        margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .justify-content-start {
+        align-items: center;
+        height: 100%;
+        min-height: 100vh;
+    }
+}
+
 .input-group-text {
     cursor: pointer;
 }

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.html
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.html
@@ -1,4 +1,4 @@
-<div class="container pb-4 pt-5 pb-md-7 pt-md-9">
+<div class="container">
   <div class="row justify-content-start">
     <div class="col-lg-5 col-md-7">
       <div class="card shadow border-0">

--- a/src/app/modules/auth/pages/reset-psw/reset-psw.component.scss
+++ b/src/app/modules/auth/pages/reset-psw/reset-psw.component.scss
@@ -1,3 +1,19 @@
-.logo-container img {
-    width: 80px;
+.container {
+    height: 100%;
+    min-height: 100vh;
+
+    @media screen and (max-height: 690px) {
+        margin-bottom: 1.5rem;
+        margin-top: 1.5rem;
+    }
+
+    .justify-content-start {
+        align-items: center;
+        height: 100%;
+        min-height: 100vh;
+    }
+
+    .logo-container img {
+        width: 80px;
+    }
 }


### PR DESCRIPTION
# Problem Description
- For divices with large width and short height the responsive view isn't the better, so it's necessary improve it for all pages in auth module

# Bug Fixes
- Update styles in the following components:
  - create-access
  - login
  - forgot-psw
  - reset-psw

# Where this change will be used
- In auth module at `/create-access` `/login` `/forgot-password` and `/reset-password` pages paths

# More details
- Login before changes:
![image](https://user-images.githubusercontent.com/38545126/123172149-52fa5680-d442-11eb-9036-b9075c394e03.png)

- Login after changes:
![image](https://user-images.githubusercontent.com/38545126/123172377-b08ea300-d442-11eb-9981-474189e9be0f.png)
