### PR TITLE
update kpi's implementation and add aup as sub kpi in revenue kpi cards

### DIFF
--- a/src/app/models/kpi.ts
+++ b/src/app/models/kpi.ts
@@ -1,0 +1,13 @@
+export class BaseKpiCard {
+    title: string;
+    name: string; // object property value within api response array
+    value: string | number;
+    format?: 'integer' | 'decimal' | 'percentage' | 'score'; // to apply a pipe or showing dynamic content from 'value' property (score is only for parent; for subKpis doesn't apply)
+    symbol?: string; // any symbol shown after value (e.g. 'USD') 
+}
+
+export class KpiCard extends BaseKpiCard {
+    icon?: string; // valid icon class (e.g. 'fas fa-hand-pointer')
+    iconBg?: string; // valid value of style property background-color
+    subKpis?: BaseKpiCard[]; // for only two subKpi's objects
+}

--- a/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-in-retail-wrapper/campaign-in-retail-wrapper.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
+import { KpiCard } from 'src/app/models/kpi';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
 import { FiltersStateService } from '../../services/filters-state.service';
 
@@ -13,91 +14,113 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
   @Input() requestInfoChange: Observable<boolean>;
 
   kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue'];
-  kpisLegends2 = ['ctr', 'users', 'cr', 'roas'];
-  kpis: any[] = [
+  kpisLegends2 = ['ctr', 'users', 'cr', 'roas', 'aup'];
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'inversión',
-      metricName: 'investment',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'inversión',
+      name: 'investment',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-wallet',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'clicks',
-      metricName: 'clicks',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'ctr',
-      subMetricName: 'ctr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'clicks',
+      name: 'clicks',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-hand-pointer',
-      iconBg: '#2f9998'
-
+      iconBg: '#2f9998',
+      subKpis: [
+        {
+          title: 'ctr',
+          name: 'ctr',
+          value: 0,
+          format: 'percentage'
+        }
+      ]
     },
     {
-      metricTitle: 'bounce rate',
-      metricName: 'bounce_rate',
-      metricValue: 0,
-      metricFormat: 'percentage',
-      subMetricTitle: 'usuarios',
-      subMetricName: 'users',
-      subMetricValue: 0,
-      subMetricFormat: 'integer',
+      title: 'bounce rate',
+      name: 'bounce_rate',
+      value: 0,
+      format: 'percentage',
       icon: 'fas fa-stopwatch',
-      iconBg: '#a77dcc'
+      iconBg: '#a77dcc',
+      subKpis: [
+        {
+          title: 'usuarios',
+          name: 'users',
+          value: 0,
+          format: 'integer'
+        }
+      ]
     },
     {
-      metricTitle: 'conversiones',
-      metricName: 'transactions',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'CR',
-      subMetricName: 'cr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'conversiones',
+      name: 'transactions',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-shopping-basket',
-      iconBg: '#f89934'
+      iconBg: '#f89934',
+      subKpis: [
+        {
+          title: 'CR',
+          name: 'cr',
+          value: 0,
+          format: 'percentage'
+        }
+      ]
     },
     {
-      metricTitle: 'revenue',
-      metricName: 'revenue',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
-      subMetricTitle: 'roas',
-      subMetricName: 'roas',
-      subMetricValue: 0,
-      subMetricFormat: 'decimals',
+      title: 'revenue',
+      name: 'revenue',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-hand-holding-usd',
-      iconBg: '#fbc001'
+      iconBg: '#fbc001',
+      subKpis: [
+        {
+          title: 'roas',
+          name: 'roas',
+          value: 0,
+          format: 'decimal',
+        },
+        {
+          title: 'aup',
+          name: 'aup',
+          value: 0,
+          format: 'decimal',
+          symbol: 'USD',
+        }
+      ]
     }
   ];
 
   metricBySectorInitial = [
     {
       id: 1,
-      metricTitle: 'search',
-      metricName: 'Search',
-      metricValue: 0,
+      title: 'search',
+      name: 'Search',
+      value: 0,
       icon: 'fab fa-google',
       iconBg: '#172b4d'
     },
     {
       id: 2,
-      metricTitle: 'marketing',
-      metricName: 'Marketing',
-      metricValue: 0,
+      title: 'marketing',
+      name: 'Marketing',
+      value: 0,
       icon: 'fas fa-bullhorn',
       iconBg: '#0096d6'
     },
     {
       id: 3,
-      metricTitle: 'ventas',
-      metricName: 'Ventas',
-      metricValue: 0,
+      title: 'ventas',
+      name: 'Ventas',
+      value: 0,
       icon: 'fas fa-store',
       iconBg: '#a77dcc'
     }
@@ -156,10 +179,14 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
 
         for (let i = 0; i < this.kpis.length; i++) {
           const baseObj = this.kpis[i];
-          baseObj.metricValue = kpis1[i]['value'];
+          baseObj.value = kpis1[i]['value'];
 
           if (i !== 0 && kpis2[i - 1]) {
-            baseObj.subMetricValue = kpis2[i - 1]['value'];
+            baseObj.subKpis[0].value = kpis2[i - 1]['value'];
+          }
+
+          if (this.kpis[i].name === 'revenue' && this.kpis[i].subKpis[1]) {
+            this.kpis[i].subKpis[1].value = resp.find(kpi => kpi.string === 'aup')?.value;
           }
 
         }
@@ -183,8 +210,8 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
 
     for (let item of this.metricBySectorInitial) {
       if (selectedSectorsIds.includes(item.id)) {
-        selectedSectorsRoas.push({ ...item, metricFormat: 'decimals' });
-        selectedSectorsCR.push({ ...item, metricFormat: 'percentage' });
+        selectedSectorsRoas.push({ ...item, format: 'decimal' });
+        selectedSectorsCR.push({ ...item, format: 'percentage' });
       }
     }
 
@@ -212,8 +239,8 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
           }
 
           for (let i = 0; i < this[arrayNameRef].length; i++) {
-            const baseObj = resp.find(item => item.name === this[arrayNameRef][i].metricName);
-            this[arrayNameRef][i].metricValue = baseObj.value;
+            const baseObj = resp.find(item => item.name === this[arrayNameRef][i].name);
+            this[arrayNameRef][i].value = baseObj.value;
           }
 
           this[reqStatusNameRef] = 2;
