### PR TITLE
preserve or clear selected tabs in other tools components

### DIFF
--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -16,7 +16,10 @@ import { IndexedService } from '../../services/indexed.service';
 export class IndexedWrapperComponent implements OnInit, OnDestroy {
   @Input() levelPage: any // latam || country || retailer;
   @Input() levelPageChange: Observable<object>;
-  @Input() requestInfoChange: Observable<'indexed' | 'omnichat' | 'pc-selector'>;
+  @Input() requestInfoChange: Observable<{
+    manualChange: boolean, // true if user clicks 'Filter' button of general-filters component; useful to preserve or clear selected tabs of active section template
+    selectedSection: 'indexed' | 'omnichat' | 'pc-selector'
+  }>;
 
   selectedTab1: number = 1; // traffic for countries (1) or retailers (2) selection -> chart-line-series
 
@@ -64,51 +67,6 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
     }
   ];
   kpisReqStatus = 0;
-
-  // exits rate and pages viewed
-  exitsAndPagesViews = [
-    {
-      name: 'Porcentaje de salidas',
-      serie: [
-        { date: '2021-06-02', value: 75 },
-        { date: '2021-06-03', value: 87 },
-        { date: '2021-06-04', value: 70 },
-        { date: '2021-06-05', value: 86 },
-        { date: '2021-06-06', value: 70 },
-        { date: '2021-06-07', value: 75 },
-        { date: '2021-06-08', value: 82 },
-        { date: '2021-06-09', value: 70 },
-        { date: '2021-06-10', value: 75 },
-        { date: '2021-06-11', value: 78 },
-        { date: '2021-06-12', value: 80 },
-        { date: '2021-06-13', value: 83 },
-        { date: '2021-06-14', value: 70 },
-        { date: '2021-06-15', value: 76 },
-        { date: '2021-06-16', value: 74 }
-      ],
-      valueFormat: '%'
-    },
-    {
-      name: 'Número de páginas vistas',
-      serie: [
-        { date: '2021-06-02', value: 7 },
-        { date: '2021-06-03', value: 5 },
-        { date: '2021-06-04', value: 4 },
-        { date: '2021-06-05', value: 2 },
-        { date: '2021-06-06', value: 3 },
-        { date: '2021-06-07', value: 5 },
-        { date: '2021-06-08', value: 4 },
-        { date: '2021-06-09', value: 3 },
-        { date: '2021-06-10', value: 7 },
-        { date: '2021-06-11', value: 6 },
-        { date: '2021-06-12', value: 5 },
-        { date: '2021-06-13', value: 2 },
-        { date: '2021-06-14', value: 3 },
-        { date: '2021-06-15', value: 1 },
-        { date: '2021-06-16', value: 6 }
-      ]
-    }
-  ]
 
   // countries or retailers chart
   counOrRet = {};
@@ -195,11 +153,13 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-
     // validate if filters are already loaded
     this.filtersAreReady() && this.getAllData();
 
