### PR TITLE
update generic-table component to use maxWidthColumn property in TableItem interface

### DIFF
--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -31,8 +31,7 @@ export class AcquisitionWrapperComponent implements OnInit, OnDestroy {
       name: 'campaign',
       title: 'Campaña',
       tooltip: true,
-      maxWidthTdPercentage: 15,
-      maxWidthSpan: '250px',
+      maxWidthColumn: 15
     },
     {
       name: 'users',

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
@@ -39,8 +39,7 @@ export class CampaignTowardsRetailWrapperComponent implements OnInit, OnDestroy 
     {
       name: 'name',
       title: 'Nombre',
-      maxWidthTdPercentage: 40,
-      maxWidthSpan: '700px',
+      maxWidthColumn: 35,
       tooltip: true,
     },
     {

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -53,8 +53,7 @@ export class ConversionWrapperComponent implements OnInit {
       name: 'product',
       title: 'Producto',
       tooltip: true,
-      maxWidthTdPercentage: 25,
-      maxWidthSpan: '400px',
+      maxWidthColumn: 25
     },
     {
       name: 'amount',

--- a/src/app/modules/dashboard/components/generic-table/generic-table.component.html
+++ b/src/app/modules/dashboard/components/generic-table/generic-table.component.html
@@ -10,8 +10,7 @@
                     {{ column.title }}
                 </th>
 
-                <td mat-cell *matCellDef="let element"
-                    [style.width.%]="column.maxWidthTdPercentage && column.maxWidthTdPercentage"
+                <td mat-cell *matCellDef="let element" [style.width.vw]="column.maxWidthColumn && column.maxWidthColumn"
                     [style.text-align]="column.textAlign ? column.textAlign : 'left'">
                     <!-- with empty line -->
                     <span *ngIf="column.emptyLine && !element[column.name]">-</span>
@@ -21,8 +20,8 @@
                         md-raised-button [matTooltip]="element[column.name]" matTooltipPosition="below"
                         matTooltipClass="custom-tooltip" [ngClass]="{'value-container' : column.comparativeName}">
 
-                        <div [ngSwitch]="column.formatValue" [ngClass]="{'lg-container': column.maxWidthTdPercentage}"
-                            [style.width]="column.maxWidthSpan" [style.max-width]="column.maxWidthSpan">
+                        <div [ngSwitch]="column.formatValue" [ngClass]="{'lg-container': column.maxWidthColumn}"
+                            [style.width.vw]="column.maxWidthColumn" [style.max-width.vw]="column.maxWidthColumn">
                             <span *ngSwitchCase="'currency'">
                                 {{ element[column.name] | currency:'USD':'symbol-narrow':'1.2-2' }}
                             </span>

--- a/src/app/modules/dashboard/components/generic-table/generic-table.component.ts
+++ b/src/app/modules/dashboard/components/generic-table/generic-table.component.ts
@@ -105,8 +105,7 @@ export interface TableItem {
   comparativeName?: string, // to compare "name" object property and show arrows with colors
   comparativeOrder?: string, // originalOverComparative | comparativeOverOriginal
   comparativeLowIsBetter?: boolean // to show arrow up or down
-  maxWidthTdPercentage?: number, //max-width in % property for column (td)
-  maxWidthSpan?: string, // valid css max-width property for text inside column (td > span)
+  maxWidthColumn?: number, //max-width (in vw) property for column (td)
   tooltip?: boolean, // to show tooltip in hover
   emptyLine?: boolean // to show a "-" when there isn't data
 }


### PR DESCRIPTION
# Problem Description
- After a request to remove horizontal scrollbar displayed in tables (for devices with 1530px as total view width), the properties were restated of TableItem interface in order to make the component more understandable

# Features
- Replace maxWidthTdPercentage and maxWidthSpan by maxWidthColumn property in TableItem interface
- Use this property in generic-table component to define max-width-vw property of columns
- Update maxWidthProperty where TableItem interface is used

# Where this change will be used
- Where generic-table component and maxWidthColumn porperty will be used

# More details
- Example of table before:
![image](https://user-images.githubusercontent.com/38545126/123338990-658e9180-d50f-11eb-94ea-b88af3daec58.png)

- Example of table after:
![image](https://user-images.githubusercontent.com/38545126/123339041-7b03bb80-d50f-11eb-957c-f26690334abc.png)

