### PR TITLE
add dynamic section tabs for other-tools component

### DIFF
--- a/src/app/models/access-levels.ts
+++ b/src/app/models/access-levels.ts
@@ -1,0 +1,23 @@
+export class MainRegion {
+    id?: number;
+    name: string
+}
+
+export class Country {
+    id: number;
+    name: string;
+    region: string;
+    indexed: boolean;
+    omnichat: boolean;
+    pc_selector: boolean;
+}
+
+export class Retailer {
+    id: number;
+    name: string;
+    country_id: number;
+    country_code: string;
+    indexed: boolean;
+    omnichat: boolean;
+    pc_selector: boolean;
+}

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -141,7 +141,7 @@ export class GeneralFiltersComponent implements OnInit {
 
     await this.getSectors();
     await this.getCategories();
-    this.userService.user.role_name === 'retailer' && this.getCampaigns();
+    (this.userService.user.role_name === 'retailer' && this.retailerID) && this.getCampaigns();
 
     const selectedCountry = this.appStateService.selectedCountry;
     const selectedRetailer = this.appStateService.selectedRetailer;
@@ -177,6 +177,10 @@ export class GeneralFiltersComponent implements OnInit {
       if (this.retailerID && this.currentPage === 'overview') {
         this.getCampaigns();
         this.campsGetByRetailerChange = true;
+      }
+
+      if ((this.retailerID && this.userService.user.role_name === 'retailer')) {
+        this.getCampaigns();
       }
     });
 

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -52,6 +52,8 @@ export class GeneralFiltersComponent implements OnInit {
     { id: 'social', name: 'Social' },
     { id: 'email', name: 'Email' },
     { id: 'display', name: 'Display' },
+    { id: 'banner', name: 'Banner' },
+    { id: 'institucional', name: 'Institucional' },
     { id: 'others', name: 'Otros' }
   ];
 

--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -778,18 +778,18 @@ export class GeneralFiltersComponent implements OnInit {
    * @param [manualTriggered] change made by "filter" button click triggered manually by the user
    */
   applyFilters(manualTriggered?: boolean) {
-    this.filtersStateService.selectPeriod({ startDate: this.startDate.value._d, endDate: this.endDate.value._d });
-    this.filtersStateService.selectSectors(this.sectors.value.filter(item => item.id));
-    this.filtersStateService.selectCategories(this.categories.value.filter(item => item.id));
-    this.filtersStateService.selectSources(this.sources.value.filter(item => item.id));
+    this.filtersStateService.selectPeriod({ startDate: this.startDate?.value._d, endDate: this.endDate?.value._d });
+    this.filtersStateService.selectSectors(this.sectors?.value.filter(item => item.id));
+    this.filtersStateService.selectCategories(this.categories?.value.filter(item => item.id));
+    this.filtersStateService.selectSources(this.sources?.value.filter(item => item.id));
 
     if (this.isLatamSelected) {
-      this.filtersStateService.selectCountries(this.countries.value.filter(item => item.id));
-      this.filtersStateService.selectRetailers(this.retailers.value.filter(item => item.id));
+      this.filtersStateService.selectCountries(this.countries?.value.filter(item => item.id));
+      this.filtersStateService.selectRetailers(this.retailers?.value.filter(item => item.id));
     }
 
     const areAllCampsSelected = this.areAllCampaignsSelected();
-    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns.value.filter(item => item.id));
+    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns?.value.filter(item => item.id));
 
     this.filtersStateService.filtersChange(manualTriggered);
   }

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -16,7 +16,7 @@ import { IndexedService } from '../../services/indexed.service';
 export class IndexedWrapperComponent implements OnInit, OnDestroy {
   @Input() levelPage: any // latam || country || retailer;
   @Input() levelPageChange: Observable<object>;
-  @Input() requestInfoChange: Observable<boolean>;
+  @Input() requestInfoChange: Observable<'indexed' | 'omnichat' | 'pc-selector'>;
 
   selectedTab1: number = 1; // traffic for countries (1) or retailers (2) selection -> chart-line-series
 
@@ -199,8 +199,10 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
     // validate if filters are already loaded
     this.filtersAreReady() && this.getAllData();
 
-    this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
-      this.filtersAreReady() && this.getAllData();
+    this.requestInfoSub = this.requestInfoChange.subscribe((selectedSection: 'indexed' | 'omnichat' | 'pc-selector') => {
+      if (selectedSection === 'indexed' && this.filtersAreReady()) {
+        this.getAllData();
+      }
     });
 
     this.levelPageSub = this.levelPageChange.subscribe((levelChange: object) => {

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -15,7 +15,7 @@ import { TranslateService } from '@ngx-translate/core';
 })
 export class OmnichatWrapperComponent implements OnInit, OnDestroy {
   @Input() levelPage: any // latam || country || retailer;
-  @Input() requestInfoChange: Observable<boolean>;
+  @Input() requestInfoChange: Observable<'indexed' | 'omnichat' | 'pc-selector'>;
 
   selectedTab1: number = 1; // users vs conversions (1) or revenue vs aup (2) selection -> chart-multiple-axes
   selectedTab2: number = 1; // traffic (1) or conversions (2) -> countries, retailers and categories charts
@@ -255,8 +255,10 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     // validate if filters are already loaded
     this.filtersAreReady() && this.getAllData();
 
-    this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
-      this.filtersAreReady() && this.getAllData();
+    this.requestInfoSub = this.requestInfoChange.subscribe((selectedSection: 'indexed' | 'omnichat' | 'pc-selector') => {
+      if (selectedSection === 'omnichat' && this.filtersAreReady()) {
+        this.getAllData();
+      }
     });
   }
 

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -179,6 +179,8 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         { id: 'social', name: 'Social' },
         { id: 'email', name: 'Email' },
         { id: 'display', name: 'Display' },
+        { id: 'banner', name: 'Banner' },
+        { id: 'institucional', name: 'Institucional' },
         { id: 'others', name: 'Otros' }
       ];
     }

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -15,7 +15,7 @@ import { PcSelectorService } from '../../services/pc-selector.service';
 })
 export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
   @Input() levelPage: any // latam || country || retailer;
