### PR TITLE
add multiple-tabs-selector component and use it in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
@@ -4,13 +4,14 @@
             <li class="nav-item mb-2">
                 <a *ngIf="showAllSelectedTab" class="nav-link p-2" [ngClass]="{'active': allSelectedTab}"
                     (click)="allSelectedTab = true; selectedTab($event); selectedTabs=[]">
-                    {{ 'others.all' | translate | titlecase }}
+                    {{ (allSelectedTabText === 'male' ? 'others.allPluralM' : 'others.allPluralF') | translate |
+                    titlecase }}
                 </a>
             </li>
             <li class="nav-item mb-2" *ngFor="let item of tabList">
                 <a class="nav-link p-2" [ngClass]="{'active': selectedTabs?.includes(item.id) && !allSelectedTab}"
                     (click)="allSelectedTab = false; selectedTab($event, item)">
-                    {{ item.id }} - {{ item.name }}
+                    {{ item.name }}
                 </a>
             </li>
         </ul>

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
@@ -1,0 +1,18 @@
+<div class="multiple-tabs-container">
+    <div [ngClass]="{ 'pills-container' : adjustTabsRow}">
+        <ul class="nav nav-pills nav-fill">
+            <li class="nav-item mb-2">
+                <a *ngIf="showAllSelectedTab" class="nav-link p-2" [ngClass]="{'active': allSelectedTab}"
+                    (click)="allSelectedTab = true; selectedTab($event); selectedTabs=[]">
+                    {{ 'others.all' | translate | titlecase }}
+                </a>
+            </li>
+            <li class="nav-item mb-2" *ngFor="let item of tabList">
+                <a class="nav-link p-2" [ngClass]="{'active': selectedTabs?.includes(item.id) && !allSelectedTab}"
+                    (click)="allSelectedTab = false; selectedTab($event, item)">
+                    {{ item.id }} - {{ item.name }}
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.html
@@ -16,4 +16,8 @@
             </li>
         </ul>
     </div>
