### PR TITLE
show countries grouped by regions in invite-user component

### DIFF
--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -153,7 +153,8 @@
                                                         <!-- item (country or region) -->
                                                         <ng-container>
                                                             <input type="checkbox" class="custom-control-input"
-                                                                [formControlName]="i" [id]="'item-custom-checkbox-'+i">
+                                                                [formControlName]="i" [id]="'item-custom-checkbox-'+i"
+                                                                (change)="countriesInRegionChange(item, $event.target.checked)">
                                                             <label class="custom-control-label"
                                                                 [for]="'item-custom-checkbox-'+i">
                                                                 <span class="text-muted">{{ item.name }}</span>
@@ -165,7 +166,9 @@
                                                             <div class="submenu"
                                                                 *ngFor="let subItem of item.countries; let j = index">
                                                                 <input type="checkbox" class="custom-control-input"
-                                                                    [id]="i+'-subitem-custom-checkbox-'+j">
+                                                                    [id]="i+'-subitem-custom-checkbox-'+j"
+                                                                    [checked]="subItem.selected"
+                                                                    (change)="regionChange(i, subItem, $event.target.checked)">
                                                                 <label class="custom-control-label"
                                                                     [for]="i+'-subitem-custom-checkbox-'+j">
                                                                     <span class="text-muted">{{ subItem.name }}</span>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.html
@@ -146,16 +146,32 @@
                                             </div>
 
                                             <div class="options-container">
-                                                <ng-container *ngFor="let country of countries; let i = index"
+                                                <ng-container *ngFor="let item of countries; let i = index"
                                                     formArrayName="countries">
-                                                    <div [hidden]="country.hidden"
+                                                    <div [hidden]="item.hidden"
                                                         class="custom-control custom-control-alternative custom-checkbox my-1">
-                                                        <input type="checkbox" class="custom-control-input"
-                                                            [formControlName]="i" [id]="'country-custom-checkbox-'+i">
-                                                        <label class="custom-control-label"
-                                                            [for]="'country-custom-checkbox-'+i">
-                                                            <span class="text-muted">{{ country.name }}</span>
-                                                        </label>
+                                                        <!-- item (country or region) -->
+                                                        <ng-container>
+                                                            <input type="checkbox" class="custom-control-input"
+                                                                [formControlName]="i" [id]="'item-custom-checkbox-'+i">
+                                                            <label class="custom-control-label"
+                                                                [for]="'item-custom-checkbox-'+i">
+                                                                <span class="text-muted">{{ item.name }}</span>
+                                                            </label>
+                                                        </ng-container>
+
+                                                        <!-- subitem (country within a region)-->
+                                                        <div class="submenu-container" *ngIf="item?.countries">
+                                                            <div class="submenu"
+                                                                *ngFor="let subItem of item.countries; let j = index">
+                                                                <input type="checkbox" class="custom-control-input"
+                                                                    [id]="i+'-subitem-custom-checkbox-'+j">
+                                                                <label class="custom-control-label"
+                                                                    [for]="i+'-subitem-custom-checkbox-'+j">
+                                                                    <span class="text-muted">{{ subItem.name }}</span>
+                                                                </label>
+                                                            </div>
+                                                        </div>
                                                     </div>
                                                 </ng-container>
                                             </div>

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.scss
@@ -54,3 +54,18 @@
         padding: 0.525rem 0.75rem;
     }
 }
