### PR TITLE
add chart-heat-map in founds by country in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-heat-map/chart-heat-map.component.ts
@@ -16,6 +16,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
   @Input() value;
   @Input() height = '350px' // valid css height to chart container
   @Input() showTooltipValue: boolean = true; // show the value in tooltip
+  @Input() formatValue: string; // value or symbol displayed in tooltip
   @Input() showGridBorders: boolean = false;
   @Input() gridBordersColor: string = '#ffffff';  // valid css color
   @Input() showHeatLegend: boolean = true; // lower legend with average values triggering by column hover
@@ -192,7 +193,7 @@ export class ChartHeatMapComponent implements OnInit, AfterViewInit {
 
     let columnTemplate = series.columns.template;
     let tooltipLegend = this.showTooltipValue
-      ? `{${this.categoryX}}, {${this.categoryY}}: {value.workingValue}`
+      ? `{${this.categoryX}}, {${this.categoryY}}: [bold]{value.workingValue} ${this.formatValue ? this.formatValue : ''}[/]`
       : `{${this.categoryX}} - {${this.categoryY}}`;
 
     columnTemplate.tooltipText = tooltipLegend;

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -50,7 +50,7 @@
                             categoryX="country"
                             [categoryY]="selectedTab1 === 1 ? 'sector' : selectedTab1 === 2 ? 'category' : 'fund'"
                             height="250px" [showGridBorders]="true" [showHeatLegend]="false"
-                            [status]="categoriesReqStatus" gridBordersColor="#f7f7f7">
+                            [status]="categoriesReqStatus" formatValue="USD" gridBordersColor="#f7f7f7">
                         </app-chart-heat-map>
                     </div>
                 </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -25,6 +25,10 @@
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
                                 (click)="getSectorsAndCategories('categories')">{{ 'general.category' | translate }}</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
+                                (click)="getSectorsAndCategories('funds')">Fondo</a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -34,7 +38,8 @@
                         <span class="h4">
                             {{
                             ('overviewLatam.chart1CardTitle1' | translate) +
-                            (( selectedTab1 === 1 ? 'overviewLatam.chart1CardTitle2' : 'overviewLatam.chart1CardTitle3')
+                            (( selectedTab1 === 1 ? 'overviewLatam.chart1CardTitle2' : selectedTab1 === 2 ?
+                            'overviewLatam.chart1CardTitle3' : 'Fondos')
                             | translate) +
                             ('overviewLatam.chart1CardTitle4' | translate)
                             }}
@@ -42,9 +47,10 @@
                     </div>
                     <div class="card-body">
                         <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
-                            categoryX="country" [categoryY]="selectedTab1 === 1 ? 'sector' : 'category'" height="250px"
-                            [showGridBorders]="true" [showHeatLegend]="false" [status]="categoriesReqStatus"
-                            gridBordersColor="#f7f7f7">
+                            categoryX="country"
+                            [categoryY]="selectedTab1 === 1 ? 'sector' : selectedTab1 === 2 ? 'category' : 'fund'"
+                            height="250px" [showGridBorders]="true" [showHeatLegend]="false"
+                            [status]="categoriesReqStatus" gridBordersColor="#f7f7f7">
                         </app-chart-heat-map>
                     </div>
                 </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -196,7 +196,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     // PRESERVE PREVIOUS SELECTION (TABS)
 
     // sectors and categories (chart-heat-map)
-    const sectorsOrCategoriesMetric = this.selectedTab1 === 1 ? 'sectors' : 'categories';
+    const sectorsOrCategoriesMetric = this.selectedTab1 === 1 ? 'sectors' : this.selectedTab1 === 2 ? 'categories' : 'funds';
 
     // demograhics
     const demohraphicMetric = this.selectedTab2 === 1 ? 'traffic' : 'sales';
@@ -281,7 +281,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         this.categoriesReqStatus = 3;
       });
 
-    this.selectedTab1 = metricType === 'sectors' ? 1 : 2;
+    this.selectedTab1 = metricType === 'sectors' ? 1 : metricType === 'categories' ? 2 : 3;
   }
 
   getDemographics(metricType: string) {


### PR DESCRIPTION
# Problem Description
- For heat map chart dispplayed in LATAM overview add a tab to show 'Investment in Funds by Country'

# Features
- Add chart-heat-map by found in overview-latam component
- Add formatValue property to chart-heat-map component
- Add formatValue property to chart-heat-map of overview-latam component

# Where this change will be used
- In LATAM overview at `/dashboard/main-region` path

# More details
![image](https://user-images.githubusercontent.com/38545126/124313782-f92b1800-db36-11eb-9cb5-0d09f9cff975.png)
