### PR TITLE
show cards dynamically in omnichat-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -151,7 +151,8 @@
         <p class="h4 mt-3">Tasas de conversión</p>
         <div class="row">
             <div *ngFor="let stat of staticData.conversionRate" class="col-lg-4 mb-2">
-                <app-card-stat [stat]="stat" [loader]="false" [smallHeader]="true" height="auto"></app-card-stat>
+                <app-card-stat [stat]="stat" [loader]="staticDataReqStatus[1].reqStatus <= 1" [smallHeader]="true"
+                    height="auto"></app-card-stat>
             </div>
             <div class="col-12 mt--3 mt-xl-2" [hidden]="staticDataReqStatus[1].reqStatus !== 3">
                 <p class="text-center text-muted mb-0">

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -90,7 +90,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         metricSymbol: 'USD'
       }
     ],
-    conversionRate: [
+    conversionRateInitial: [
       {
         metricTitle: 'ps',
         metricName: 'PS',
@@ -109,7 +109,8 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
         metricValue: 0,
         metricFormat: 'percentage',
       }
-    ]
+    ],
+    conversionRate: []
   };
   staticDataReqStatus = [
     { name: 'kpis', reqStatus: 0 },
@@ -287,10 +288,19 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
             }
 
           } else if (metric.name === 'conversionRate') {
+            this.staticData.conversionRate = this.staticData.conversionRateInitial.map(item => ({ ...item }));
+
             for (let i = 0; i < this.staticData.conversionRate.length; i++) {
               const baseObj = resp.find(item => item.name === this.staticData.conversionRate[i].metricName);
-              this.staticData.conversionRate[i].metricValue = baseObj.value;
+              if (baseObj) {
+                this.staticData.conversionRate[i].metricValue = baseObj.value;
+              }
+
             }
+
+            // show only selected categories in general filters
+            const selectedCategories = this.filtersStateService.categories.map(item => item.name.toLowerCase());
+            this.staticData.conversionRate = this.staticData.conversionRate.filter(item => selectedCategories.includes(item.metricName.toLowerCase()));
           }
 
           reqStatusObj.reqStatus = 2;


### PR DESCRIPTION
# Problem Description
- Show conversion rate cards dynamically depending on selected categories in general filters

# Features
- Show cards dynamically in omnichat-wrapper component

# Where this change will be used
- In LATAM/Country/Retailer > Other tools > Omnichat section

# More details
![image](https://user-images.githubusercontent.com/38545126/125115020-5e8b8580-e0b0-11eb-94b3-e16c73b0d5cd.png)