-  @Input() requestInfoChange: Observable<boolean>;
+  @Input() requestInfoChange: Observable<'indexed' | 'omnichat' | 'pc-selector'>;
 
   selectedTab1: number = 1; // users vs conversions (1) or revenue vs aup (2) selection -> chart-multiple-axes
   selectedTab2: number = 1; // traffic (1) or conversions (2) -> multiple charts
@@ -127,8 +127,10 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
     // validate if filters are already loaded
     this.filtersAreReady() && this.getAllData();
 
-    this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
-      this.filtersAreReady() && this.getAllData();
+    this.requestInfoSub = this.requestInfoChange.subscribe((selectedSection: 'indexed' | 'omnichat' | 'pc-selector') => {
+      if (selectedSection === 'pc-selector' && this.filtersAreReady()) {
+        this.getAllData();
+      }
     });
   }
 

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -3,21 +3,21 @@
         <li class="nav-item"
             *ngIf="levelPage.latam || (levelPage.country && country?.indexed) || (levelPage.retailer && retailer?.indexed)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}"
-                (click)="emitSelectedSection('indexed')">
+                (click)="sectionChange('indexed')">
                 <span class="h2 py-2 ml-3 mr-3">Indexado</span>
             </a>
         </li>
         <li class="nav-item"
             *ngIf="levelPage.latam || (levelPage.country && country?.omnichat) || (levelPage.retailer && retailer?.omnichat)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}"
-                (click)="emitSelectedSection('omnichat')">
+                (click)="sectionChange('omnichat')">
                 <span class="h2 py-2 ml-3 mr-3">OmniChat</span>
             </a>
         </li>
         <li class="nav-item"
             *ngIf="levelPage.latam || (levelPage.country && country?.pc_selector) || (levelPage.retailer && retailer?.pc_selector)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}"
-                (click)="emitSelectedSection('pc-selector')">
+                (click)="sectionChange('pc-selector')">
                 <span class="h2 py-2 ml-3 mr-3">PC Selector</span>
             </a>
         </li>

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.html
@@ -1,18 +1,21 @@
 <div class="main-container mt-4">
     <ul class="nav nav-tabs mb-4">
-        <li class="nav-item">
+        <li class="nav-item"
+            *ngIf="levelPage.latam || (levelPage.country && country?.indexed) || (levelPage.retailer && retailer?.indexed)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 1}"
                 (click)="emitSelectedSection('indexed')">
                 <span class="h2 py-2 ml-3 mr-3">Indexado</span>
             </a>
         </li>