+
+    <p class="mb-1 text-right" *ngIf="tabList?.length > 1">
+        <small class="text-muted">Ctrl + click para selección múltiple</small>
+    </p>
 </div>

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.scss
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.scss
@@ -1,6 +1,10 @@
 .multiple-tabs-container {
     width: 100%;
 
+    li {
+        cursor: pointer;
+    }
+
     .pills-container {
         width: 60%;
     

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.scss
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.scss
@@ -1,0 +1,11 @@
+.multiple-tabs-container {
+    width: 100%;
+
+    .pills-container {
+        width: 60%;
+    
+        @media screen and (max-width: 820px) {
+            width: 100%;
+        }
+    }
+}

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.spec.ts
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultipleTabsSelectorComponent } from './multiple-tabs-selector.component';
+
+describe('MultipleTabsSelectorComponent', () => {
+  let component: MultipleTabsSelectorComponent;
+  let fixture: ComponentFixture<MultipleTabsSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ MultipleTabsSelectorComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultipleTabsSelectorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
@@ -1,0 +1,96 @@
+import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-multiple-tabs-selector',
+  templateUrl: './multiple-tabs-selector.component.html',
+  styleUrls: ['./multiple-tabs-selector.component.scss']
+})
+export class MultipleTabsSelectorComponent implements OnInit {
+  @Input() showAllSelectedTab: boolean = true; // to show 'select all' tab
+  @Input() adjustTabsRow: boolean;
+
+  private _tabList: TabItem[];
+  get tabList() {
+    return this._tabList;
+  }
+  @Input() set tabList(value) {
+    this._tabList = value;
+  }
+
+  private _selectedTabs: (number | string)[];
+  get selectedTabs() {
+    return this._selectedTabs;
+  }
+  @Input() set selectedTabs(value) {
+    this._selectedTabs = value;
+    // this.getAllSelectTabValue();
+  }
+
+  @Output() private selectedTabsChange = new EventEmitter<(number | string)[]>();
+
+  allSelectedTab: boolean;
+
+  constructor(
+    private translate: TranslateService
+  ) { }
+
+  ngOnInit(): void {
+    this.getAllSelectTabValue();
+  }
+
+  getAllSelectTabValue() {
+    if (this.showAllSelectedTab && (!this.selectedTabs || this.selectedTabs?.length < 1)) {
+      this.allSelectedTab = true;
+
+    } else {
+      this.allSelectedTab = false;
+    }
+
+    console.log('allSelectedTab', this.allSelectedTab)
+  }
+
+  selectedTab(ev, item: TabItem) {
+    console.log('ev.ctrlKey', ev?.ctrlKey)
+    console.log('item', item)
+    console.log('selectedTabs', this.selectedTabs)
+
+    // unique selection (click over one tab except 'select all' tab)
+    if (!ev?.ctrlKey && item?.id) {
+      this.selectedTabs = [item.id];
+    }
+
+    // unique selection (ctrl + click after 'select all' tab)
+    else if (ev?.ctrlKey && !this.selectedTabs && item?.id) {
+      this.selectedTabs = [item.id];
+    }
+
+    // multiple selection ('select all' tab)
+    else if (!item) {
+      this.selectedTabs = this.tabList.map((item: any) => item.id);
+    }
+
+    // multiple selection (any tab except 'select all' tab)
+    else if (ev?.ctrlKey) {
+      const repeatedItemIndex = this.selectedTabs.findIndex((i: any) => i === item.id);
+
+      if (repeatedItemIndex >= 0) {
+        // avoid repeated items
+        this.selectedTabs.splice(repeatedItemIndex, 1)
+      } else {
+        !this.selectedTabs.some((i: any) => i === item.id) && this.selectedTabs.push(item.id);
+      }
+    }
+
+    console.log('selectedTabs', this.selectedTabs)
+    console.log('______________________________')
+
+    this.selectedTabsChange.emit(this.selectedTabs)
+  }
+
+}
+
+export interface TabItem {
+  id: number | string,
+  name: string
+}

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
@@ -60,7 +60,7 @@ export class MultipleTabsSelectorComponent implements OnInit {
     if (JSON.stringify(this._tabList) !== JSON.stringify(this.prevTabList)) {
       this.prevTabList = this._tabList;
 
-      const prevSelectedTab = this._tabList.some(r => this.selectedTabs.indexOf(r.id) >= 0);
+      const prevSelectedTab = this._tabList.some(r => this.selectedTabs?.indexOf(r.id) >= 0);
 
       if (!prevSelectedTab) {
         this.allSelectedTab = true;

--- a/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
+++ b/src/app/modules/dashboard/components/multiple-tabs-selector/multiple-tabs-selector.component.ts
@@ -98,6 +98,10 @@ export class MultipleTabsSelectorComponent implements OnInit {
 
     this.selectionWasAllTab = !item ? true : false;
 
+    if (this.showAllSelectedTab && this.selectedTabs.length < 1) {
+      this.allSelectedTab = true;
+    }
+
     this.selectedTabsChange.emit(this.selectedTabs)
   }
 }

--- a/src/app/modules/dashboard/dashboard.module.ts
+++ b/src/app/modules/dashboard/dashboard.module.ts
@@ -68,6 +68,7 @@ import { StarRaitingComponent } from './components/star-raiting/star-raiting.com
 import { PcSelectorWrapperComponent } from './components/pc-selector-wrapper/pc-selector-wrapper.component';
 import { ChartFunnelComponent } from './components/charts/chart-funnel/chart-funnel.component';
 import { HomeComponent } from './pages/home/home.component';
+import { MultipleTabsSelectorComponent } from './components/multiple-tabs-selector/multiple-tabs-selector.component';
 
 
 @NgModule({
@@ -113,6 +114,7 @@ import { HomeComponent } from './pages/home/home.component';
     ChartFunnelComponent,
     CampaignInRetailWrapperComponent,
     HomeComponent,
+    MultipleTabsSelectorComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -104,25 +104,33 @@
                                     </li>
                                 </ul>
                             </div>
+
                             <div class="col-12 mb-2">
                                 <div [ngClass]="{'pills-container' : selectedTab4 !== 3}">
                                     <!-- sector -->
-                                    <ul class="nav nav-pills nav-fill"
+                                    <!-- <ul class="nav nav-pills nav-fill"
                                         *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                         <li class="nav-item mb-2">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup($event); clearUsersAndSalesTabs()">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectAllTab}"
+                                                (click)="selectAllTab = true; getDataByUsersInvOrAup(); clearUsersAndSalesTabs()">
                                                 {{ 'others.all' | translate | titlecase }}
                                             </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
                                             <a class="nav-link p-2"
-                                                [ngClass]="{'active': selectedSectorsTab.includes(sector.id)}"
-                                                (click)="getDataByUsersInvOrAup($event, null, sector)">
+                                                [ngClass]="{'active': selectedSectorsTab?.includes(sector.id) && !selectAllTab}"
+                                                (click)="selectAllTab = false; getDataByUsersInvOrAup(null, sector)">
                                                 {{ sector.id }} - {{ sector.name }}
                                             </a>
                                         </li>
-                                    </ul>
+                                    </ul> -->
+
+                                    <ng-container *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
+                                        <app-multiple-tabs-selector [tabList]="selectedSectors"
+                                            [selectedTabs]="selectedSectorsTab"
+                                            (selectedTabsChange)="multipleSelectorChange('sectors', $event)">
+                                        </app-multiple-tabs-selector>
+                                    </ng-container>
 
                                     <!-- categoria -->
                                     <ul class="nav nav-pills nav-fill"

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -63,19 +63,19 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 1}"
-                                (click)="getDataByUsersInvOrAup('users-vs-conversions')">
+                                (click)="getDataByUsersInvOrAup('users-vs-conversions', selectedSectorsTab, selectedCategoriesTab, selectedSourcesTab)">
                                 {{ 'general.usersVsSales' | translate }}
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 2}"
-                                (click)="getDataByUsersInvOrAup('investment-vs-revenue')">
+                                (click)="getDataByUsersInvOrAup('investment-vs-revenue', selectedSectorsTab, selectedCategoriesTab, selectedSourcesTab)">
                                 {{ 'general.investmentVsRevenue' | translate }}
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab3 === 3}"
-                                (click)="getDataByUsersInvOrAup('aup-vs-revenue')">
+                                (click)="getDataByUsersInvOrAup('aup-vs-revenue',selectedSectorsTab, selectedCategoriesTab, selectedSourcesTab)">
                                 {{ 'general.revenueVsAup' | translate }}
                             </a>
                         </li>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -106,34 +106,33 @@
                             </div>
 
                             <div class="col-12 mb-2">
-                                <div [ngClass]="{'pills-container' : selectedTab4 !== 3}">
-                                    <!-- sector -->
-                                    <!-- <ul class="nav nav-pills nav-fill"
+                                <!-- sector -->
+                                <!-- <ul class="nav nav-pills nav-fill"
                                         *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                         <li class="nav-item mb-2">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectAllTab}"
-                                                (click)="selectAllTab = true; getDataByUsersInvOrAup(); clearUsersAndSalesTabs()">
+                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
+                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup(); clearUsersAndSalesTabs()">
                                                 {{ 'others.all' | translate | titlecase }}
                                             </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
                                             <a class="nav-link p-2"
-                                                [ngClass]="{'active': selectedSectorsTab?.includes(sector.id) && !selectAllTab}"
-                                                (click)="selectAllTab = false; getDataByUsersInvOrAup(null, sector)">
+                                                [ngClass]="{'active': category.id + 2 === selectedTab5}"
+                                                (click)="selectedTab5 = category.id + 2; getDataByUsersInvOrAup(null, sector)">
                                                 {{ sector.id }} - {{ sector.name }}
                                             </a>
                                         </li>
                                     </ul> -->
 
-                                    <ng-container *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
-                                        <app-multiple-tabs-selector [tabList]="selectedSectors"
-                                            [selectedTabs]="selectedSectorsTab"
-                                            (selectedTabsChange)="multipleSelectorChange('sectors', $event)">
-                                        </app-multiple-tabs-selector>
-                                    </ng-container>
+                                <ng-container *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
+                                    <app-multiple-tabs-selector [tabList]="selectedSectors"
+                                        [selectedTabs]="selectedSectorsTab" [adjustTabsRow]="true"
+                                        (selectedTabsChange)="multipleSelectorChange('sectors', $event)">
+                                    </app-multiple-tabs-selector>
+                                </ng-container>
 
-                                    <!-- categoria -->
-                                    <ul class="nav nav-pills nav-fill"
+                                <!-- categoria -->
+                                <!-- <ul class="nav nav-pills nav-fill"
                                         *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
@@ -148,10 +147,18 @@
                                                 {{ category.name }}
                                             </a>
                                         </li>
-                                    </ul>
+                                    </ul> -->
 
-                                    <!-- fuente -->
-                                    <ul class="nav nav-pills nav-fill"
+                                <ng-container *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
+                                    <app-multiple-tabs-selector [tabList]="selectedCategories"
+                                        [selectedTabs]="selectedCategoriesTab" [adjustTabsRow]="true"
+                                        allSelectedTabText="female"
+                                        (selectedTabsChange)="multipleSelectorChange('categories', $event)">
+                                    </app-multiple-tabs-selector>
+                                </ng-container>
+
+                                <!-- fuente -->
+                                <!-- <ul class="nav nav-pills nav-fill"
                                         *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
@@ -166,8 +173,18 @@
                                                 {{ source.name }}
                                             </a>
                                         </li>
-                                    </ul>
-                                </div>
+                                    </ul> -->
+
+                                <ng-container *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
+                                    <app-multiple-tabs-selector [tabList]="selectedSources"
+                                        [selectedTabs]="selectedSourcesTab" allSelectedTabText="female"
+                                        (selectedTabsChange)="multipleSelectorChange('sources', $event)">
+                                    </app-multiple-tabs-selector>
+                                </ng-container>
+
+                                <p class="mb-1 text-right">
+                                    <small class="text-muted">Ctrl + click para selección múltiple</small>
+                                </p>
                             </div>
                         </div>
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -111,15 +111,15 @@
                                         *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                         <li class="nav-item mb-2">
                                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup(); clearUsersAndSalesTabs()">
+                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup($event); clearUsersAndSalesTabs()">
                                                 {{ 'others.all' | translate | titlecase }}
                                             </a>
                                         </li>
                                         <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
                                             <a class="nav-link p-2"
-                                                [ngClass]="{'active': sector.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = sector.id + 2; getDataByUsersInvOrAup(null, sector)">
-                                                {{ sector.name }}
+                                                [ngClass]="{'active': selectedSectorsTab.includes(sector.id)}"
+                                                (click)="getDataByUsersInvOrAup($event, null, sector)">
+                                                {{ sector.id }} - {{ sector.name }}
                                             </a>
                                         </li>
                                     </ul>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -98,7 +98,7 @@
                                 <ul class="nav nav-tabs">
                                     <li class="nav-item" *ngFor="let metric of usersInvOrAupMetrics; let i = index">
                                         <a class="nav-link" [ngClass]="{'active bg-light' : selectedTab4 === i + 1}"
-                                            (click)="selectedTab4 = i + 1; selectedTab5 = 1; getDataByUsersInvOrAup()">
+                                            (click)="selectedTab4 = i + 1; clearSubtabsSelection(); getDataByUsersInvOrAup()">
                                             <span>{{ metric | titlecase }}</span>
                                         </a>
                                     </li>
@@ -107,23 +107,6 @@
 
                             <div class="col-12 mb-2">
                                 <!-- sector -->
-                                <!-- <ul class="nav nav-pills nav-fill"
-                                        *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
-                                        <li class="nav-item mb-2">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup(); clearUsersAndSalesTabs()">
-                                                {{ 'others.all' | translate | titlecase }}
-                                            </a>
-                                        </li>
-                                        <li class="nav-item mb-2" *ngFor="let sector of selectedSectors">
-                                            <a class="nav-link p-2"
-                                                [ngClass]="{'active': category.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = category.id + 2; getDataByUsersInvOrAup(null, sector)">
-                                                {{ sector.id }} - {{ sector.name }}
-                                            </a>
-                                        </li>
-                                    </ul> -->
-
                                 <ng-container *ngIf="selectedTab4 === 1 && selectedSectors?.length > 1">
                                     <app-multiple-tabs-selector [tabList]="selectedSectors"
                                         [selectedTabs]="selectedSectorsTab" [adjustTabsRow]="true"
@@ -132,23 +115,6 @@
                                 </ng-container>
 
                                 <!-- categoria -->
-                                <!-- <ul class="nav nav-pills nav-fill"
-                                        *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
-                                        <li class="nav-item mb-2">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup()">
-                                                {{ 'others.all' | translate | titlecase }}
-                                            </a>
-                                        </li>
-                                        <li class="nav-item mb-2" *ngFor="let category of selectedCategories">
-                                            <a class="nav-link p-2"
-                                                [ngClass]="{'active': category.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = category.id + 2; getDataByUsersInvOrAup(null, null, category)">
-                                                {{ category.name }}
-                                            </a>
-                                        </li>
-                                    </ul> -->
-
                                 <ng-container *ngIf="selectedTab4 === 2 && selectedCategories?.length > 1">
                                     <app-multiple-tabs-selector [tabList]="selectedCategories"
                                         [selectedTabs]="selectedCategoriesTab" [adjustTabsRow]="true"
@@ -158,33 +124,12 @@
                                 </ng-container>
 
                                 <!-- fuente -->
-                                <!-- <ul class="nav nav-pills nav-fill"
-                                        *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
-                                        <li class="nav-item mb-2">
-                                            <a class="nav-link p-2" [ngClass]="{'active': selectedTab5 === 1}"
-                                                (click)="selectedTab5 = 1; getDataByUsersInvOrAup()">
-                                                {{ 'others.all' | translate | titlecase }}
-                                            </a>
-                                        </li>
-                                        <li class="nav-item mb-2" *ngFor="let source of selectedSources">
-                                            <a class="nav-link p-2"
-                                                [ngClass]="{'active': source.id + 2 === selectedTab5}"
-                                                (click)="selectedTab5 = source.id + 2; getDataByUsersInvOrAup(null, null, null, source)">
-                                                {{ source.name }}
-                                            </a>
-                                        </li>
-                                    </ul> -->
-
                                 <ng-container *ngIf="selectedTab4 === 3 && selectedSources?.length > 1">
                                     <app-multiple-tabs-selector [tabList]="selectedSources"
                                         [selectedTabs]="selectedSourcesTab" allSelectedTabText="female"
                                         (selectedTabsChange)="multipleSelectorChange('sources', $event)">
                                     </app-multiple-tabs-selector>
                                 </ng-container>
-
-                                <p class="mb-1 text-right">
-                                    <small class="text-muted">Ctrl + click para selección múltiple</small>
-                                </p>
                             </div>
                         </div>
 
@@ -371,7 +316,7 @@
                 <div class="pills-container mb-4">
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item" *ngFor="let category of selectedCategories">
-                            <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab6}"
+                            <a class="nav-link p-2" [ngClass]="{'active': category.id === selectedTab5}"
                                 (click)="getTopProducts(category)">
                                 {{ category.name }}
                             </a>