@@ -233,11 +260,11 @@ export class CampaignInRetailWrapperComponent implements OnInit, OnDestroy {
 
   clearStats(stats) {
     for (let stat of stats) {
-      stat.metricValue = 0;
+      stat.value = 0;
 
-      if (stat.subMetricValue) {
-        stat.subMetricValue = 0;
-      }
+      stat.subKpis?.forEach(item => {
+        item.value = 0;
+      });
     }
   }
 

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.html
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.html
@@ -1,36 +1,36 @@
 <div class="card card-stats mb-4 mb-xl-0" [style.height]="height">
     <div class="card-body">
-        <div class="metric-container" [ngClass]="{ 'with-icon': stat.icon, 'with-submetric' : stat.subMetricTitle}">
+        <div class="metric-container" [ngClass]="{ 'with-icon': stat.icon, 'with-submetric' : stat.subKpis}">
             <div class="metric-data">
                 <p class="card-title text-uppercase text-muted mb-0"
-                    [ngClass]="{'h4': !smallHeader, 'h5': smallHeader}">{{ stat.metricTitle }}</p>
+                    [ngClass]="{'h4': !smallHeader, 'h5': smallHeader}">{{ stat.title }}</p>
                 <!-- content -->
                 <p *ngIf="!loader" class="metric-details">
-                    <ng-container [ngSwitch]="stat.metricFormat">
-                        <div class="h3 font-weight-bold mb-0" [ngClass]="{'mr-1': stat.metricSymbol}">
+                    <ng-container [ngSwitch]="stat.format">
+                        <div class="h3 font-weight-bold mb-0" [ngClass]="{'mr-1': stat.symbol}">
                             <span *ngSwitchCase="'percentage'">
-                                {{ stat.metricValue | number : '1.2-2' }}%
+                                {{ stat.value | number : '1.2-2' }}%
                             </span>
-                            <span *ngSwitchCase="'decimals'">
-                                {{ stat.metricValue | number : '1.2-2' }}
+                            <span *ngSwitchCase="'decimal'">
+                                {{ stat.value | number : '1.2-2' }}
                             </span>
                             <span *ngSwitchCase="'integer'">
-                                {{ stat.metricValue | number : '1.0-0' }}
+                                {{ stat.value | number : '1.0-0' }}
                             </span>
 
-                            <app-star-raiting *ngSwitchCase="'score'" [value]="stat.metricValue"></app-star-raiting>
+                            <app-star-raiting *ngSwitchCase="'score'" [value]="stat.value"></app-star-raiting>
 
                             <span *ngSwitchDefault class="h3 font-weight-bold mb-0">
-                                {{ stat.metricValue }}
+                                {{ stat.value }}
                             </span>
                         </div>
                     </ng-container>
-                    <span class="h3 font-weight-bold mb-0">{{ stat.metricSymbol }}</span>
+                    <span class="h3 font-weight-bold mb-0">{{ stat.symbol }}</span>
                 </p>
 
                 <!-- loader -->
                 <ng-container *ngIf="loader">
-                    <div class="bar-loader"></div>
+                    <div class="bar-loader mt-1"></div>
                 </ng-container>
             </div>
             <div class="metric-icon" *ngIf="stat.icon">
@@ -39,32 +39,29 @@
                 </div>
             </div>
         </div>
-        <div class="submetric-container text-muted" *ngIf="stat.subMetricTitle">
-            <div class="submetric-data my-0 h5">
-                <span class="text-nowrap mr-2 text-muted text-uppercase">{{ stat.subMetricTitle }}</span>
-                <!-- content -->
-                <p *ngIf="!loader" class="submetric-details">
-                    <ng-container [ngSwitch]="stat.subMetricFormat">
-                        <span *ngSwitchCase="'percentage'" class="text-muted">
-                            {{ stat.subMetricValue | number : '1.2-2' }}%
-                        </span>
-                        <span *ngSwitchCase="'decimals'" class="text-muted">
-                            {{ stat.subMetricValue | number : '1.2-2' }}
-                        </span>
-                        <span *ngSwitchCase="'integer'" class="text-muted">
-                            {{ stat.subMetricValue | number : '1.0-0' }}
-                        </span>
-                        <span *ngSwitchDefault class="text-muted">
-                            {{ stat.subMetricValue }}
-                        </span>
-                    </ng-container>
-                    <span class="text-muted ml-2">{{ stat.subMetricSymbol }}</span>
-                </p>
+        <div class="submetrics-container text-muted" *ngIf="stat.subKpis">
+            <div class="submetrics-wrapper my-0 h5">
+                <div class="submetric-data" *ngFor="let subKip of stat.subKpis">
+                    <span class="text-nowrap mr-1 text-muted text-uppercase">{{ subKip.title }} </span>
 
-                <!-- loader -->
-                <ng-container *ngIf="loader">
-                    <div class="bar-loader"></div>
-                </ng-container>
+                    <p *ngIf="!loader" class="submetric-details">
+                        <ng-container [ngSwitch]="subKip.format">
+                            <span *ngSwitchCase="'percentage'" class="text-muted">
+                                {{ subKip.value | number : '1.2-2' }}%
+                            </span>
+                            <span *ngSwitchCase="'decimal'" class="text-muted">
+                                {{ subKip.value | number : '1.2-2' }}
+                            </span>
+                            <span *ngSwitchCase="'integer'" class="text-muted">
+                                {{ subKip.value | number : '1.0-0' }}
+                            </span>
+                            <span *ngSwitchDefault class="text-muted">
+                                {{ subKip.value }}
+                            </span>
+                        </ng-container>
+                        <span class="text-muted ml-1">{{ subKip.symbol }}</span>
+                    </p>
+                </div>
             </div>
         </div>
     </div>

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.scss
@@ -14,7 +14,9 @@
         padding: 1rem 1.5rem;
 
         @media screen and (min-width: 1200px) and (max-width: 1328px) {
+            padding: 1.3rem 1rem;
             grid-template-columns: 1fr;
+
             .icon {
                 display: none;
             }
@@ -31,7 +33,7 @@
             margin-bottom: 0;
         
             span {
-                display: inline-block;
+                display: block;
             }
         }
         
@@ -41,6 +43,13 @@
 
         &.with-submetric {
             overflow-y: auto;
+
+            .metric-details {
+                span {
+                    line-height: 12px;
+                    margin-top: 5px;
+                }
+            }
         }
 
         .icon {
@@ -49,25 +58,45 @@
         }
     }
     