-    this.requestInfoSub = this.requestInfoChange.subscribe((selectedSection: 'indexed' | 'omnichat' | 'pc-selector') => {
+    this.requestInfoSub = this.requestInfoChange.subscribe(({ manualChange, selectedSection }) => {
+      // manualChange isn't useful in this component because there isn't tabs to preserve or clear selection
+      // the only tab only appears in LATAM view level and it isn't necessary to clear the selection 
+      // when the view changes to country or retailer since it isn't shown at these levels
       if (selectedSection === 'indexed' && this.filtersAreReady()) {
         this.getAllData();
       }

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -15,7 +15,11 @@ import { PcSelectorService } from '../../services/pc-selector.service';
 })
 export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
   @Input() levelPage: any // latam || country || retailer;
-  @Input() requestInfoChange: Observable<'indexed' | 'omnichat' | 'pc-selector'>;
+  @Input() requestInfoChange: Observable<{
+    manualChange: boolean, // true if user clicks 'Filter' button of general-filters component; useful to preserve or clear selected tabs of active section template
+    selectedSection: 'indexed' | 'omnichat' | 'pc-selector'
+  }>;
+
 
   selectedTab1: number = 1; // users vs conversions (1) or revenue vs aup (2) selection -> chart-multiple-axes
   selectedTab2: number = 1; // traffic (1) or conversions (2) -> multiple charts
@@ -127,18 +131,31 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
     // validate if filters are already loaded
     this.filtersAreReady() && this.getAllData();
 
-    this.requestInfoSub = this.requestInfoChange.subscribe((selectedSection: 'indexed' | 'omnichat' | 'pc-selector') => {
+    this.requestInfoSub = this.requestInfoChange.subscribe(({ manualChange, selectedSection }) => {
       if (selectedSection === 'pc-selector' && this.filtersAreReady()) {
-        this.getAllData();
+        this.getAllData(manualChange);
       }
     });
   }
 
-  getAllData() {
-    let metricTab1 = this.selectedTab1 === 1 ? 'conversions' : 'revenue-vs-aup';
-    let subMetricTab1 = this.selectedTab1 === 1 && 'users';
-    let metricTab2 = this.selectedTab2 === 1 ? 'traffic' : 'conversions';
-    let metricTab3 = this.selectedTab3 === 1 ? 'traffic' : 'conversions';
+  getAllData(preserveSelectedTabs?: boolean) {
+    let metricTab1;
+    let subMetricTab1;
+    let metricTab2;
+    let metricTab3;
+
+    if (!preserveSelectedTabs) {
+      metricTab1 = 'conversions';
+      subMetricTab1 = 'users';
+      metricTab2 = 'traffic';
+      metricTab3 = 'traffic';
+
+    } else {
+      metricTab1 = this.selectedTab1 === 1 ? 'conversions' : 'revenue-vs-aup';
+      subMetricTab1 = this.selectedTab1 === 1 && 'users';
+      metricTab2 = this.selectedTab2 === 1 ? 'traffic' : 'conversions';
+      metricTab3 = this.selectedTab3 === 1 ? 'traffic' : 'conversions';
+    }
 
     this.getKpis();
     this.getUsersOrRevenue(metricTab1, subMetricTab1);

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -29,7 +29,10 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
 
   activeTabView: number;
 
-  private requestInfoSource = new Subject<'indexed' | 'omnichat' | 'pc-selector'>();
+  private requestInfoSource = new Subject<{
+    manualChange: boolean, // true if user clicks 'Filter' button of general-filters component; useful to preserve or clear selected tabs of active section template
+    selectedSection: 'indexed' | 'omnichat' | 'pc-selector'
+  }>();
   requestInfoChange$ = this.requestInfoSource.asObservable();
 
   private levelPageSource = new Subject<object>();
@@ -75,7 +78,7 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
       }
     });
 
-    // catch if its country  view
+    // catch if its country view
     this.countrySub = this.appStateService.selectedCountry$.subscribe(country => {
       if (country?.id !== this.country?.id) {
         this.country = country;
@@ -105,7 +108,7 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
 
     // catch a change in general filters
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
-      this.emitRequestInfo();
+      this.emitRequestInfo(manualChange);
     });
   }
 
@@ -166,10 +169,10 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
     }
   }
 
-  emitRequestInfo() {
+  emitRequestInfo(manualChange: boolean) {
     if (this.country?.id || this.retailer?.id || this.levelPage?.latam) {
       let selectedSection: any = this.activeTabView === 1 ? 'indexed' : this.activeTabView === 2 ? 'omnichat' : 'pc-selector';
-      this.requestInfoSource.next(selectedSection);
+      this.requestInfoSource.next({ manualChange, selectedSection });
 
     } else {
       // Since this component is reused in the 3 levels (latam, country or retailer) 
@@ -183,7 +186,7 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
       // the tests that were made were never repeated more than once, for what so far is the most feasible option.
 
       setTimeout(() => {
-        this.emitRequestInfo();
+        this.emitRequestInfo(manualChange);
       }, 500);
     }
   }


### PR DESCRIPTION
# Problem Description
- For other tools components (Indexed, Omnichat and PC Selector) is necessary to preserve selected tabs after click on 'Filter' button of general filters and clear the selection after a new selection (LATAM, Country or Retailer) from sidebar

# Features
- Emit filter manual change from other-tools components
- Preserve or clear selected tabs in indexed-wrapper component
- Preserve or clear selected tabs in omnichat-wrapper component
- Preserve or clear selected tabs in pc-selector component

- Others:
  - Remove unused variable in indexed-wrapper component

# Where this change will be used
- In LATAM/Country/Retailer > Other tools > Indexed/OmniChat/PC Selector at `/dashboard/tools` path
