### PR TITLE
hide categories filter in pc selector section

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -179,7 +179,8 @@
         </div>
 
         <!-- category -->
-        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
+        <div [hidden]="hideCategories" class="col-12 col-sm-6 mb-4"
+            [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
             <span class="mb-1 h4">{{ 'general.category' | translate }}</span>
             <mat-select formControlName="categories" multiple [placeholder]="'filters.categoryPh' | translate"
                 disableOptionCentering>

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -67,6 +67,8 @@ export class GeneralFiltersComponent implements OnInit {
   filteredCampaign: boolean; // flag to know is campaignsList is the result of a search filter
   campaignFilter: string; // filtered value in campaignsList
 
+  hideCategories: boolean;
+
   countryID: number;
   retailerID: number;
   isLatamSelected: boolean;
@@ -85,6 +87,7 @@ export class GeneralFiltersComponent implements OnInit {
   countrySub: Subscription;
   retailerSub: Subscription;
   routeSub: Subscription;
+  hideCategorySub: Subscription;
 
   prevCountries: any[];
   prevRetailers: any[];
@@ -177,6 +180,11 @@ export class GeneralFiltersComponent implements OnInit {
 
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
       this.countryID = country?.id;
+    });
+
+    // catch if categories filter have to be hide
+    this.hideCategorySub = this.filtersStateService.hideCategories$.subscribe(value => {
+      this.hideCategories = value;
     });
   }
 
@@ -809,5 +817,6 @@ export class GeneralFiltersComponent implements OnInit {
     this.routeSub?.unsubscribe();
     this.countrySub?.unsubscribe();
     this.retailerSub?.unsubscribe();
+    this.hideCategorySub?.unsubscribe();
   }
 }

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -340,7 +340,6 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
           }
         });
 
-        console.log('bouncesExitsAndPv', this.bouncesExitsAndPv)
         this.bouncesExitsAndPvReqStatus = 2;
       },
       error => {

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -1,17 +1,20 @@
 <div class="main-container mt-4">
     <ul class="nav nav-tabs mb-4">
         <li class="nav-item">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}" (click)="activeTabView = 1">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}"
+                (click)="emitSelectedSection('indexed')">
                 <span class="h2 py-2 ml-3 mr-3">Indexado</span>
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}" (click)="activeTabView = 2">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}"
+                (click)="emitSelectedSection('omnichat')">
                 <span class="h2 py-2 ml-3 mr-3">OmniChat</span>
             </a>
         </li>
         <li class="nav-item" *ngIf="levelPage.latam || (countryID === 9 && !retailerID) || retailerID === 29">
-            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}" (click)="activeTabView = 3">
+            <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}"
+                (click)="emitSelectedSection('pc-selector')">
                 <span class="h2 py-2 ml-3 mr-3">PC Selector</span>
             </a>
         </li>

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -54,7 +54,7 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
       this.getActiveView();
     }
 
-    // catch if its LATAM view
+    // catch if the route changes
     this.routeSub = this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(event => {
       if (event instanceof NavigationEnd) {
         this.filtersStateService.restoreFilters();
@@ -69,7 +69,9 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
       if (country?.id !== this.countryID) {
         this.countryID = country?.id;
         this.getActiveView();
+
         this.activeTabView = 1;
+        this.emitSelectedSection('indexed');
       }
     });
 
@@ -78,7 +80,9 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
       if (retailer?.id !== this.retailerID) {
         this.retailerID = retailer?.id;
         this.getActiveView();
+
         this.activeTabView = 1;
+        this.emitSelectedSection('indexed');
       }
     });
 
@@ -122,7 +126,28 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
     }
   }
 
+  emitSelectedSection(section: string) {
+    switch (section) {
+      case 'indexed':
+        this.activeTabView = 1;
+        this.filtersStateService.hideCategories(false);
+        break;
+
+      case 'omnichat':
+        this.activeTabView = 2;
+        this.filtersStateService.hideCategories(false);
+        break;
+
+      case 'pc-selector':
+        this.activeTabView = 3;
+        this.filtersStateService.hideCategories(true);
+        break;
+    }
+  }
+
   ngOnDestroy() {
+    this.filtersStateService.hideCategories(false);
+
     this.routeSub?.unsubscribe();
     this.countrySub?.unsubscribe();
     this.retailerSub?.unsubscribe();

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -70,7 +70,6 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
         this.countryID = country?.id;
         this.getActiveView();
 
-        this.activeTabView = 1;
         this.emitSelectedSection('indexed');
       }
     });
@@ -81,7 +80,6 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
         this.retailerID = retailer?.id;
         this.getActiveView();
 
-        this.activeTabView = 1;
         this.emitSelectedSection('indexed');
       }
     });

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -42,6 +42,8 @@ export class FiltersStateService {
   // selected categories
   private categoriesSource = new Subject<any[]>();
   categories$ = this.categoriesSource.asObservable();
+  private hideCategoriesSource = new Subject<boolean>(); // only used in other-tools component
+  hideCategories$ = this.hideCategoriesSource.asObservable();
   categories: any[];
   categoriesInitial: any[];
   categoriesQParams;
@@ -141,6 +143,10 @@ export class FiltersStateService {
   selectRetailAudiences(audiences: any[]) {
     this.retailAudiencesSource.next(audiences);
     this.retailAudiences = audiences;
+  }
+
+  hideCategories(value) {
+    this.hideCategoriesSource.next(value);
   }
 
   convertFiltersToQueryParams() {


### PR DESCRIPTION
# Problem Description
- Because Other tools > PC Selector section only displays data from the PC category is necessary to hide categories filter

# Features
- Add hideCategory observable and method in general-filters service
- Use hideCategories method in other-tools component
- Add hideCategorySub subscription in general-filters component

# Bug Fixes
- Remove log line in indexed-wrapper component

# Where this change will be used
- In dashboard filters when the user is in LATAM/Country/Retailer > Other tools > PC Selector section at `/dashboard/tools` path

# More details
![image](https://user-images.githubusercontent.com/38545126/123866195-61d58300-d8f2-11eb-96c1-87bf5ca9a43c.png)
