### PR TITLE
avoid repeated requests before destroying the component when redirecting to a new route 

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -209,6 +209,9 @@ export class SidebarComponent implements OnInit, OnDestroy {
   }
 
   async getPrevSelection() {
+    const baseUrl = this.router.url.split('?')[0];
+    this.appStateService.selectedPage = this.getPageUsingRoute(baseUrl);
+
     const params = this.route.snapshot.queryParams;
 
     const mainRegion = params['main-region'];
@@ -275,8 +278,8 @@ export class SidebarComponent implements OnInit, OnDestroy {
       this.selectedItemL1.submenuOpen = true;
       this.selectedItemL2 = this.getSelectionUsingRoute(this.selectedItemL1);
       this.appStateService.selectMainRegion({ id: this.selectedItemL1.id, name: this.selectedItemL1.title });
-    }
-    else if (retailer) {
+
+    } else if (retailer) {
       const item = this.menuItems.find(item => item.title.toLowerCase() === retailer.replaceAll('-', ' '));
       this.selectedItemL1 = item;
       this.appStateService.selectRetailer(this.createSelectedItem(this.selectedItemL1, 'retailer'));
@@ -287,6 +290,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
         this.selectedItemL1.submenuOpen = true;
         this.selectedItemL2 = itemL2;
       }
+
     } else {
       const item = this.menuItems.find(item => item.path == this.router.url);
       if (item) {
@@ -315,6 +319,31 @@ export class SidebarComponent implements OnInit, OnDestroy {
     const currentPath = this.router.url.split('?')[0];
     const selectedSubItem = selectedItem.submenu.find(item => item.path === currentPath);
     return selectedSubItem;
+  }
+
+  getPageUsingRoute(url: string): 'overview' | 'other-tools' | 'other' {
+    const path = url.replace('/dashboard/', '');
+
+    let page;
+
+    switch (path) {
+      case 'main-region':
+      case 'country':
+      case 'retailer':
+        page = 'overview';
+        break;
+
+      case 'tools':
+        page = 'other-tools';
+        break
+
+      default:
+        page = 'others';
+        break;
+    }
+
+    console.log('page', page)
+    return page;
   }
 
   getAvailableCountries() {
@@ -613,6 +642,10 @@ export class SidebarComponent implements OnInit, OnDestroy {
   }
 
   emitNewSelection(item) {
+    if (item?.path) {
+      this.appStateService.selectedPage = this.getPageUsingRoute(item?.path);
+    }
+
     switch (item.paramName) {
       case 'main-region':
         if (this.selectedItemL2.param && item.param === 'latam' && this.selectedMainRegionName !== this.selectedItemL1.title) {

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
 import { KpiCard } from 'src/app/models/kpi';
+import { AppStateService } from 'src/app/services/app-state.service';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { FiltersStateService } from '../../services/filters-state.service';
@@ -146,6 +147,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   constructor(
     private filtersStateService: FiltersStateService,
+    private appStateService: AppStateService,
     private overviewService: OverviewService,
     private translate: TranslateService
   ) { }
@@ -160,7 +162,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     }
 
     this.requestInfoSub = this.requestInfoChange.subscribe((manualChange: boolean) => {
-      this.getAllData(manualChange);
+      this.appStateService.selectedPage === 'overview' && this.getAllData(manualChange);
     })
   }
 

--- a/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
+++ b/src/app/modules/dashboard/pages/other-tools/other-tools.component.ts
@@ -108,7 +108,7 @@ export class OtherToolsComponent implements OnInit, OnDestroy {
 
     // catch a change in general filters
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange: boolean) => {
-      this.emitRequestInfo(manualChange);
+      this.appStateService.selectedPage === 'other-tools' && this.emitRequestInfo(manualChange);
     });
   }
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -7,6 +7,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { KpiCard } from 'src/app/models/kpi';
+import { AppStateService } from 'src/app/services/app-state.service';
 
 @Component({
   selector: 'app-overview-latam',
@@ -172,6 +173,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   constructor(
     private filtersStateService: FiltersStateService,
+    private appStateService: AppStateService,
     private overviewService: OverviewService,
     private translate: TranslateService
   ) {
@@ -212,7 +214,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     }
 
     this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
-      this.getAllData();
+      this.appStateService.selectedPage === 'overview' && this.getAllData();
     });
   }
 

--- a/src/app/services/app-state.service.ts
+++ b/src/app/services/app-state.service.ts
@@ -31,6 +31,11 @@ export class AppStateService {
   selectedLang$ = this.langSource.asObservable();
   selectedLang: string;
 
+  // selected page of main region, country or retailer
+  selectedPage: 'overview' | 'other-tools' | 'other';
+  // variable used as a validator in the subscribers of the observable filtersChange$ (in filter-state service)
+  // to avoid making requests just before destroying the component when redirecting to a new route
+
   constructor() { }
 
   selectMainRegion(mainRegion?: MainRegion) {


### PR DESCRIPTION
# Problem Description
- Just in the moment of selecting a new country or retailer from the sidebar, the subscribers of this selection hear a change before the redirection is made. Therefore, multiple requests to the API can be made:

   If we start from the overview of a retailer within a country:
![image](https://user-images.githubusercontent.com/38545126/125708270-c8e835f4-760f-43f6-8178-dead291de397.png)

   And then we went to a retailer in another country but this time changing the page (from _Coop Program_ to _Other tools_)
The following happens:
![image](https://user-images.githubusercontent.com/38545126/125710253-be0183eb-ee2b-42c6-99e1-14d102990f8b.png)
![image](https://user-images.githubusercontent.com/38545126/125710462-be28b759-8f80-433f-b036-d54836587f39.png)

   Two groups of requests were made:
  - The first group belongs to the overview component because it heard a change in the selection just before being redirected to another route ( it's to say, just before the component is destroyed)
  - The second group belongs to the corresponding requests after being redirected to the new route

# Bug Fixes
- Add selectedPage variable to app-state service
- Assign selectedPage value from sidebar component
- Add selectedPage validation in the following componts:
   - overview-latam
   - overview-wrapper
   - other tools
   
# Where this change will be used
- In sidebar navigation of dashboard module

# More details
![image](https://user-images.githubusercontent.com/38545126/125711074-eb9a17dd-f747-401d-a329-8cce9424ef03.png)

