### PR TITLE
remove countrySub subscription from retailer component

### DIFF
--- a/src/app/modules/dashboard/pages/retailer/retailer.component.ts
+++ b/src/app/modules/dashboard/pages/retailer/retailer.component.ts
@@ -18,7 +18,6 @@ export class RetailerComponent implements OnInit, OnDestroy {
   activeTabView: number = 1;
 
   retailerID: number;
-  countryID: number;
 
   googleMyBusiness: boolean;
 
@@ -45,10 +44,6 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
       this.requestInfoSource.next(manualChange);
-    });
-
-    this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
-      this.countryID = country?.id
     });
 
     this.retailerSub = this.appStateService.selectedRetailer$.subscribe(retailer => {
@@ -80,7 +75,6 @@ export class RetailerComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.retailerSub?.unsubscribe();
-    this.countrySub?.unsubscribe();
     this.filtersSub?.unsubscribe();
   }
 }


### PR DESCRIPTION
# Problem Description
- After change the logic to decide when "Google My Business" tab will be displayed (based on retailerID instead of countryID) is no longer necessary use a country subscription in retailer component

# Features
- Remove countrySub subscription and countryID variable from retailer component

# Where this change will be used
- In retailer page at `/dashboard/retailer`