+
+.submenu-container {
+    margin-bottom: 12px;
+    margin-top: 12px;
+   
+    .submenu {
+        margin-left: 2rem;
+    }
+    
+    .custom-control-label {
+        &::before, &::after {
+            left: -2rem !important;
+        }
+    }
+}

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -339,16 +339,35 @@ export class InviteUserComponent implements OnInit {
   convertToValue(key: string, entityType: string): Permission[] {
     const permissions: Permission[] = [];
     this.form.value[key].forEach((x, i) => {
+
       if (x && this[key][i]) {
-        const permission = {
-          role_id: this.selectedRole.id,
-          entity_type: entityType,
-          entity_id: this[key][i].id
+        // for countries, retailers, sectors and categories
+        if (this[key][i].id) {
+          const permission = {
+            role_id: this.selectedRole.id,
+            entity_type: entityType,
+            entity_id: this[key][i].id
+          }
+          permissions.push(permission);
+
+        } else if (this[key][i].countries) {
+
+          // for countries grouped in regions
+          for (let item of this[key][i].countries) {
+            const permission = {
+              role_id: this.selectedRole.id,
+              entity_type: entityType,
+              entity_id: item.id
+            }
+            permissions.push(permission);
+          }
+
+          // falta un caso
+          // cuando no se tiene seleccionada la region pero si algunos paises dentro de la region 
+          // hacer un barrido para concatenarlos todos a la peticion
         }
-        permissions.push(permission);
       }
     });
-
     return permissions;
   }
 
@@ -413,12 +432,14 @@ export class InviteUserComponent implements OnInit {
     permissions = [...permissions, ...this.convertToValue('sectors', 'sector')];
     permissions = [...permissions, ...this.convertToValue('categories', 'category')];
 
+    console.log('FINAL permissions', permissions)
+
     const invite: Invite = {
       email: this.form.value.email,
       permissions
     }
 
-    this.sendInviteToUser(invite);
+    // this.sendInviteToUser(invite);
   }
 
   sendInviteToUser(invite) {

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -169,6 +169,7 @@ export class InviteUserComponent implements OnInit {
       const region = (regions[item.region] || []);
       region.push(item);
       regions[item.region] = region;
+      regions.selected = false;
       return regions;
     }, {});
 
@@ -316,6 +317,19 @@ export class InviteUserComponent implements OnInit {
       this.form.controls[formSuboption].reset();
       formOption.allOptSelected = false;
     }
+
+    if (formSuboption === 'countries') {
+      for (let item of this.countries) {
+
+        if (!item.countries) {
+          continue;
+        }
+
+        item.countries = item.countries.map(subitem => {
+          return { ...subitem, selected: selectAllOptions }
+        });
+      }
+    }
   }
 
   allOptionsSelected(formSuboption) {
@@ -341,10 +355,40 @@ export class InviteUserComponent implements OnInit {
   filterFromList(listName: string, value: string) {
     this[listName].forEach(element => {
       element.hidden && delete element.hidden;
-      if (!element.name.toLowerCase().includes(value.toLowerCase())) {
+      if (!element.countries && !element.name.toLowerCase().includes(value.toLowerCase())) {
+        element.hidden = true;
+
+      } else if (element.countries && !element.countries.some(item => item.name.toLowerCase().includes(value.toLowerCase()))) {
         element.hidden = true;
       }
     });
+  }
+
+  countriesInRegionChange(selectedItem, selected) {
+    if (!selectedItem.countries) {
+      return;
+    }
+
+    selectedItem.countries = selectedItem.countries.map(subitem => {
+      return { ...subitem, selected };
+    });
+  }
+
+  regionChange(regionIndex, selectedItem, selected) {
+    selectedItem.selected = selected;
+
+    const countriesInRegion = this.countries.find(item => item.name === selectedItem.region)?.countries;
+    const selectedCountries = countriesInRegion.filter(item => item.selected);
+
+    const countriesFormList = this.form.controls['countries'].value;
+
+    if (countriesInRegion.length === selectedCountries.length) {
+      countriesFormList[regionIndex] = true;
+    } else {
+      countriesFormList[regionIndex] = "";
+    }
+
+    this.form.controls['countries'].patchValue(countriesFormList);
   }
 
   onSubmit() {

--- a/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
+++ b/src/app/modules/users-mngmt/pages/invite-user/invite-user.component.ts
@@ -92,8 +92,23 @@ export class InviteUserComponent implements OnInit {
   getCountries() {
     return this.usersMngmtService.getCountries()
       .toPromise()
-      .then((resp: any[]) => {
-        this.countries = resp;
+      .then((countries: any[]) => {
+        const countriesWithoutRegion = countries.filter(c => !c.region);
+        const countriesWithRegion = countries.filter(c => c.region);
+
+        const regionsList = [];
+        const { regionsNames, regions } = this.groupCountriesByRegion(countriesWithRegion);
+
+        for (let region of regionsNames) {
+          regionsList.push({
+            name: region,
+            countries: regions[region]
+          });
+        }
+
+        if (regionsNames.length > 0) {
+          this.countries = [...countriesWithoutRegion, ...regionsList].sort((a, b) => (a.name < b.name ? -1 : 1));
+        }
       })
       .catch((error) => {
         console.error(`[invite-user.component]: ${error}`);
@@ -141,6 +156,26 @@ export class InviteUserComponent implements OnInit {
         console.error(`[invite-user.component]: ${error}`);
         throw (new Error());
       });
+  }
+
+  groupCountriesByRegion(countries) {
+    const regionsNames = [];
+    const regions = countries.reduce((regions, item) => {
+
+      if (!regionsNames.includes(item.region)) {
+        regionsNames.push(item.region);
+      }
+
+      const region = (regions[item.region] || []);
+      region.push(item);
+      regions[item.region] = region;
+      return regions;
+    }, {});
+
+    return {
+      regionsNames,
+      regions
+    }
   }
 
   roleChange() {


### PR DESCRIPTION
# Problem Description
- Is necessary show countries grouped by region when an invitation is sending with country role
- These countries also have to be selectable (in order to selected all region or only some countries in the region) 

# Features
- Show countries grouped by region
- Implement selection and filtering of regions
- Reset regions subitems 
- Generate permissions for regions
- Rename convertToValue method by generatePermissions

# Where this change will be used
- When an invitation is sending with country role in `/dashboard/users/invite-user path`

# More details
- Invite user exaple 
![image](https://user-images.githubusercontent.com/38545126/124307557-997c3f00-db2d-11eb-808b-63bdc09cb5bc.png)

- request payload 
![image](https://user-images.githubusercontent.com/38545126/124307597-ad27a580-db2d-11eb-90e3-6aed7b843f1e.png)

- New user view 
![image](https://user-images.githubusercontent.com/38545126/124307646-bdd81b80-db2d-11eb-9894-268d7d932fb6.png)
