### PR TITLE
use selected sources in overview-wrapper component for country view

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -262,7 +262,7 @@ export class GeneralFiltersComponent implements OnInit {
     this.prevPeriod = this.defaultPeriod;
 
     this.filtersStateService.periodInitial = this.defaultPeriod;
-    this.filtersStateService.sourcesInitial = this.sources.value;
+    this.filtersStateService.sourcesInitial = [...this.sourceList];
 
     this.formSub = this.form.valueChanges
       .pipe(debounceTime(5))

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -154,7 +154,9 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     if (this.filtersStateService.period && this.filtersStateService.sectors && this.filtersStateService.categories) {
       // removed line and used it from country & retailer components (init)
       // this.filtersStateService.restoreFilters();
-      this.getAllData();
+      if ((this.selectedType === 'country' && this.filtersStateService.sources) || this.selectedType === 'retailer') {
+        this.getAllData();
+      }
     }
 
     this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
@@ -165,13 +167,21 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   getAllData(preserveSelectedTabs?: boolean) {
     this.selectedSectors = this.filtersStateService.sectors;
     this.selectedCategories = this.filtersStateService.categories;
-    this.selectedSources = [
-      { id: 'google', name: 'Google' },
-      { id: 'social', name: 'Social' },
-      { id: 'email', name: 'Email' },
-      { id: 'display', name: 'Display' },
-      { id: 'others', name: 'Otros' }
-    ]
+
+    // for country view selected sources in general filters are used
+    if (this.selectedType === 'country') {
+      this.selectedSources = this.filtersStateService.sources;
+
+    } else if (this.selectedType === 'retailer') {
+      // for retailer view all valid sources are used because sources filter isn't shown 
+      this.selectedSources = [
+        { id: 'google', name: 'Google' },
+        { id: 'social', name: 'Social' },
+        { id: 'email', name: 'Email' },
+        { id: 'display', name: 'Display' },
+        { id: 'others', name: 'Otros' }
+      ];
+    }
 
     let selectedSectorHM;
     let demographicMetric;


### PR DESCRIPTION
# Problem Description
- After adding sources to general filters for country overview is necessary to use selected sources in overview-wrapper component in order to preserve dynamic tabs and keep using default values for retailer view (because for retailer view sources filter isn't shown in general filters)

# Features
- Use selected sources in overview-wrapper component for country view
- Add validation to avoid call getAllData method when country filters are incomplete

# Bug Fixes
- Fix sourceInitial assignment in general-filters component

# More details
![image](https://user-images.githubusercontent.com/38545126/125490055-2233e9e7-4114-4512-83f2-5cc4a2b2f85b.png)