-    .submetric-container {
+    .submetrics-container {
         background-color: #f0f0f0;
         bottom: 0;
         position: absolute;
         width: 100%;
+        display: flex;
     
-        .submetric-data {
+        .submetrics-wrapper {
             align-items: center;
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             height: 25px;
-            overflow: hidden;
+            justify-content: space-between;
             padding: 0.1rem 1.5rem;
-            text-overflow: ellipsis;
+            overflow-x: overlay;
+            width: 100%;
+
+            &::-webkit-scrollbar {
+                height: 3px;
+            }
+
+            @media screen and (min-width: 1200px) and (max-width: 1328px) {
+                padding: 0.1rem 1rem;
+            }
+        }
+
+        .submetric-data {
+            display: flex;
+            flex-direction: row;
+            align-items: center;
         }
 
         .submetric-details {
+            display: contents;
             font-size: 13px;
+            line-height: normal;
             margin-bottom: 0;
+            margin-top: 0;
+           
            
             span {
                 display: inline-block;

--- a/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
+++ b/src/app/modules/dashboard/components/card-stat/card-stat.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { KpiCard } from 'src/app/models/kpi';
 
 @Component({
   selector: 'app-card-stat',
@@ -7,7 +8,7 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class CardStatComponent implements OnInit {
 
-  @Input() stat;
+  @Input() stat: KpiCard;
   @Input() height: string = '120px' // valid css height property value
   @Input() loader: boolean;
   @Input() smallHeader: boolean = false;

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import * as moment from 'moment';
 import { Subscription } from 'rxjs';
+import { KpiCard } from 'src/app/models/kpi';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { TableItem } from '../generic-table/generic-table.component';
@@ -13,30 +13,30 @@ import { TableItem } from '../generic-table/generic-table.component';
 export class ConversionWrapperComponent implements OnInit {
 
   // kpis
-  kpis: any[] = [
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'cantidad',
-      metricName: 'quantity',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'cantidad',
+      name: 'quantity',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-chart-line',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'revenue',
-      metricName: 'revenue',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'revenue',
+      name: 'revenue',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-hand-holding-usd',
       iconBg: '#2f9998'
     },
     {
-      metricTitle: 'aup',
-      metricName: 'aup',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'aup',
+      name: 'aup',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-file-invoice-dollar',
       iconBg: '#a77dcc'
     }
@@ -138,8 +138,8 @@ export class ConversionWrapperComponent implements OnInit {
         }
 
         for (let i = 0; i < this.kpis.length; i++) {
-          const baseObj = resp.find(item => item.name === this.kpis[i].metricName);
-          this.kpis[i].metricValue = baseObj.value;
+          const baseObj = resp.find(item => item.name === this.kpis[i].name);
+          this.kpis[i].value = baseObj.value;
         }
 
         this.kpisReqStatus = 2;
@@ -189,7 +189,7 @@ export class ConversionWrapperComponent implements OnInit {
 
   clearKpis() {
     for (let kpi of this.kpis) {
-      kpi.metricValue = 0;
+      kpi.value = 0;
     }
   }
 

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
+import { KpiCard } from 'src/app/models/kpi';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { strTimeFormat } from 'src/app/tools/functions/time-format';
@@ -20,44 +21,44 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
   selectedTab1: number = 1; // traffic for countries (1) or retailers (2) selection -> chart-line-series
 
   // kpis
-  kpis: any[] = [
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'usuarios',
-      metricName: 'users',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'usuarios',
+      name: 'users',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-users',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'usuarios nuevos',
-      metricName: 'new_users',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'usuarios nuevos',
+      name: 'new_users',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-user-plus',
       iconBg: '#2f9998'
 
     },
     {
-      metricTitle: 'sesiones',
-      metricName: 'sessions',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'sesiones',
+      name: 'sessions',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-eye',
       iconBg: '#a77dcc'
     },
     {
-      metricTitle: 'páginas/sesión',
-      metricName: 'page_views_per_session',
-      metricValue: 0,
-      metricFormat: 'decimals',
+      title: 'páginas/sesión',
+      name: 'page_views_per_session',
+      value: 0,
+      format: 'decimal',
       icon: 'fas fa-file',
       iconBg: '#fbc001'
     },
     {
-      metricTitle: 'duración media de la sesión',
-      metricName: 'avg_session_duration',
-      metricValue: '00:00:00',
+      title: 'duración media de la sesión',
+      name: 'avg_session_duration',
+      value: '00:00:00',
       icon: 'fas fa-user-clock',
       iconBg: '#2B96D5'
     }
@@ -225,16 +226,16 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
     this.indexedService.getDataByMetric(this.levelPage.latam, 'kpis').subscribe(
       (resp: any[]) => {
         for (let i = 0; i < this.kpis.length; i++) {
-          const baseObj = resp.find(item => item.string === this.kpis[i].metricName);
+          const baseObj = resp.find(item => item.string === this.kpis[i].name);
 
           if (!baseObj) {
             break;
           }
 
-          if (this.kpis[i].metricName === 'avg_session_duration') {
-            this.kpis[i].metricValue = strTimeFormat(baseObj.value);
+          if (this.kpis[i].name === 'avg_session_duration') {
+            this.kpis[i].value = strTimeFormat(baseObj.value);
           } else {
-            this.kpis[i].metricValue = baseObj.value;
+            this.kpis[i].value = baseObj.value;
           }
         }
 
@@ -416,10 +417,10 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
 
   clearKpis() {
     for (let kpi of this.kpis) {
-      if (kpi.metricName === 'avg_session_duration') {
-        kpi.metricValue = '00:00:00';
+      if (kpi.name === 'avg_session_duration') {
+        kpi.value = '00:00:00';
       } else {
-        kpi.metricValue = 0;
+        kpi.value = 0;
       }
     }
   }

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -26,105 +26,118 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
   staticData = {
     kpis: [
       {
-        metricTitle: 'total chats',
-        metricName: 'total_chats',
-        metricValue: 0,
-        metricFormat: 'integer',
+        title: 'total chats',
+        name: 'total_chats',
+        value: 0,
+        format: 'integer',
         icon: 'fas fa-comment-dots',
         iconBg: '#172b4d'
       },
       {
-        metricTitle: 'promedio de chats por día',
-        metricName: 'average_chats_by_day',
-        metricValue: 0,
-        metricFormat: 'integer',
+        title: 'promedio de chats por día',
+        name: 'average_chats_by_day',
+        value: 0,
+        format: 'decimal',
         icon: 'far fa-chart-bar',
         iconBg: '#2f9998'
       },
       {
-        metricTitle: '% dedicado al cliente',
-        metricName: 'average_of_answer_time',
-        metricValue: 0,
-        metricFormat: 'percentage',
+        title: '% dedicado al cliente',
+        name: 'average_of_answer_time',
+        value: 0,
+        format: 'percentage',
         icon: 'fas fa-user-check',
         iconBg: '#a77dcc'
       },
       {
-        metricTitle: 'duración media de la sesión',
-        metricName: 'median_chat_duration',
-        metricValue: '00:00:00',
+        title: 'duración media de la sesión',
+        name: 'median_chat_duration',
+        value: '00:00:00',
         icon: 'fas fa-user-clock',
         iconBg: '#fbc001'
       },
       {
-        metricTitle: 'páginas por sesión',
-        metricName: 'pages_per_session',
-        metricValue: 0,
-        metricFormat: 'decimals',
+        title: 'páginas por sesión',
+        name: 'pages_per_session',
+        value: 0,
+        format: 'decimal',
         icon: 'fas fa-file',
         iconBg: '#2B96D5'
       },
       {
-        metricTitle: 'calificación del chat',
-        metricName: 'chat_score',
-        metricValue: 0,
-        metricFormat: 'score',
-        subMetricTitle: 'resultado',
-        subMetricName: 'chat_score',
-        subMetricValue: '0% - 0/5'
+        title: 'calificación del chat',
+        name: 'chat_score',
+        value: 0,
+        format: 'score',
+        subKpis: [
+          {
+            title: 'resultado',
+            name: 'chat_score',
+            value: '0% - 0/5'
+          }
+        ]
       },
       {
-        metricTitle: 'usuarios',
-        metricName: 'users',
-        metricValue: 0,
-        metricFormat: 'integer',
+        title: 'usuarios',
+        name: 'users',
+        value: 0,
+        format: 'integer',
         icon: 'fas fa-users',
         iconBg: '#2f9998'
       },
       {
-        metricTitle: 'conversiones',
-        metricName: 'conversions',
-        metricValue: 0,
-        metricFormat: 'integer',
+        title: 'conversiones',
+        name: 'conversions',
+        value: 0,
+        format: 'integer',
         icon: 'fas fa-shopping-basket',
         iconBg: '#a77dcc'
       },
       {
-        metricTitle: 'tasa de conversión',
-        metricName: 'conversion_rate',
-        metricValue: 0,
-        metricFormat: 'percentage',
+        title: 'tasa de conversión',
+        name: 'conversion_rate',
+        value: 0,
+        format: 'percentage',
         icon: 'fas fa-percentage',
         iconBg: '#fbc001'
       },
       {
-        metricTitle: 'revenue',
-        metricName: 'revenue',
-        metricValue: 0,
-        metricFormat: 'decimals',
-        metricSymbol: 'USD',
+        title: 'revenue',
+        name: 'revenue',
+        value: 0,
+        format: 'decimal',
+        symbol: 'USD',
         icon: 'fas fa-hand-holding-usd',
-        iconBg: '#2B96D5'
+        iconBg: '#2B96D5',
+        subKpis: [
+          {
+            title: 'aup',
+            name: 'aup',
+            value: 0,
+            format: 'decimal',
+            symbol: 'USD',
+          }
+        ]
       }
     ],
     conversionRateInitial: [
       {
-        metricTitle: 'ps',
-        metricName: 'PS',
-        metricValue: 0,
-        metricFormat: 'percentage'
+        title: 'ps',
+        name: 'PS',
+        value: 0,
+        format: 'percentage'
       },
       {
-        metricTitle: 'hw Print',
-        metricName: 'HW Print',
-        metricValue: 0,
-        metricFormat: 'percentage'
+        title: 'hw Print',
+        name: 'HW Print',
+        value: 0,
+        format: 'percentage'
       },
       {
-        metricTitle: 'Supplies',
-        metricName: 'Supplies',
-        metricValue: 0,
-        metricFormat: 'percentage',
+        title: 'Supplies',
+        name: 'Supplies',
+        value: 0,
+        format: 'percentage',
       }
     ],
     conversionRate: []
@@ -286,22 +299,28 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
 
           if (metric.name === 'kpis') {
             for (let i = 0; i < this.staticData.kpis.length; i++) {
-              const baseObj = resp.find(item => item.string === this.staticData.kpis[i].metricName);
+              const baseObj = resp.find(item => item.string === this.staticData.kpis[i].name);
 
               if (!baseObj) {
-                break;
+                continue;
               }
 
-              const metricName = this.staticData.kpis[i].metricName;
+              const metricName = this.staticData.kpis[i].name;
 
               if (metricName === 'median_chat_duration') {
-                this.staticData.kpis[i].metricValue = strTimeFormat(baseObj.value);
+                this.staticData.kpis[i].value = strTimeFormat(baseObj.value);
+
               } else if (metricName === 'chat_score') {
                 const percentageScore = ((baseObj.value * 100) / 5).toFixed(2);
-                this.staticData.kpis[i].metricValue = percentageScore;
-                this.staticData.kpis[i].subMetricValue = `${percentageScore}% - ${baseObj.value.toFixed(2)}/5`;
+                this.staticData.kpis[i].value = percentageScore;
+                this.staticData.kpis[i].subKpis[0].value = `${percentageScore}% - ${baseObj.value.toFixed(2)}/5`;
+
+              } else if (metricName === 'revenue') {
+                this.staticData.kpis[i].value = baseObj.value;
+                this.staticData.kpis[i].subKpis[0].value = resp.find(kpi => kpi.string === 'aup')?.value;
+
               } else {
-                this.staticData.kpis[i].metricValue = baseObj.value;
+                this.staticData.kpis[i].value = baseObj.value;
               }
             }
 
@@ -315,16 +334,16 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
             this.dataByLevel['category3'] = [];
 
             for (let i = 0; i < this.staticData.conversionRate.length; i++) {
-              const baseObj = resp.find(item => item.name === this.staticData.conversionRate[i].metricName);
+              const baseObj = resp.find(item => item.name === this.staticData.conversionRate[i].name);
               if (baseObj) {
-                this.staticData.conversionRate[i].metricValue = baseObj.value;
+                this.staticData.conversionRate[i].value = baseObj.value;
                 this.dataByLevel['category3'].push(baseObj);
               }
             }
 
             // show only selected categories in general filters
             const selectedCategories = this.filtersStateService.categories.map(item => item.name.toLowerCase());
-            this.staticData.conversionRate = this.staticData.conversionRate.filter(item => selectedCategories.includes(item.metricName.toLowerCase()));
+            this.staticData.conversionRate = this.staticData.conversionRate.filter(item => selectedCategories.includes(item.name.toLowerCase()));
           }
 
           reqStatusObj.reqStatus = 2;
@@ -539,20 +558,23 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
 
   clearKpis() {
     for (let kpi of this.staticData.kpis) {
-      if (kpi.metricName.includes('median_chat')) {
-        kpi.metricValue = '00:00:00';
-      } else if (kpi.metricName === 'chat_score') {
-        kpi.metricValue = '0';
-        kpi.subMetricValue = '0% - 0/5';
+      if (kpi.name.includes('median_chat')) {
+        kpi.value = '00:00:00';
+      } else if (kpi.name === 'chat_score') {
+        kpi.value = '0';
+        kpi.subKpis[0].value = '0% - 0/5';
       } else {
-        kpi.metricValue = 0;
+        kpi.value = 0;
+        kpi.subKpis?.forEach(item => {
+          item.value = 0;
+        });
       }
     }
   }
 
   clearConversionsRate() {
     for (let kpi of this.staticData.conversionRate) {
-      kpi.metricValue = 0;
+      kpi.value = 0;
     }
   }
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
+import { KpiCard } from 'src/app/models/kpi';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { FiltersStateService } from '../../services/filters-state.service';
@@ -22,69 +23,90 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   selectedTab4: number = 1; // sector (1) or category (2) or source (3) selection ->  chart-multiple-axes
 
   kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
-  kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
-  kpis: any[] = [
+  kpisLegends2 = ['ctr', 'users', 'cr', 'roas', 'aup'];
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'inversión',
-      metricName: 'investment',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'inversión',
+      name: 'investment',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-wallet',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'clicks',
-      metricName: 'clicks',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'ctr',
-      subMetricName: 'ctr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'clicks',
+      name: 'clicks',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-hand-pointer',
-      iconBg: '#2f9998'
-
+      iconBg: '#2f9998',
+      subKpis: [
+        {
+          title: 'ctr',
+          name: 'ctr',
+          value: 0,
+          format: 'percentage',
+        }
+      ]
     },
     {
-      metricTitle: 'bounce rate',
-      metricName: 'bounce_rate',
-      metricValue: 0,
-      metricFormat: 'percentage',
-      subMetricTitle: 'usuarios',
-      subMetricName: 'users',
-      subMetricValue: 0,
-      subMetricFormat: 'integer',
+      title: 'bounce rate',
+      name: 'bounce_rate',
+      value: 0,
+      format: 'percentage',
       icon: 'fas fa-stopwatch',
-      iconBg: '#a77dcc'
+      iconBg: '#a77dcc',
+      subKpis: [
+        {
+          title: 'usuarios',
+          name: 'users',
+          value: 0,
+          format: 'integer',
+        }
+      ]
     },
     {
-      metricTitle: 'conversiones',
-      metricName: 'transactions',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'CR',
-      subMetricName: 'cr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'conversiones',
+      name: 'transactions',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-shopping-basket',
-      iconBg: '#f89934'
+      iconBg: '#f89934',
+      subKpis: [
+        {
+          title: 'CR',
+          name: 'cr',
+          value: 0,
+          format: 'percentage',
+        }
+      ]
     },
     {
-      metricTitle: 'revenue',
-      metricName: 'revenue',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
-      subMetricTitle: 'roas',
-      subMetricName: 'roas',
-      subMetricValue: 0,
-      subMetricFormat: 'decimals',
+      title: 'revenue',
+      name: 'revenue',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-hand-holding-usd',
-      iconBg: '#fbc001'
+      iconBg: '#fbc001',
+      subKpis: [
+        {
+          title: 'roas',
+          name: 'roas',
+          value: 0,
+          format: 'decimal',
+        },
+        {
+          title: 'aup',
+          name: 'aup',
+          value: 0,
+          format: 'decimal',
+          symbol: 'USD',
+        }
+      ]
     }
   ];
-
 
   categoriesBySector: any[] = [];
 
@@ -216,13 +238,17 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
         for (let i = 0; i < this.kpis.length; i++) {
           const baseObj = this.kpis[i];
-          baseObj.metricValue = kpis1[i]['value'];
+          baseObj.value = kpis1[i]['value'];
 
           if (i !== 0 && kpis2[i - 1]) {
-            baseObj.subMetricValue = kpis2[i - 1]['value'];
+            baseObj.subKpis[0].value = kpis2[i - 1]['value'];
           }
 
+          if (this.kpis[i].name === 'revenue' && this.kpis[i].subKpis[1]) {
+            this.kpis[i].subKpis[1].value = resp.find(kpi => kpi.string === 'aup')?.value;
+          }
         }
+
         this.kpisReqStatus = 2;
       },
       error => {
@@ -356,11 +382,11 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   clearKpis() {
     for (let kpi of this.kpis) {
-      kpi.metricValue = 0;
+      kpi.value = 0;
 
-      if (kpi.subMetricValue) {
-        kpi.subMetricValue = 0;
-      }
+      kpi.subKpis?.forEach(item => {
+        item.value = 0;
+      });
     }
   }
 

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
+import { KpiCard } from 'src/app/models/kpi';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertMonthToString, convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { strTimeFormat } from 'src/app/tools/functions/time-format';
@@ -20,54 +21,63 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
   selectedTab2: number = 1; // traffic (1) or conversions (2) -> multiple charts
   selectedTab3: number = 1; // traffic (1) or conversions (2) -> audience
 
-  kpis: any[] = [
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'usuarios',
-      metricName: 'users',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'usuarios',
+      name: 'users',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-users',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'usuarios nuevos',
-      metricName: 'new_users',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'usuarios nuevos',
+      name: 'new_users',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-user-plus',
       iconBg: '#2f9998'
     },
     {
-      metricTitle: 'duración media de la sesión',
-      metricName: 'median_of_session_duration',
-      metricValue: '00:00:00',
+      title: 'duración media de la sesión',
+      name: 'median_of_session_duration',
+      value: '00:00:00',
       icon: 'fas fa-user-clock',
       iconBg: '#a77dcc'
     },
     {
-      metricTitle: 'conversiones',
-      metricName: 'conversions',
-      metricValue: 0,
-      metricFormat: 'integer',
+      title: 'conversiones',
+      name: 'conversions',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-shopping-cart',
       iconBg: '#f89934'
     },
     {
-      metricTitle: 'tasa de conversión',
-      metricName: 'conversion_rate',
-      metricValue: 0,
-      metricFormat: 'percentage',
+      title: 'tasa de conversión',
+      name: 'conversion_rate',
+      value: 0,
+      format: 'percentage',
       icon: 'fas fa-percentage',
       iconBg: '#fbc001'
     },
     {
-      metricTitle: 'revenue',
-      metricName: 'revenue',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'revenue',
+      name: 'revenue',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-hand-holding-usd',
-      iconBg: '#2B96D5'
+      iconBg: '#2B96D5',
+      subKpis: [
+        {
+          title: 'aup',
+          name: 'aup',
+          value: 0,
+          format: 'decimal',
+          symbol: 'USD',
+        }
+      ]
     }
   ];
   kpisReqStatus: number = 0;
@@ -142,16 +152,20 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
     this.pcSelectorService.getDataByMetric(this.levelPage.latam, 'kpis').subscribe(
       (resp: any[]) => {
         for (let i = 0; i < this.kpis.length; i++) {
-          const baseObj = resp.find(item => item.string === this.kpis[i].metricName);
+          const baseObj = resp.find(item => item.string === this.kpis[i].name);
 
           if (!baseObj) {
             continue;
           }
 
-          if (this.kpis[i].metricName === 'median_of_session_duration') {
-            this.kpis[i].metricValue = strTimeFormat(baseObj.value);
+          if (this.kpis[i].name === 'median_of_session_duration') {
+            this.kpis[i].value = strTimeFormat(baseObj.value);
           } else {
-            this.kpis[i].metricValue = baseObj.value;
+            this.kpis[i].value = baseObj.value;
+          }
+
+          if (this.kpis[i].name === 'revenue' && this.kpis[i].subKpis[0]) {
+            this.kpis[i].subKpis[0].value = resp.find(kpi => kpi.string === 'aup')?.value;
           }
         }
         this.kpisReqStatus = 2;
@@ -341,11 +355,15 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
 
   clearKpis() {
     for (let kpi of this.kpis) {
-      if (kpi.metricName === 'median_of_session_duration') {
-        kpi.metricValue = '00:00:00';
+      if (kpi.name === 'median_of_session_duration') {
+        kpi.value = '00:00:00';
       } else {
-        kpi.metricValue = 0;
+        kpi.value = 0;
       }
+
+      kpi.subKpis?.forEach(item => {
+        item.value = 0;
+      });
     }
   }
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -6,6 +6,7 @@ import { TableItem } from '../../components/generic-table/generic-table.componen
 import { TranslateService } from '@ngx-translate/core';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
+import { KpiCard } from 'src/app/models/kpi';
 
 @Component({
   selector: 'app-overview-latam',
@@ -23,67 +24,89 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   selectionList: number[] = [1];
 
-  kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue']
-  kpisLegends2 = ['ctr', 'users', 'cr', 'roas']
-  kpis: any[] = [
+  kpisLegends1 = ['investment', 'clicks', 'bounce_rate', 'transactions', 'revenue'] // main kpis
+  kpisLegends2 = ['ctr', 'users', 'cr', 'roas', 'aup']; // sub kpis
+  kpis: KpiCard[] = [
     {
-      metricTitle: 'inversión',
-      metricName: 'investment',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
+      title: 'inversión',
+      name: 'investment',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-wallet',
       iconBg: '#172b4d'
     },
     {
-      metricTitle: 'clicks',
-      metricName: 'clicks',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'ctr',
-      subMetricName: 'ctr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'clicks',
+      name: 'clicks',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-hand-pointer',
-      iconBg: '#2f9998'
-
+      iconBg: '#2f9998',
+      subKpis: [
+        {
+          title: 'ctr',
+          name: 'ctr',
+          value: 0,
+          format: 'percentage',
+        }
+      ]
     },
     {
-      metricTitle: 'bounce rate',
-      metricName: 'bounce_rate',
-      metricValue: 0,
-      metricFormat: 'percentage',
-      subMetricTitle: 'usuarios',
-      subMetricName: 'users',
-      subMetricValue: 0,
-      subMetricFormat: 'integer',
+      title: 'bounce rate',
+      name: 'bounce_rate',
+      value: 0,
+      format: 'percentage',
       icon: 'fas fa-stopwatch',
-      iconBg: '#a77dcc'
+      iconBg: '#a77dcc',
+      subKpis: [
+        {
+          title: 'usuarios',
+          name: 'users',
+          value: 0,
+          format: 'integer',
+        }
+      ]
     },
     {
-      metricTitle: 'conversiones',
-      metricName: 'transactions',
-      metricValue: 0,
-      metricFormat: 'integer',
-      subMetricTitle: 'CR',
-      subMetricName: 'cr',
-      subMetricValue: 0,
-      subMetricFormat: 'percentage',
+      title: 'conversiones',
+      name: 'transactions',
+      value: 0,
+      format: 'integer',
       icon: 'fas fa-shopping-basket',
-      iconBg: '#f89934'
+      iconBg: '#f89934',
+      subKpis: [
+        {
+          title: 'CR',
+          name: 'cr',
+          value: 0,
+          format: 'percentage',
+        }
+      ]
     },
     {
-      metricTitle: 'revenue',
-      metricName: 'revenue',
-      metricValue: 0,
-      metricFormat: 'decimals',
-      metricSymbol: 'USD',
-      subMetricTitle: 'roas',
-      subMetricName: 'roas',
-      subMetricValue: 0,
-      subMetricFormat: 'decimals',
+      title: 'revenue',
+      name: 'revenue',
+      value: 0,
+      format: 'decimal',
+      symbol: 'USD',
       icon: 'fas fa-hand-holding-usd',
-      iconBg: '#fbc001'
+      iconBg: '#fbc001',
+      subKpis: [
+        {
+          title: 'roas',
+          name: 'roas',
+          value: 0,
+          format: 'decimal',
+        },
+        {
+          title: 'aup',
+          name: 'aup',
+          value: 0,
+          format: 'decimal',
+          symbol: 'USD',
+        }
+      ]
     }
   ];
 
@@ -154,9 +177,9 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   ) {
 
     this.translateSub = translate.stream('overviewLatam').subscribe(() => {
-      this.kpis[0].metricTitle = this.translate.instant('kpis.investment');
-      this.kpis[2].subMetricTitle = this.translate.instant('general.users');
-      this.kpis[3].metricTitle = this.translate.instant('kpis.transactions');
+      this.kpis[0].title = this.translate.instant('kpis.investment');
+      this.kpis[2].subKpis[0].title = this.translate.instant('general.users');
+      this.kpis[3].title = this.translate.instant('kpis.transactions');
 
       this.topProductsColumns[0].title = this.translate.instant('general.ranking');
       this.topProductsColumns[1].title = this.translate.instant('general.product');
@@ -255,13 +278,17 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
         for (let i = 0; i < this.kpis.length; i++) {
           const baseObj = this.kpis[i];
-          baseObj.metricValue = kpis1[i]['value'];
+          baseObj.value = kpis1[i]['value'];
 
           if (i !== 0 && kpis2[i - 1]) {
-            baseObj.subMetricValue = kpis2[i - 1]['value'];
+            baseObj.subKpis[0].value = kpis2[i - 1]['value'];
           }
 
+          if (this.kpis[i].name === 'revenue' && this.kpis[i].subKpis[1]) {
+            baseObj.subKpis[1].value = resp.find(kpi => kpi.string === 'aup')?.value;
+          }
         }
+
         this.kpisReqStatus = 2;
       },
       error => {
@@ -414,11 +441,11 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   clearKpis() {
     for (let kpi of this.kpis) {
-      kpi.metricValue = 0;
+      kpi.value = 0;
 
-      if (kpi.subMetricValue) {
-        kpi.subMetricValue = 0;
-      }
+      kpi.subKpis?.forEach(item => {
+        item.value = 0;
+      });
     }
   }
 


### PR DESCRIPTION
# Problem Description
- When wanting to add AUP as a subkpi within all Revenue cards i's defined that a kpi card can have up to two sub kpis, due to this, to standardize and document the code a class was created to define these objects, therefore, it had to adapt the implementation in all components where kpis are shown.

# Features
- Add kpi's class to app models
- Update card-stat component template
- Adapt the following components:
   - overview-latam
   - overview-wrapper
   - campaign-in-retail-wrapper
   - conversion-wrapper
   - indexed-wrapper
   - omnichat-wrapper
   - pc-selector-wrapper

# Where this change will be used
- Where card of kpis will be use in dashboard component at `/dashboard/*`

# More details
![image](https://user-images.githubusercontent.com/38545126/125351078-3eb0c780-e325-11eb-94de-100787be5ace.png)
![image](https://user-images.githubusercontent.com/38545126/125351117-4cfee380-e325-11eb-96d5-708e457da1b9.png)