@@ -384,7 +329,7 @@
                     <div class="card-header">
                         <span class="h4">{{ 'overviewLatam.table1CardTitle1' | translate }}</span>
                         <ng-container *ngIf="selectedCategories?.length > 1">
-                            <ng-container [ngSwitch]="selectedTab6">
+                            <ng-container [ngSwitch]="selectedTab5">
                                 <span *ngSwitchCase="1" class="h4"> - PS</span>
                                 <span *ngSwitchCase="2" class="h4"> - HW Print</span>
                                 <span *ngSwitchCase="3" class="h4"> - Supplies</span>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -145,7 +145,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   translateSub: Subscription;
   chartsInitLoad: boolean = true;
 
-  selectAllTab: boolean = true;
 
   constructor(
     private filtersStateService: FiltersStateService,
@@ -218,7 +217,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     switch (this.selectedTab4) {
       case 1:
         // there's a previous selected sector
-
         previousSectors = this.selectedSectors.filter(sector => this.selectedSectorsTab.includes(sector.id));
         console.log('previousSectors', previousSectors);
         break;
@@ -237,20 +235,27 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     }
     // }
 
-    let selectedSectors = previousSectors?.length > 0 ? previousSectors.map(item => item.id) : null;
+    const selectedSectors = previousSectors?.length > 0 ? previousSectors.map(item => item.id) : null;
     const selectedCategories = previousCategories?.length > 0 ? previousCategories.map(item => item.id) : null;
     const selectedSources = previousSources?.length > 0 ? previousSources.map(item => item.id) : null;
     const selectedCategory2 = previousCategory2 ? previousCategory2 : this.selectedCategories[0];
 
+    if (!selectedSectors) {
+      this.selectedSectorsTab = [];
+    }
+
+    if (!selectedCategories) {
+      this.selectedCategoriesTab = [];
+    }
+
+    if (!selectedSectors) {
+      this.selectedSourcesTab = [];
+    }
+
     this.getKpis();
     this.getSectorsAndCategories(sectorsOrCategoriesMetric);
     this.getDemographics(demohraphicMetric);
-    console.log('selectedSectors', selectedSectors)
-    console.log('this.selectedSectors', this.selectedSectors)
 
-    if (!selectedSectors && !selectedCategories && !selectedSources) {
-      selectedSectors = this.selectedSectors.map(item => item.id);
-    }
 
     this.getDataByUsersInvOrAup(null, selectedSectors, selectedCategories, selectedSources);
 
@@ -365,6 +370,8 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         originalItemsLength = this.selectedSources.length;
         break;
     }