-        <li class="nav-item">
+        <li class="nav-item"
+            *ngIf="levelPage.latam || (levelPage.country && country?.omnichat) || (levelPage.retailer && retailer?.omnichat)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 2}"
                 (click)="emitSelectedSection('omnichat')">
                 <span class="h2 py-2 ml-3 mr-3">OmniChat</span>
             </a>
         </li>
-        <li class="nav-item" *ngIf="levelPage.latam || (countryID === 9 && !retailerID) || retailerID === 29">
+        <li class="nav-item"
+            *ngIf="levelPage.latam || (levelPage.country && country?.pc_selector) || (levelPage.retailer && retailer?.pc_selector)">
             <a class="nav-link" [ngClass]="{'active bg-light' : activeTabView === 3}"
                 (click)="emitSelectedSection('pc-selector')">
                 <span class="h2 py-2 ml-3 mr-3">PC Selector</span>

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -112,7 +112,7 @@ export class OverviewService {
   // *** filters ***
   getCampaigns(period?: any, sectorsStrList?: string, categoriesStrList?: string) {
     if (!this.retailerID) {
-      return throwError('[overview.service]: not countryID provided');
+      return throwError('[overview.service]: not retailerID provided');
     }
 
     const periodQParams = period ? `start_date=${moment(period.startDate).format('YYYY-MM-DD')}&end_date=${moment(period.endDate).format('YYYY-MM-DD')}` : '';

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+import { MainRegion, Country, Retailer } from '../models/access-levels';
 
 @Injectable({
   providedIn: 'root'
@@ -11,19 +12,19 @@ export class AppStateService {
   sidebarData$ = this.sidebarSource.asObservable();
 
   // selected main region as LATAM
-  private mainRegionSource = new Subject<any>();
+  private mainRegionSource = new Subject<MainRegion>();
   selectedMainRegion$ = this.mainRegionSource.asObservable();
-  selectedMainRegion;
+  selectedMainRegion: MainRegion;
 
   // selected country
-  private countrySource = new Subject<any>();
+  private countrySource = new Subject<Country>();
   selectedCountry$ = this.countrySource.asObservable();
-  selectedCountry;
+  selectedCountry: Country;
 
   // selected retailer
-  private retailerSource = new Subject<any>();
+  private retailerSource = new Subject<Retailer>();
   selectedRetailer$ = this.retailerSource.asObservable();
-  selectedRetailer;
+  selectedRetailer: Retailer;
 
   // selected language
   private langSource = new Subject<string>();
@@ -32,7 +33,7 @@ export class AppStateService {
 
   constructor() { }
 
-  selectMainRegion(mainRegion?) {
+  selectMainRegion(mainRegion?: MainRegion) {
     if (mainRegion) {
       this.mainRegionSource.next(mainRegion);
       this.selectedMainRegion = mainRegion;
@@ -42,7 +43,7 @@ export class AppStateService {
     }
   }
 
-  selectCountry(country?) {
+  selectCountry(country?: Country) {
     if (country) {
       this.countrySource.next(country);
       this.selectedCountry = country;
@@ -52,7 +53,7 @@ export class AppStateService {
     }
   }
 
-  selectRetailer(retailer?) {
+  selectRetailer(retailer?: Retailer) {
     if (retailer) {
       this.retailerSource.next(retailer);
       this.selectedRetailer = retailer;


### PR DESCRIPTION
# Problem Description
- Is necessary show dynamic tabs in LATAM/Country/Retailer > Other tools in order to show these tabs based on item selected data returned by the API (Country, Retailer) or show all tabs for LATAM

# Features
- Add access levels classes (MainRegion, Country, Retailer) in app models
- Use access levels classes in app-state service
- Update sidebar component to emit selected item data
- Use selected item properties to show dynamic tabs in other-tools component
- Other implicatios:
   - Update requestInfoChange observable in indexed-wrapper component
   - Update requestInfoChange observable in omnichat-wrapper component
   - Update requestInfoChange observable in pc-selector-wrapper component

# Bug Fixes
- Fix error to call getCampaigns method in general-filters component
- Add variables validations to general-filters component
- Fix error msg in overview service

# Where this change will be used
- In LATAM/Contry/Retailer > Other tools at `/dashboard/tools` path

# More details
- E.g. for retailer 
![image](https://user-images.githubusercontent.com/38545126/125655478-fb1dfb98-aff9-429e-95b7-7574a1b35c86.png)

- E.g for country
![image](https://user-images.githubusercontent.com/38545126/125655636-31e386bf-2f7d-49cf-be48-1e06876b65f2.png)

