### PR TITLE
homologate copys in other tools components

### DIFF
--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -45,7 +45,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         metricFormat: 'percentage'
       },
       {
-        metricTitle: 'mediana de duración',
+        metricTitle: 'duración media de la sesión',
         metricName: 'median_chat_duration',
         metricValue: '00:00:00',
       },
@@ -76,7 +76,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         metricFormat: 'integer',
       },
       {
-        metricTitle: 'conversion rate',
+        metricTitle: 'tasa de conversión',
         metricName: 'conversion_rate',
         metricValue: 0,
         metricFormat: 'percentage',

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -45,7 +45,7 @@ export class PcSelectorWrapperComponent implements OnInit {
       iconBg: '#f89934'
     },
     {
-      metricTitle: 'conversion rate',
+      metricTitle: 'tasa de conversión',
       metricName: 'conversion_rate',
       metricValue: 2.35,
       metricFormat: 'percentage',


### PR DESCRIPTION
# Problem Description
- Is necessary to homologate 'Tasa de conversión' y 'Duración media de la sesión' copys

# Features
- Homologate copys in other tools components in the following components:
  - omnichat-wrapper
  - pc-selector-wrapper

# Where this change will be used
- In LATAM/Country/Retailer > Other tools at `/dashboard/tools` path
