### PR TITLE
handle kpis request errors in dashboard module

### DIFF
--- a/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
-import { Observable, Subject, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
 import { FiltersStateService } from '../../services/filters-state.service';
 
@@ -162,6 +162,7 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
         this.kpisReqStatus = 2;
       },
       error => {
+        this.clearStats(this.kpis);
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[campaign-in-retail.component]: ${errorMsg}`);
         this.kpisReqStatus = 3;
@@ -185,6 +186,7 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
         this.roasReqStatus = 2;
       },
       error => {
+        this.clearStats(this.roasBySector);
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[campaign-in-retail.component]: ${errorMsg}`);
         this.roasReqStatus = 3;
@@ -193,6 +195,16 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
 
   panelChange(panel, value) {
     this.extPanelIsOpen[panel] = value;
+  }
+
+  clearStats(stats) {
+    for (let stat of stats) {
+      stat.metricValue = 0;
+
+      if (stat.subMetricValue) {
+        stat.subMetricValue = 0;
+      }
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -145,6 +145,7 @@ export class ConversionWrapperComponent implements OnInit {
         this.kpisReqStatus = 2;
       },
       error => {
+        this.clearKpis();
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[conversion-wrapper.component]: ${errorMsg}`);
         this.kpisReqStatus = 3;
@@ -184,6 +185,12 @@ export class ConversionWrapperComponent implements OnInit {
       });
 
     this.selectedTab = metricType === 'conversions-vs-users' ? 1 : 2
+  }
+
+  clearKpis() {
+    for (let kpi of this.kpis) {
+      kpi.metricValue = 0;
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -235,6 +235,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         this.kpisReqStatus = 2;
       },
       error => {
+        this.clearKpis();
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-wrapper.component]: ${errorMsg}`);
         this.kpisReqStatus = 3;
@@ -336,6 +337,16 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     this.selectedSectorTab && delete this.selectedSectorTab;
     this.selectedCategoryTab && delete this.selectedCategoryTab;
     this.selectedSourceTab && delete this.selectedSourceTab;
+  }
+
+  clearKpis() {
+    for (let kpi of this.kpis) {
+      kpi.metricValue = 0;
+
+      if (kpi.subMetricValue) {
+        kpi.subMetricValue = 0;
+      }
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -261,6 +261,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         this.kpisReqStatus = 2;
       },
       error => {
+        this.clearKpis();
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-latam.component]: ${errorMsg}`);
         this.kpisReqStatus = 3;
@@ -380,6 +381,16 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     this.selectedSectorTab && delete this.selectedSectorTab;
     this.selectedCategoryTab1 && delete this.selectedCategoryTab1;
     this.selectedSourceTab && delete this.selectedSourceTab;
+  }
+
+  clearKpis() {
+    for (let kpi of this.kpis) {
+      kpi.metricValue = 0;
+
+      if (kpi.subMetricValue) {
+        kpi.subMetricValue = 0;
+      }
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
# Problem Description
- After a wrong response of the request to the API is necessary to clear all kpis values, because could be possible that they display data of the request prior to the one that generated the error

# Features
- Add clearKpis method in the following component after a wrong response of the request:
   - overview-latam
   - overview-wrapper
   - campaign-in-retail-wrapper
   - conversion-wrapper

# Where this change will be used
- Where kpis cards will be displayed in dashboard module

# More details
![image](https://user-images.githubusercontent.com/38545126/123851107-714bd080-d8e0-11eb-8e4f-05e8e0fae71e.png)