+
+    console.log('_____________________')
 
     // if (selectedIds.length === 1 || originalItemsLength === selectedIds.length) {
     this.getDataByUsersInvOrAup(null, this.selectedSectorsTab, this.selectedCategoriesTab, this.selectedSourcesTab);

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -18,8 +18,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   selectedTab2: number = 2; // traffic (1) or conversions (2) selection -> demographics
   selectedTab3: number = 1; // users vs conversions (1) or investment vs revenue (2) or aup vs revenue (3) selection -> chart-multiple-axes
   selectedTab4: number = 1; // sector (1) or category (2) or source (3) selection ->  chart-multiple-axes
-  selectedTab5: number = 1; // subtab (sector, category or source) selection ->  chart-multiple-axes
-  selectedTab6: number = 1; // category selection -> generic-table (top products)
+  selectedTab5: number = 1; // category selection -> generic-table (top products)
 
   selectionList: number[] = [1];
 
@@ -213,53 +212,34 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     let previousCategories;
     let previousSources;
 
-    // if (this.selectedTab5 !== 1) {
     switch (this.selectedTab4) {
       case 1:
-        // there's a previous selected sector
+        // there's previous selected sectors
         previousSectors = this.selectedSectors.filter(sector => this.selectedSectorsTab.includes(sector.id));
-        console.log('previousSectors', previousSectors);
         break;
 
       case 2:
-        // there's a previous selected category
-        previousCategories = this.selectedCategories.find(category => this.selectedCategoriesTab.includes(category.id));
-        console.log('previousCategories', previousCategories);
+        // there's previous selected categories
+        previousCategories = this.selectedCategories.filter(category => this.selectedCategoriesTab.includes(category.id));
         break;
 
       case 3:
-        // there's a previous selected source
-        previousSources = this.selectedSources.find(source => this.selectedSourcesTab.includes(source.id));
-        console.log('previousSources', previousSources);
+        // there's previous selected sources
+        previousSources = this.selectedSources.filter(source => this.selectedSourcesTab.includes(source.id));
         break;
     }
