### PR TITLE
add sticky property to general filters in dashboard component

### DIFF
--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -1,9 +1,13 @@
-<div class="container-fluid mt-4">
-    <div class="row" [hidden]="!title">
-        <div class="col-12">
-            <p class="h2 mb-5 text-xl">{{ title }}</p>
-        </div>
+<div class="dashboard-container mt-4">
+    <div class="container-fluid-lg" [hidden]="!title">
+        <p class="h2 text-xl">{{ title }}</p>
     </div>
-    <app-general-filters></app-general-filters>
-    <router-outlet></router-outlet>
+    <div class="filters-container container-fluid-lg">
+        <app-general-filters></app-general-filters>
+        <hr class="mt-3 mb-5">
+    </div>
+
+    <div class="container-fluid">
+        <router-outlet></router-outlet>
+    </div>
 </div>

--- a/src/app/modules/dashboard/dashboard.component.scss
+++ b/src/app/modules/dashboard/dashboard.component.scss
@@ -1,0 +1,29 @@
+.dashboard-container {
+    position: relative;
+
+    .container-fluid-lg {
+        padding-left: 10px;
+        padding-right: 10px;
+        margin-left: auto;
+        margin-right: auto;
+        width: calc(100% - 58px);
+
+        @media screen and (max-width: 767px){
+            width: calc(100% - 10px);   
+        }
+    }
+
+    .filters-container {
+        @media screen and (min-width: 575px) {
+            background: #F8F9FE;
+            padding-top: 36px;
+            position: sticky;
+            top: 50px;
+            z-index: 100;   
+        }
+    
+        hr {
+            border-top: 1px solid rgba(0, 0, 0, 0.05) !important;
+        }
+    }    
+}


### PR DESCRIPTION
# Problem Description
- In order to improve UX is necessary add sticky position css property to general filters in this way, even if the filters are scrolled, they remain at the top of the screen.

# Features
- Update content distribution of dashboard component template
- Add scss styles to apply sticky position property only for tablet and desktop view

# Where this change will be used
- In dashboard module at `/dashboard` path

# More details
![image](https://user-images.githubusercontent.com/38545126/124042765-31174b80-d9cf-11eb-890d-35fea909ef8b.png)
