### PR TITLE
show conversion rate charts in omnichat-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.ts
@@ -56,6 +56,16 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit, OnDes
     this.series && this.loadSeriesNames(this.series);
   }
 
+  private _valueFormat: string; // USD, MXN, % copy shown in tooltip
+  get valueFormat() {
+    return this._valueFormat;
+  }
+  @Input() set valueFormat(value) {
+    this._valueFormat = value;
+    this.series && this.loadTooltips();
+  }
+
+
   chartID;
   chart;
   series;
@@ -112,18 +122,6 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit, OnDes
       label.maxWidth = 150;
     }
 
-    if (this.showCategoryInToolip) {
-      series.tooltipText = '[bold]{valueX}[/] - {categoryY}';
-
-      series.tooltip.fontSize = 12;
-      series.tooltip.label.maxWidth = 250;
-      series.tooltip.label.wrap = true;
-      series.tooltip.pointerOrientation = 'down';
-    } else {
-      series.tooltipText = '{valueX}';
-      series.tooltip.pointerOrientation = 'left';
-    }
-
     // series.columns.template.column.cornerRadiusTopLeft = 10;
     series.columns.template.column.cornerRadiusTopRight = 10;
     series.columns.template.column.cornerRadiusBottomRight = 10;
@@ -142,6 +140,7 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit, OnDes
     }
 
     this.loadSeriesNames(series);
+    this.loadTooltips();
 
     // Cursor
     chart.cursor = new am4charts.XYCursor();
@@ -160,6 +159,19 @@ export class ChartBarHorizontalComponent implements OnInit, AfterViewInit, OnDes
     this.series.dataFields.categoryY = this.category;
   }
 
+  loadTooltips() {
+    if (this.showCategoryInToolip) {
+      this.series.tooltipText = `[bold]{valueX}[/] - {categoryY}${this.valueFormat ? this.valueFormat : ''}`;
+
+      this.series.tooltip.fontSize = 12;
+      this.series.tooltip.label.maxWidth = 250;
+      this.series.tooltip.label.wrap = true;
+      this.series.tooltip.pointerOrientation = 'down';
+    } else {
+      this.series.tooltipText = `{valueX}${this.valueFormat ? this.valueFormat : ''}`;
+      this.series.tooltip.pointerOrientation = 'left';
+    }
+  }
 
   ngOnDestroy() {
     this.langSub?.unsubscribe();

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -74,6 +74,10 @@
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
                         (click)="getDataByLevel('sales')">Conversiones</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 3}"
+                        (click)="getDataByLevel('conversion-rate')">Tasa de conversión</a>
+                </li>
             </ul>
         </div>
     </div>
@@ -81,13 +85,16 @@
     <div class="col-12 col-lg-4 mt-4" *ngIf="levelPage.latam">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">
-                    {{ selectedTab2 === 1 ? 'Tráfico' : 'Conversiones' }} por país
-                </span>
+                <ng-container [ngSwitch]="selectedTab2">
+                    <span *ngSwitchCase="1" class="h4">Tráfico por país</span>
+                    <span *ngSwitchCase="2" class="h4">Conversiones por país</span>
+                    <span *ngSwitchCase="3" class="h4">Tasa de conversión por país</span>
+                </ng-container>
             </div>
             <div class="card-body">
                 <app-chart-bar-horizontal [data]="dataByLevel.countries" name="omnichat-chats-by-country"
-                    category="country" [value]="selectedTab2 === 1 ? 'chats' : 'value'" [singleColorBars]="true"
+                    category="country" [value]="selectedTab2 === 1 ? 'chats' : 'value'"
+                    [valueFormat]="selectedTab2 === 3 && '%'" [singleColorBars]="true"
                     [status]="dataByLevelReqStatus[0].reqStatus">
                 </app-chart-bar-horizontal>
             </div>
@@ -97,15 +104,18 @@
         [ngClass]="{'col-lg-6' : !levelPage.latam}">
         <div class="card height-fluid superimposed">
             <div class="card-header">
-                <span class="h4">
-                    {{ selectedTab2 === 1 ? 'Tráfico' : 'Conversiones' }} por retailer
-                </span>
+                <ng-container [ngSwitch]="selectedTab2">
+                    <span *ngSwitchCase="1" class="h4">Tráfico por retailer</span>
+                    <span *ngSwitchCase="2" class="h4">Conversiones por retailer</span>
+                    <span *ngSwitchCase="3" class="h4">Tasa de conversión por retailer</span>
+                </ng-container>
             </div>
             <div class="card-body" [ngClass]="{'overfow-container': dataByLevel?.retailers?.length > 10}">
                 <div class="superimposed">
                     <app-chart-bar-horizontal [data]="dataByLevel.retailers" name="omnichat-chats-by-retailer"
-                        category="retailer" [value]="selectedTab2 === 1 ? 'chats' : 'value'" [truncateLabels]="true"
-                        [singleColorBars]="true" [height]="dataByLevel?.retailers?.length > 10 ? '600px' : '350px'"
+                        category="retailer" [value]="selectedTab2 === 1 ? 'chats' : 'value'"
+                        [valueFormat]="selectedTab2 === 3 && '%'" [truncateLabels]="true" [singleColorBars]="true"
+                        [height]="dataByLevel?.retailers?.length > 10 ? '600px' : '350px'"
                         [status]="dataByLevelReqStatus[1].reqStatus">
                     </app-chart-bar-horizontal>
                 </div>
