### PR TITLE
move period filter at the end of row in general-filters component

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.html
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.html
@@ -112,27 +112,6 @@
             </small>
         </div>
 
-        <!-- period -->
-        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
-            <div class="date-picker">
-                <span class="mb-1 h4">{{ 'filters.period' | translate }}</span>
-                <mat-form-field appearance="fill">
-                    <mat-date-range-input [rangePicker]="picker">
-                        <input matStartDate formControlName="startDate" [placeholder]="'filters.periodPh1' | translate">
-                        <input matEndDate formControlName="endDate" [placeholder]="'filters.periodPh2' | translate">
-                    </mat-date-range-input>
-                    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-                    <mat-date-range-picker #picker></mat-date-range-picker>
-                </mat-form-field>
-                <small class="text-danger" *ngIf="!startDate.valid && startDate.touched">
-                    {{ 'filters.periodError1' | translate }}
-                </small>
-                <small class="text-danger" *ngIf="!endDate.valid && endDate.touched">
-                    {{ 'filters.periodError2' | translate }}
-                </small>
-            </div>
-        </div>
-
         <!-- sector -->
         <div class="col-12 col-sm-6 mb-4" [hidden]="currentPage === 'tools'"
             [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
@@ -322,6 +301,27 @@
             <small class="text-danger" *ngIf="sources?.value?.length < 1 && sources.touched">
                 {{ 'filters.sourceError1' | translate }}
             </small>
+        </div>
+
+        <!-- period -->
+        <div class="col-12 col-sm-6 mb-4" [ngClass]="{'col-lg-3' : !isLatamSelected, 'col-lg-2' : isLatamSelected}">
+            <div class="date-picker">
+                <span class="mb-1 h4">{{ 'filters.period' | translate }}</span>
+                <mat-form-field appearance="fill">
+                    <mat-date-range-input [rangePicker]="picker">
+                        <input matStartDate formControlName="startDate" [placeholder]="'filters.periodPh1' | translate">
+                        <input matEndDate formControlName="endDate" [placeholder]="'filters.periodPh2' | translate">
+                    </mat-date-range-input>
+                    <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+                    <mat-date-range-picker #picker></mat-date-range-picker>
+                </mat-form-field>
+                <small class="text-danger" *ngIf="!startDate.valid && startDate.touched">
+                    {{ 'filters.periodError1' | translate }}
+                </small>
+                <small class="text-danger" *ngIf="!endDate.valid && endDate.touched">
+                    {{ 'filters.periodError2' | translate }}
+                </small>
+            </div>
         </div>
     </div>
 </form>


### PR DESCRIPTION
# Problem Description
- In order to organize filters and improve UX is necessary to move period filter at the end of row in general filters

# Features
- Move period filter at the end of row in general-filters component

# Where this change will be used
- In dashboard module at `/dashboard/*` path

# More details
![image](https://user-images.githubusercontent.com/38545126/125312910-56bf2180-e2fa-11eb-880f-3709d4ec28da.png)