-    // }
 
-    const selectedSectors = previousSectors?.length > 0 ? previousSectors.map(item => item.id) : null;
-    const selectedCategories = previousCategories?.length > 0 ? previousCategories.map(item => item.id) : null;
-    const selectedSources = previousSources?.length > 0 ? previousSources.map(item => item.id) : null;
-    const selectedCategory2 = previousCategory2 ? previousCategory2 : this.selectedCategories[0];
+    this.selectedSectorsTab = previousSectors?.map(item => item.id);
+    this.selectedCategoriesTab = previousCategories?.map(item => item.id);
+    this.selectedSourcesTab = previousSources?.map(item => item.id);
 
-    if (!selectedSectors) {
-      this.selectedSectorsTab = [];
-    }
-
-    if (!selectedCategories) {
-      this.selectedCategoriesTab = [];
-    }
-
-    if (!selectedSectors) {
-      this.selectedSourcesTab = [];
-    }
+    const selectedCategoryTab = previousCategory2 ? previousCategory2 : this.selectedCategories[0];
 
     this.getKpis();
     this.getSectorsAndCategories(sectorsOrCategoriesMetric);
     this.getDemographics(demohraphicMetric);
-
-
-    this.getDataByUsersInvOrAup(null, selectedSectors, selectedCategories, selectedSources);
-
-    this.getTopProducts(selectedCategory2);
+    this.getDataByUsersInvOrAup(null, this.selectedSectorsTab, this.selectedCategoriesTab, this.selectedSourcesTab);
+    this.getTopProducts(selectedCategoryTab);
 
     this.chartsInitLoad = true;
   }
