### PR TITLE
add chart-heat-map to overviews components template to show traffic and conversions

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -150,11 +150,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="getDemographics('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                            (click)="getTrafficOrSales('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="getDemographics('sales'); chartsInitLoad = chartsInitLoad && false;">Conversiones</a>
+                            (click)="getTrafficOrSales('sales'); chartsInitLoad = chartsInitLoad && false;">Conversiones</a>
                     </li>
                 </ul>
             </div>
@@ -173,28 +173,29 @@
                     <div class="row">
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="demographics?.desktop?.length > 0">
+                                <div class="legend-container" *ngIf="trafficOrSales?.desktop?.length > 0">
                                     <div class="legend-square on color-1"></div>
-                                    <div class="legend-label">Desktop {{ demographics.desktop[1].value }}%
+                                    <div class="legend-label">Desktop {{ trafficOrSales.desktop[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="demographics?.desktop" [name]="selectedType + 'device-desktop'"
-                                [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
-                                [status]="demographicsReqStatus[0].reqStatus" height="280px">
+                            <app-chart-pictorial [data]="trafficOrSales?.desktop"
+                                [name]="selectedType + 'device-desktop'" [uniqueDimensionConf]="{color: '#67B6DC'}"
+                                category="name" iconType="monitor" [status]="trafficOrSalesReqStatus[0].reqStatus"
+                                height="280px">
                             </app-chart-pictorial>
                         </div>
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="demographics?.mobile?.length > 0">
+                                <div class="legend-container" *ngIf="trafficOrSales?.mobile?.length > 0">
                                     <div class="legend-square on color-2"></div>
-                                    <div class="legend-label">Mobile {{ demographics.mobile[1].value }}%
+                                    <div class="legend-label">Mobile {{ trafficOrSales.mobile[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="demographics?.mobile" [name]="selectedType + 'device-mobile'"
+                            <app-chart-pictorial [data]="trafficOrSales?.mobile" [name]="selectedType + 'device-mobile'"
                                 [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
-                                height="280px" [status]="demographicsReqStatus[0].reqStatus">
+                                height="280px" [status]="trafficOrSalesReqStatus[0].reqStatus">
                             </app-chart-pictorial>
                         </div>
                     </div>
@@ -215,32 +216,32 @@
                     <div class="row">
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="demographics?.men?.length > 0">
+                                <div class="legend-container" *ngIf="trafficOrSales?.men?.length > 0">
                                     <div class="legend-square on color-1"></div>
                                     <div class="legend-label">
                                         {{ ('others.men'| translate) + ' '}}
-                                        {{ demographics.men[1].value }}%
+                                        {{ trafficOrSales.men[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="demographics?.men" [name]="selectedType + 'gender-man'"
+                            <app-chart-pictorial [data]="trafficOrSales?.men" [name]="selectedType + 'gender-man'"
                                 [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
-                                [status]="demographicsReqStatus[1].reqStatus" height="280px">
+                                [status]="trafficOrSalesReqStatus[1].reqStatus" height="280px">
                             </app-chart-pictorial>
                         </div>
                         <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                             <div class="chart-legend legend-center mt-0">
-                                <div class="legend-container" *ngIf="demographics?.women?.length > 0">
+                                <div class="legend-container" *ngIf="trafficOrSales?.women?.length > 0">
                                     <div class="legend-square on color-2"></div>
                                     <div class="legend-label">
                                         {{ ('others.women'| translate) + ' '}}
-                                        {{ demographics.women[1].value }}%
+                                        {{ trafficOrSales.women[1].value }}%
                                     </div>
                                 </div>
                             </div>
-                            <app-chart-pictorial [data]="demographics?.women" [name]="selectedType + 'gender-woman'"
+                            <app-chart-pictorial [data]="trafficOrSales?.women" [name]="selectedType + 'gender-woman'"
                                 [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
-                                height="280px" [status]="demographicsReqStatus[1].reqStatus">
+                                height="280px" [status]="trafficOrSalesReqStatus[1].reqStatus">
                             </app-chart-pictorial>
                         </div>
                     </div>
@@ -255,9 +256,9 @@
                     <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}} por Edad</span>
                 </div>
                 <div class="card-body">
-                    <app-chart-lollipop [data]="demographics?.age" [name]="selectedType + 'age'" category="age"
+                    <app-chart-lollipop [data]="trafficOrSales?.age" [name]="selectedType + 'age'" category="age"
                         [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
-                        [status]="demographicsReqStatus[2].reqStatus">
+                        [status]="trafficOrSalesReqStatus[2].reqStatus">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -271,17 +272,17 @@
                 </div>
                 <div class="card-body" style="height: 328px">
                     <!-- loader -->
-                    <app-chart-loader *ngIf="chartsInitLoad && demographicsReqStatus[3].reqStatus <= 1">
+                    <app-chart-loader *ngIf="chartsInitLoad && trafficOrSalesReqStatus[3].reqStatus <= 1">
                     </app-chart-loader>
 
                     <!-- ready -->
-                    <app-chart-pyramid *ngIf="demographics?.genderByAge?.length > 0" [data]="demographics?.genderByAge"
-                        [name]="selectedType + 'age-and-gender'" [status]="demographicsReqStatus[3].reqStatus"
-                        height="280px">
+                    <app-chart-pyramid *ngIf="trafficOrSales?.genderAndAge?.length > 0"
+                        [data]="trafficOrSales?.genderAndAge" [name]="selectedType + 'age-and-gender'"
+                        [status]="trafficOrSalesReqStatus[3].reqStatus" height="280px">
                     </app-chart-pyramid>
 
                     <!-- empty data -->
-                    <div *ngIf="demographicsReqStatus[3].reqStatus === 2 && demographics?.genderByAge?.length === 0"
+                    <div *ngIf="trafficOrSalesReqStatus[3].reqStatus === 2 && trafficOrSales?.genderAndAge?.length === 0"
                         class="chart-error-container text-muted">
                         <p class="text-center">
                             Sin datos disponibles <br>
@@ -290,10 +291,27 @@
                     </div>
 
                     <!-- error -->
-                    <div *ngIf="chartsInitLoad && demographicsReqStatus[3].reqStatus === 3"
+                    <div *ngIf="chartsInitLoad && trafficOrSalesReqStatus[3].reqStatus === 3"
                         class="chart-error-container text-muted">
                         <span>Error al consultar datos</span>
                     </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- weekday and hour -->
+        <div class="col-12 col-lg-6 mt-4">
+            <div class="card height-fluid">
+                <div class="card-header">
+                    <span class="h4">
+                        {{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}} por día de la semana y hora del día
+                    </span>
+                </div>
+                <div class="card-body">
+                    <app-chart-heat-map [data]="trafficOrSales?.weekdayAndHour"
+                        [name]="selectedType + '-weekday-sesions'" height="615px"
+                        [status]="trafficOrSalesReqStatus[4].reqStatus" categoryX="weekdayName">
+                    </app-chart-heat-map>
                 </div>
             </div>
         </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -152,13 +152,13 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                                (click)="getDemographics('traffic'); chartsInitLoad = chartsInitLoad && false">
+                                (click)="gettrafficOrSales('traffic'); chartsInitLoad = chartsInitLoad && false">
                                 {{ 'general.traffic' | translate }}
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                                (click)="getDemographics('sales'); chartsInitLoad = chartsInitLoad && false">
+                                (click)="gettrafficOrSales('sales'); chartsInitLoad = chartsInitLoad && false">
                                 {{ 'general.sales' | translate }}
                             </a>
                         </li>
@@ -179,28 +179,28 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="demographics?.desktop?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficOrSales?.desktop?.length > 0">
                                         <div class="legend-square on color-1"></div>
-                                        <div class="legend-label">Desktop {{ demographics.desktop[1].value }}%
+                                        <div class="legend-label">Desktop {{ trafficOrSales.desktop[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="demographics?.desktop" name="latam-devices-desktop"
+                                <app-chart-pictorial [data]="trafficOrSales?.desktop" name="latam-devices-desktop"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="monitor"
-                                    [status]="demographicsReqStatus[0].reqStatus" height="280px">
+                                    [status]="trafficOrSalesReqStatus[0].reqStatus" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="demographics?.mobile?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficOrSales?.mobile?.length > 0">
                                         <div class="legend-square on color-2"></div>
-                                        <div class="legend-label">Mobile {{ demographics.mobile[1].value }}%
+                                        <div class="legend-label">Mobile {{ trafficOrSales.mobile[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="demographics?.mobile" name="latam-devices-mobile"
+                                <app-chart-pictorial [data]="trafficOrSales?.mobile" name="latam-devices-mobile"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="cellphone"
-                                    height="280px" [status]="demographicsReqStatus[0].reqStatus">
+                                    height="280px" [status]="trafficOrSalesReqStatus[0].reqStatus">
                                 </app-chart-pictorial>
                             </div>
                         </div>
@@ -221,32 +221,32 @@
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="demographics?.men?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficOrSales?.men?.length > 0">
                                         <div class="legend-square on color-1"></div>
                                         <div class="legend-label">
                                             {{ ('others.men'| translate) + ' '}}
-                                            {{ demographics.men[1].value }}%
+                                            {{ trafficOrSales.men[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="demographics?.men" name="latam-gender-man"
+                                <app-chart-pictorial [data]="trafficOrSales?.men" name="latam-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
-                                    [status]="demographicsReqStatus[1].reqStatus" height="280px">
+                                    [status]="trafficOrSalesReqStatus[1].reqStatus" height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
                                 <div class="chart-legend legend-center mt-0">
-                                    <div class="legend-container" *ngIf="demographics?.women?.length > 0">
+                                    <div class="legend-container" *ngIf="trafficOrSales?.women?.length > 0">
                                         <div class="legend-square on color-2"></div>
                                         <div class="legend-label">
                                             {{ ('others.women'| translate) + ' '}}
-                                            {{ demographics.women[1].value }}%
+                                            {{ trafficOrSales.women[1].value }}%
                                         </div>
                                     </div>
                                 </div>
-                                <app-chart-pictorial [data]="demographics?.women" name="latam-gender-woman"
+                                <app-chart-pictorial [data]="trafficOrSales?.women" name="latam-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
-                                    height="280px" [status]="demographicsReqStatus[1].reqStatus">
+                                    height="280px" [status]="trafficOrSalesReqStatus[1].reqStatus">
                                 </app-chart-pictorial>
                             </div>
                         </div>
@@ -264,9 +264,9 @@
                         </span>
                     </div>
                     <div class="card-body">
-                        <app-chart-lollipop [data]="demographics?.age" name="latam-age" category="age"
+                        <app-chart-lollipop [data]="trafficOrSales?.age" name="latam-age" category="age"
                             [value]="selectedTab2 === 1 ? 'visits' : 'sales'" height="280px"
-                            [status]="demographicsReqStatus[2].reqStatus">
+                            [status]="trafficOrSalesReqStatus[2].reqStatus">
                         </app-chart-lollipop>
                     </div>
                 </div>
@@ -283,17 +283,17 @@
                     </div>
                     <div class="card-body" style="height: 328px">
                         <!-- loader -->
-                        <app-chart-loader *ngIf="chartsInitLoad && demographicsReqStatus[3].reqStatus <= 1">
+                        <app-chart-loader *ngIf="chartsInitLoad && trafficOrSalesReqStatus[3].reqStatus <= 1">
                         </app-chart-loader>
 
                         <!-- ready -->
-                        <app-chart-pyramid *ngIf="demographics?.genderByAge?.length > 0"
-                            [data]="demographics?.genderByAge" name="latam-age-and-gender"
-                            [status]="demographicsReqStatus[3].reqStatus" height="280px">
+                        <app-chart-pyramid *ngIf="trafficOrSales?.genderAndAge?.length > 0"
+                            [data]="trafficOrSales?.genderAndAge" name="latam-age-and-gender"
+                            [status]="trafficOrSalesReqStatus[3].reqStatus" height="280px">
                         </app-chart-pyramid>
 
                         <!-- empty data -->
-                        <div *ngIf="demographicsReqStatus[3].reqStatus === 2 && demographics?.genderByAge?.length === 0"
+                        <div *ngIf="trafficOrSalesReqStatus[3].reqStatus === 2 && trafficOrSales?.genderAndAge?.length === 0"
                             class="chart-error-container text-muted">
                             <p class="text-center">
                                 {{ 'general.withoutData' | translate }} <br>
@@ -302,10 +302,26 @@
                         </div>
 
                         <!-- error -->
-                        <div *ngIf="chartsInitLoad && demographicsReqStatus[3].reqStatus === 3"
+                        <div *ngIf="chartsInitLoad && trafficOrSalesReqStatus[3].reqStatus === 3"
                             class="chart-error-container text-muted">
                             <span> {{ 'general.errorData' | translate }}</span>
                         </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- weekday and hour -->
+            <div class="col-12 col-lg-6 mt-4">
+                <div class="card height-fluid">
+                    <div class="card-header">
+                        <span class="h4">
+                            {{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}} por día de la semana y hora del día
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        <app-chart-heat-map [data]="trafficOrSales?.weekdayAndHour" name="latam-weekday-sesions"
+                            height="615px" [status]="trafficOrSalesReqStatus[4].reqStatus" categoryX="weekdayName">
+                        </app-chart-heat-map>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -152,13 +152,13 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                                (click)="gettrafficOrSales('traffic'); chartsInitLoad = chartsInitLoad && false">
+                                (click)="getTrafficOrSales('traffic'); chartsInitLoad = chartsInitLoad && false">
                                 {{ 'general.traffic' | translate }}
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                                (click)="gettrafficOrSales('sales'); chartsInitLoad = chartsInitLoad && false">
+                                (click)="getTrafficOrSales('sales'); chartsInitLoad = chartsInitLoad && false">
                                 {{ 'general.sales' | translate }}
                             </a>
                         </li>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -239,7 +239,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
     this.getKpis();
     this.getSectorsAndCategories(sectorsOrCategoriesMetric);
-    this.gettrafficOrSales(demohraphicMetric);
+    this.getTrafficOrSales(demohraphicMetric);
     this.getDataByUsersInvOrAup(null, this.selectedSectorsTab, this.selectedCategoriesTab, this.selectedSourcesTab);
     this.getTopProducts(selectedCategoryTab);
 
@@ -288,7 +288,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     this.selectedTab1 = metricType === 'sectors' ? 1 : metricType === 'categories' ? 2 : 3;
   }
 
-  gettrafficOrSales(metricType: string) {
+  getTrafficOrSales(metricType: string) {
     const requiredData = [
       { subMetricType: 'device', name: 'device' },
       { subMetricType: 'gender', name: 'gender' },

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -216,7 +216,7 @@ export class OverviewService {
   }
 
   // *** demographics ***
-  getDemographicsLatam(metricType: string, subMetricType: string) {
+  getTrafficOrSalesLatam(metricType: string, subMetricType: string) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
     }

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -154,8 +154,8 @@ export class OverviewService {
     }
   }
 
-  // *** demographics ***
-  getDemographics(metricType: string, subMetricType: string) {
+  // *** traffic or sales + submetric ***
+  getTrafficOrSales(metricType: string, subMetricType: string) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');
     }
@@ -215,7 +215,7 @@ export class OverviewService {
     return this.http.get(`${this.baseUrl}/latam/countries/${metricType}/segments?${queryParams}`);
   }
 
-  // *** demographics ***
+  // *** traffic or sales + submetric ***
   getTrafficOrSalesLatam(metricType: string, subMetricType: string) {
     if (!metricType) {
       return throwError('[overview.service]: not metricType provided');


### PR DESCRIPTION
# Problem Description
- Is necessary to add a new chart (heat map) in LATAM/Retailers/Countries overviews to show traffic or conversions by weekdays and hours

# Features
- Update overview-latam component
- Update overview-wrapper component
- Other implications: 
  - Rename getDemographicsLatam method in overview service
  - Rename getDemographics method in overview service

# Where this change will be used
- In LATAM/Country/Retailer overviews

# More details
![image](https://user-images.githubusercontent.com/38545126/124981526-4ad21780-dffb-11eb-85fe-e7f002ea6f28.png)

