### PR TITLE
replace kpi in omnichat component

### DIFF
--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -50,9 +50,10 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         metricValue: '00:00:00',
       },
       {
-        metricTitle: 'mediana de retardo',
-        metricName: 'median_chat_delay',
-        metricValue: '00:00:00',
+        metricTitle: 'páginas por sesión',
+        metricName: 'pages_per_session',
+        metricValue: 0,
+        metricFormat: 'decimals'
       },
       {
         metricTitle: 'calificación del chat',
@@ -274,7 +275,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
 
               const metricName = this.staticData.kpis[i].metricName;
 
-              if (metricName === 'median_chat_duration' || metricName === 'median_chat_delay') {
+              if (metricName === 'median_chat_duration') {
                 this.staticData.kpis[i].metricValue = strTimeFormat(baseObj.value);
               } else if (metricName === 'chat_score') {
                 const percentageScore = ((baseObj.value * 100) / 5).toFixed(2);


### PR DESCRIPTION
# Problem Description
- Is necessary replace median chat delay by pages per session kpi in card shown in omnichat component

# Features
- Replace kpi in omnichat component
- Remove references to median chat delay kpi

# Where this change will be used
- In LATAM/Country/Retailer > Other tools > Omnichat section

# More details
![image](https://user-images.githubusercontent.com/38545126/125103597-1feece80-e0a2-11eb-8f98-aea8e80348db.png)