@@ -347,11 +327,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   multipleSelectorChange(option: string, selectedIds: any[]) {
-    console.log('option', option)
-    console.log('selectedIds', selectedIds)
-
     let originalItemsLength;
-
 
     switch (option) {
       case 'sectors':
@@ -371,11 +347,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         break;
     }
 
-    console.log('_____________________')
-
-    // if (selectedIds.length === 1 || originalItemsLength === selectedIds.length) {
     this.getDataByUsersInvOrAup(null, this.selectedSectorsTab, this.selectedCategoriesTab, this.selectedSourcesTab);
-    // }
   }
 
   getDataByUsersInvOrAup(metricType?: string, sectors?: any, categories?: any, sources?: any) {
@@ -421,10 +393,10 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       }
     )
 
-    this.selectedTab6 = selectedCategory.id;
+    this.selectedTab5 = selectedCategory.id;
   }
 
-  clearUsersAndSalesTabs() {
+  clearSubtabsSelection() {
     this.selectedSectorsTab && delete this.selectedSectorsTab;
     this.selectedCategoriesTab && delete this.selectedCategoriesTab;
     this.selectedSourcesTab && delete this.selectedSourcesTab;

--- a/src/app/modules/dashboard/services/filters-state.service.ts
+++ b/src/app/modules/dashboard/services/filters-state.service.ts
@@ -165,10 +165,15 @@ export class FiltersStateService {
     this.retailAudiencesQParams = this.retailAudiences && this.convertArrayToQueryParams(this.retailAudiences, 'id');
   }
 
-  convertArrayToQueryParams(array, param: string): string {
+  convertArrayToQueryParams(array, param?: string): string {
     let stringArray = '';
     for (let i = 0; i < array.length; i++) {
-      stringArray = array[i][param] ? stringArray.concat(',', array[i][param]) : stringArray;
+
+      if (param) {
+        stringArray = array[i][param] ? stringArray.concat(',', array[i][param]) : stringArray;
+      } else {
+        stringArray = array[i] ? stringArray.concat(',', array[i]) : stringArray;
+      }
     }
 
     return stringArray.substring(1);

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -77,6 +77,27 @@ export class OverviewService {
     }
   }
 
+  customQueryParams(isLatam?: boolean, sectorsQP?: string, categoriesQP?: string, sourcesQP?: string, forceSourcesUse?: boolean) {
+    let startDate = this.filtersStateService.periodQParams.startDate;
+    let endDate = this.filtersStateService.periodQParams.endDate;
+    let campaigns = this.filtersStateService.campaignsQParams;
+    let sectors = !sectorsQP ? this.filtersStateService.sectorsQParams : sectorsQP;
+    let categories = !categoriesQP ? this.filtersStateService.categoriesQParams : categoriesQP;
+    let sources = !sourcesQP ? this.filtersStateService.sourcesQParams : sourcesQP;
+
+    const baseQParams = `start_date=${startDate}&end_date=${endDate}&sectors=${sectors}&categories=${categories}`;
+    if (!isLatam && !forceSourcesUse) {
+      return `${baseQParams}${campaigns ? `&campaigns=${campaigns}` : ''}`;
+
+    } else if (!isLatam && forceSourcesUse) {
+      return `${baseQParams}&sources=${sources}${campaigns ? `&campaigns=${campaigns}` : ''}`;
+
+    } else {
+      let retailers = this.filtersStateService.retailersQParams;
+      return `retailers=${retailers}&${baseQParams}&sources=${sources}`;
+    }
+  }
+
   /**** COUNTRIES AND RETAILERS
   * Overview endpoints for Countries and Retailers
   * ****/
@@ -191,12 +212,17 @@ export class OverviewService {
   }
 
   // *** users vs conversions / investment vs revenue / revenue vs aup ***
-  getUsersInvOrAupLatam(metricType: string, sectorID?: number, categoryID?: number, sourceID?: number) {
+  getUsersInvOrAupLatam(metricType: string, sectors?: number[], categories?: number[], sources?: number[]) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
     }
 
-    let queryParams = this.concatedQueryParams(true, sectorID, categoryID, sourceID);
+    const sectorsQParams = sectors && this.filtersStateService.convertArrayToQueryParams(sectors);
+    const categoriesQParams = categories && this.filtersStateService.convertArrayToQueryParams(categories);
+    const sourcesQParams = sources && this.filtersStateService.convertArrayToQueryParams(sources);
+
+    let queryParams = this.customQueryParams(true, sectorsQParams, categoriesQParams, sourcesQParams, true);
+
     return this.http.get(`${this.baseUrl}/latam/${metricType}?${queryParams}`);
   }
 

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -77,6 +77,19 @@ export class OverviewService {
     }
   }
 
+
+  /**
+   * Customs query params
+   * @param [isLatam] to add reatilers and sources query params
+   * @param [sectorsQP] sectors query params
+   * @param [categoriesQP] categories query params
+   * @param [sourcesQP] sources query params
+   * @param [forceSourcesUse] to use sources query params (usefull when !isLatam)
+   * @returns query params
+   */
+
+  // This method not use sectors, categories and sources selected in general filters
+  // So the selection and query params are generated independently
   customQueryParams(isLatam?: boolean, sectorsQP?: string, categoriesQP?: string, sourcesQP?: string, forceSourcesUse?: boolean) {
     let startDate = this.filtersStateService.periodQParams.startDate;
     let endDate = this.filtersStateService.periodQParams.endDate;


### PR DESCRIPTION
# Problem Description
- For a chart shown in overviews (LATAM, Country and Retailer) is necessary to implement multiple tabs selections functionality, so the first step is create a generic component and use it in LATAM overview component

# Features
- Add multiple-tabs-selector component (generic component to be used from differents components as a child)
- Add customQueryParams method in overview service
- Update getUsersInvOrAupLatam method in overview service
- Use multiple-tabs-selector component and replace chart functionality in overview-latam component 
- Other implications:
  - Update convertArrayToQueryParams method in filter-state service

# Where this change will be used
- In LATAM overview at _/dashboard/main-region_ path

# More details
![image](https://user-images.githubusercontent.com/38545126/124961493-2e29e580-dfe3-11eb-8035-7f33c0f6efd5.png)
