### PR TITLE
add conversion rate by sector cards in campaign-in-retail component template

### DIFF
--- a/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.html
+++ b/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.html
@@ -3,7 +3,7 @@
     <app-retail-filters></app-retail-filters>
 </div>
 
-<!-- CARD STATS -->
+<!-- KPIS CARDS -->
 <div class="row mt-5">
     <div class="col-12">
         <div class="stats-container">
@@ -32,8 +32,25 @@
     </div>
 </div>
 
+<!-- CR CARDS -->
+<div class="row">
+    <div class="col-12">
+        <span class="h3">Tasa de conversión por Sector</span>
+    </div>
+</div>
+<div class="row mt-2">
+    <div *ngFor="let sector of crBySector" class="col-12 col-sm-4 mb-4">
+        <app-card-stat [stat]="sector" [loader]="crReqStatus <= 1" height="76px"></app-card-stat>
+    </div>
+    <div class="col-12 mt--3 mt-xl-2" [hidden]="crReqStatus !== 3">
+        <p class="text-center text-muted mb-0">
+            Error al consultar datos
+        </p>
+    </div>
+</div>
+
 <!-- ACCORDION -->
-<div class="mt-5">
+<div class="mt-4">
     <mat-accordion multi>
         <mat-expansion-panel (opened)="panelChange('panel1',true)" (closed)="panelChange('panel1',false)">
             <mat-expansion-panel-header>

--- a/src/app/modules/dashboard/services/campaign-in-retail.service.ts
+++ b/src/app/modules/dashboard/services/campaign-in-retail.service.ts
@@ -62,18 +62,6 @@ export class CampaignInRetailService {
     return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/in-retail/kpis?${queryParams}&${queryParamsR}`);
   }
 
-  getRoasBySector() {
-    if (!this.retailerID) {
-      return throwError('[campaign-in-retail.service]: not retailerID provided');
-    }
-
-    let queryParams = this.concatedQueryParams();
-    let queryParamsR = this.concatedRetailerQueryParams();
-
-    return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/in-retail/roas?${queryParams}&${queryParamsR}`);
-  }
-
-
   /**
    *  GENERIC ENDPOINT
    * For endponts with a metric and optional submetric


### PR DESCRIPTION
# Problem Description
- Show conversion rate by sector cards in campaign in retail section

# Features
- Remove deprecated getRoasBySector method in campaign-in-retail service
- Add conversion rate cards in campaign-in-retail component template

# Where this change will be used
- In Retailer > Campaign in retail section at `/dashboard/retailer/` path

# More details
![image](https://user-images.githubusercontent.com/38545126/124996467-95a95a80-e00e-11eb-8b94-5f08044e841c.png)
