### PR TITLE
update 'remember me' functionality in login component 

### DIFF
--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -69,20 +69,16 @@ export class LoginComponent implements OnInit {
     this.remember_password = this.form.controls['remember_password'];
 
     this.getSavedUserData();
-    if (this.usermail) {
-      this.email.setValue(this.usermail);
-    }
   }
 
   getSavedUserData() {
-    const un = !!localStorage.getItem('username')
-      ? localStorage.getItem('username')
-      : '';
-    this.username = un === 'null' ? '' : un;
-    const um = !!localStorage.getItem('usermail')
-      ? localStorage.getItem('usermail')
-      : '';
-    this.usermail = um === 'null' ? '' : um;
+    const savedUser = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'));
+
+    if (savedUser) {
+      this.email.setValue(savedUser.email);
+      this.password.setValue(savedUser.secret_key);
+      this.remember_password.setValue(true);
+    }
   }
 
   login(email: string, password: string) {
@@ -120,9 +116,11 @@ export class LoginComponent implements OnInit {
   rememberPsw() {
     const user = {
       email: this.email.value,
-      // anonymous_id: this.userService.hashPsw(this.password.value)
-      anonymous_id: this.password.value
+      // secret_key: this.userService.hashPsw(this.password.value)
+      secret_key: this.password.value,
+      create_at: new Date().getTime()
     }
+
     this.cookieService.set('coop_user', JSON.stringify(user), 365);
   }
 

--- a/src/app/services/interceptor.service.ts
+++ b/src/app/services/interceptor.service.ts
@@ -1,10 +1,7 @@
 import { HttpErrorResponse, HttpEvent, HttpHandler, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
-import { FiltersStateService } from '../modules/dashboard/services/filters-state.service';
 import { UserService } from './user.service';
 
 @Injectable({
@@ -12,10 +9,7 @@ import { UserService } from './user.service';
 })
 export class SessionInterceptor {
   constructor(
-    private userService: UserService,
-    private cookieService: CookieService,
-    private router: Router,
-    private filtersStateService: FiltersStateService
+    private userService: UserService
   ) { }
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
@@ -29,37 +23,10 @@ export class SessionInterceptor {
     return next.handle(request).pipe(
       tap(() => { },
         err => {
-          if (err instanceof HttpErrorResponse) {
-            if (err.status === 401) {
-
-              const savedUser = this.cookieService.get('coop_user') && JSON.parse(this.cookieService.get('coop_user'));
-              const currentUsermail = localStorage.getItem('usermail');
-
-              if (savedUser.email === currentUsermail) {
-                this.generatePersistSession(savedUser.email, savedUser.anonymous_id);
-              } else {
-                this.userService.logout();
-              }
-            }
+          if (err instanceof HttpErrorResponse && err.status === 401) {
+            this.userService.logout();
           }
         })
     );
-  }
-
-  generatePersistSession(email: string, password: string) {
-    this.userService.login(email, password).subscribe(
-      () => {
-
-        this.router.navigate(['/dashboard/home']);
-
-        // default redirection deprecated
-        // this.userService.redirectToDefaultPage();
-      },
-      error => {
-        this.userService.logout();
-        this.router.navigate(['/login']);
-        console.error(`[interceptor.service]: ${error?.error?.message ? error.error.message : error?.message}`);
-      }
-    )
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -230,7 +230,7 @@ export class UserService {
   cleanUserData() {
     this._loggedIn = false;
     this._user = new User();
-    this.router.navigate(["/"]);
+    this.router.navigate(['/login']);
 
     const savedLang = localStorage.getItem('lang') || 'es';
     window.localStorage.clear();


### PR DESCRIPTION
# Problem Description
- After define a daily expiration token, the 'remeber me' functionality in login have to change. Instead of generate a persistent user session defined in interceptor service when the API responses a 401 status code is necessary logout to the user and only fill user, email and remember me fields in login component.

# Features
- Update properties of coop_user cookie
- Use cookie (if exists) to fill fields in login component
- Remove persistent session functionality from interceptor service
- Update redirection of cleanUserData method in user service

# Where this change will be used
- In login component at `/login` path

# More details
![image](https://user-images.githubusercontent.com/38545126/124032070-b72a9680-d9bd-11eb-8081-1fdc8fcf6426.png)
