### PR TITLE
update performance chart in campaigns-towards-retail-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
@@ -1,14 +1,54 @@
 <div class="row my-5">
     <div class="col-12">
+        <div class="pills-container">
+            <ul class="nav nav-pills nav-fill">
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}" (click)="selectedTab1 = 1">
+                        Inversión - Conversiones
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}" (click)="selectedTab1 = 2">
+                        Impresiones - Clicks
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="col-12 mt-4">
         <div class="card">
+            <div class="card-header">
+                <ng-container [ngSwitch]="selectedTab1">
+                    <span class="h4" *ngSwitchCase="1">Inversión - Conversiones</span>
+                    <span class="h4" *ngSwitchCase="2">Impresiones - Clicks</span>
+                </ng-container>
+            </div>
             <div class="card-body">
-                <app-chart-line-series [series]="campPerformance" [status]="campPerformanceReqStatus"
-                    name="campaign-towards-retail-metrics">
-                </app-chart-line-series>
+                <app-chart-multiple-axes [data]="selectedTab1 === 1 ?  conversionsVsInvestment : impresionsVsClicks"
+                    [value1]="selectedTab1 === 1 ? 'conversions' : 'clicks'"
+                    [value2]="selectedTab1 === 1 ? 'investment' : 'impressions'"
+                    [valueName1]="selectedTab1 === 1 ? 'Conversiones' : 'Clicks'"
+                    [valueName2]="selectedTab1 === 1 ? 'Inversión' : 'Impresiones'"
+                    [valueFormat2]="selectedTab1 === 1 && 'USD'" name="campaign-towards-retail-metrics"
+                    [status]="campPerformanceReqStatus">
+                </app-chart-multiple-axes>
             </div>
         </div>
     </div>
 </div>
+
+<!-- <div class="row my-5">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-body">
+                <app-chart-line-series [series]="campPerformance" [status]="campPerformanceReqStatus"
+                    name="campaign-towards-retail-metrics-deprecated">
+                </app-chart-line-series>
+            </div>
+        </div>
+    </div>
+</div> -->
 
 <div class="row">
     <div class="col-12 mb-5" *ngFor="let campaigns of campList">

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.scss
@@ -1,0 +1,7 @@
+.pills-container {
+    width: 60%;
+
+    @media screen and (max-width: 820px) {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
# Problem Description
- In order to improve the comparison between metrics in performance chart of campaign towards retail section is necessary disaggregate series chart and use two comparsion chart.

# Features
- Update performance chart in campaigns-towards-retail-wrapper component

# Where this change will be used
- In Retailer > Campaign towards retail section at `/dashboard/retailer` path

# More details
- Before changes:
![image](https://user-images.githubusercontent.com/38545126/124324270-4a8fd300-db48-11eb-944e-d3d2d1bc3f2c.png)

- After changes:
![image](https://user-images.githubusercontent.com/38545126/124324306-58455880-db48-11eb-93f2-76e094c6ab29.png)

