### PR TITLE
update applyFilters method in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -767,11 +767,11 @@ export class GeneralFiltersComponent implements OnInit {
     this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
     this.filtersStateService.selectSectors(this.sectors.value.filter(item => item.id));
     this.filtersStateService.selectCategories(this.categories.value.filter(item => item.id));
+    this.filtersStateService.selectSources(this.sources.value.filter(item => item.id));
 
     if (this.isLatamSelected) {
       this.filtersStateService.selectCountries(this.countries.value.filter(item => item.id));
       this.filtersStateService.selectRetailers(this.retailers.value.filter(item => item.id));
-      this.filtersStateService.selectSources(this.sources.value.filter(item => item.id));
     }
 
     const areAllCampsSelected = this.areAllCampaignsSelected();


### PR DESCRIPTION
# Problem Description
- After last changes for charts using sources as query params in overview component it's necessary to save the value of the selection regardless of whether or not it is the latam view

# Bug Fixes
- Update applyFilters method in general-filters component

# Where this change will be used
- In dashboard module pages