@@ -113,34 +123,65 @@
             </div>
         </div>
     </div>
-    <div class="col-12 col-lg-4 mt-4" [ngClass]="{'col-lg-6' : !levelPage.latam}">
+    <div class="col-12 col-lg-4 mt-4" [ngClass]="{'col-lg-6' : levelPage.country}">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4" *ngIf="!levelPage.retailer">
-                    {{ selectedTab2 === 1 ? 'Tráfico' : 'Conversiones' }} por categoría
-                </span>
-                <span class="h4" *ngIf="levelPage.retailer">Tráfico por categoría</span>
+                <ng-container *ngIf="!levelPage.retailer">
+                    <ng-container [ngSwitch]="selectedTab2">
+                        <span *ngSwitchCase="1" class="h4">Tráfico por categoría</span>
+                        <span *ngSwitchCase="2" class="h4">Conversiones por categoría</span>
+                        <span *ngSwitchCase="3" class="h4">Tasa de conversión por categoría</span>
+                    </ng-container>
+                </ng-container>
+
+                <span *ngIf="levelPage.retailer" class="h4">Tráfico por categoría</span>
             </div>
             <div class="card-body">
-                <app-chart-pie [data]="dataByLevel.category1" [status]="dataByLevelReqStatus[2].reqStatus"
-                    name="omnichat-chats-by-category-1" legendPosition="bottom">
-                </app-chart-pie>
+                <!-- for traffic and conversions selected tab -->
+                <ng-container *ngIf="selectedTab2 !== 3">
+                    <app-chart-pie [data]="dataByLevel.category1" [status]="dataByLevelReqStatus[2].reqStatus"
+                        name="omnichat-chats-by-category-1" legendPosition="bottom">
+                    </app-chart-pie>
+                </ng-container>
+
+                <!-- for conversion rate selected tab -->
+                <ng-container *ngIf="selectedTab2 === 3">
+                    <app-chart-bar-horizontal [data]="dataByLevel.category3" name="omnichat-chats-by-category-2"
+                        category="name" value="value" valueFormat="%" [truncateLabels]="true" [singleColorBars]="true"
+                        [status]="staticDataReqStatus[1].reqStatus">
+                    </app-chart-bar-horizontal>
+                </ng-container>
             </div>
         </div>
     </div>
 
-    <div class="col-12 col-lg-6 mt-4" *ngIf="levelPage.retailer">
-        <div class="card height-fluid">
-            <div class="card-header">
-                <span class="h4" *ngIf="levelPage.retailer">Conversiones por categoría</span>
-            </div>
-            <div class="card-body">
-                <app-chart-pie [data]="dataByLevel.category2" [status]="dataByLevelReqStatus[3].reqStatus"
-                    name="omnichat-chats-by-category-2" legendPosition="bottom">
-                </app-chart-pie>
+    <ng-container *ngIf="levelPage.retailer">
+        <div class="col-12 col-lg-4 mt-4">
+            <div class="card height-fluid">
+                <div class="card-header">
+                    <span class="h4">Conversiones por categoría</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-pie [data]="dataByLevel.category2" [status]="dataByLevelReqStatus[3].reqStatus"
+                        name="omnichat-chats-by-category-3" legendPosition="bottom">
+                    </app-chart-pie>
+                </div>
             </div>
         </div>
-    </div>
+        <div class="col-12 col-lg-4 mt-4">
+            <div class="card height-fluid">
+                <div class="card-header">
+                    <span class="h4">Tasa de conversión por categoría</span>
+                </div>
+                <div class="card-body">
+                    <app-chart-bar-horizontal [data]="dataByLevel.category3" name="omnichat-chats-by-category-3"
+                        category="name" value="value" valueFormat="%" [truncateLabels]="true" [singleColorBars]="true"
+                        [status]="staticDataReqStatus[1].reqStatus">
+                    </app-chart-bar-horizontal>
+                </div>
+            </div>
+        </div>
+    </ng-container>
 </div>
 <hr>
 

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -56,11 +56,11 @@
 </div>
 <hr>
 
-<!-- CHATS POR PAÍS, RETAILER & CATEGORIA -->
+<!-- CHARTS POR PAÍS, RETAILER & CATEGORIA -->
 <div class="row mt-5">
     <div class="col-12">
         <div class="mb-3">
-            <span class="h3">Tráfico y Conversiones</span>
+            <span class="h3">Tráfico, Conversiones y Tasa de conversión</span>
         </div>
     </div>
     <div class="col-12" *ngIf="!levelPage.retailer">


### PR DESCRIPTION
# Problem Description
- Is necessary to add 3 charts more on omnichat-wrapper component template to show conversion rate by country, retailer and category

# Features
- Show conversion rate charts in omnichat-wrapper component
- Add formatValue input to chart-bar-horizontal component

# Where this change will be used
- In LATAM/Contry/Retailer > Other tools > Omnichat section

# More details
- LATAM view:
![image](https://user-images.githubusercontent.com/38545126/125138157-c1dadf00-e0d3-11eb-8ce0-61a34499e563.png)

- Country view:
![image](https://user-images.githubusercontent.com/38545126/125138277-fc447c00-e0d3-11eb-81a4-142631ec060d.png)

- Retailer view:
![image](https://user-images.githubusercontent.com/38545126/125138314-0fefe280-e0d4-11eb-90ef-d8c53c62ab84.png)
