### PR TITLE
avoid repeated requests when initializing the components of the dashboard module

### DIFF
--- a/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
+++ b/src/app/modules/dashboard/components/general-filters/general-filters.component.ts
@@ -779,17 +779,17 @@ export class GeneralFiltersComponent implements OnInit {
    */
   applyFilters(manualTriggered?: boolean) {
     this.filtersStateService.selectPeriod({ startDate: this.startDate?.value._d, endDate: this.endDate?.value._d });
-    this.filtersStateService.selectSectors(this.sectors?.value.filter(item => item.id));
-    this.filtersStateService.selectCategories(this.categories?.value.filter(item => item.id));
-    this.filtersStateService.selectSources(this.sources?.value.filter(item => item.id));
+    this.filtersStateService.selectSectors(this.sectors?.value?.filter(item => item.id));
+    this.filtersStateService.selectCategories(this.categories?.value?.filter(item => item.id));
+    this.filtersStateService.selectSources(this.sources?.value?.filter(item => item.id));
 
     if (this.isLatamSelected) {
-      this.filtersStateService.selectCountries(this.countries?.value.filter(item => item.id));
-      this.filtersStateService.selectRetailers(this.retailers?.value.filter(item => item.id));
+      this.filtersStateService.selectCountries(this.countries?.value?.filter(item => item.id));
+      this.filtersStateService.selectRetailers(this.retailers?.value?.filter(item => item.id));
     }
 
     const areAllCampsSelected = this.areAllCampaignsSelected();
-    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns?.value.filter(item => item.id));
+    this.filtersStateService.selectCampaigns(areAllCampsSelected ? [] : this.campaigns?.value?.filter(item => item.id));
 
     this.filtersStateService.filtersChange(manualTriggered);
   }

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -153,14 +153,34 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
+    let loadedFromInit: boolean; // first call to getAllData is from init
+    let firstTimeSub: boolean = true; // first time requestInfoSub listen a change
+
     // validate if filters are already loaded
-    this.filtersAreReady() && this.getAllData();
+    if (this.filtersAreReady()) {
+      this.getAllData();
+
+      // use loadedFromInit to avoid repeated calls to getAllData()
+      // when dashboard component is loaded for first time
+      // (e.g after page refresh or be redirected from other component that doesn't belong to to dashboard module)
+      loadedFromInit = true
+    }
 
     this.requestInfoSub = this.requestInfoChange.subscribe(({ manualChange, selectedSection }) => {
       // manualChange isn't useful in this component because there isn't tabs to preserve or clear selection
       // the only tab only appears in LATAM view level and it isn't necessary to clear the selection 
-      // when the view changes to country or retailer since it isn't shown at these levels
-      if (selectedSection === 'indexed' && this.filtersAreReady()) {
+      // when the view changes to country or retailer since it isn't shown at these levels 
+
+      // avoid repeated call to getAllData()
+      if (loadedFromInit && firstTimeSub && !manualChange) {
+        firstTimeSub = false;
+        return;
+      }
+
+      firstTimeSub = false;
+      loadedFromInit = false;
+
+      if (selectedSection === 'indexed' && this.filtersAreReady() && !loadedFromInit) {
         this.getAllData();
       }
     });

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -253,11 +253,30 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
+    let loadedFromInit: boolean; // first call to getAllData is from init
+    let firstTimeSub: boolean = true; // first time requestInfoSub listen a change
+
     // validate if filters are already loaded
-    this.filtersAreReady() && this.getAllData();
+    if (this.filtersAreReady()) {
+      this.getAllData();
+
+      // use loadedFromInit to avoid repeated calls to getAllData()
+      // when dashboard component is loaded for first time
+      // (e.g after page refresh or be redirected from other component that doesn't belong to to dashboard module)
+      loadedFromInit = true
+    }
 
     this.requestInfoSub = this.requestInfoChange.subscribe(({ manualChange, selectedSection }) => {
-      if (selectedSection === 'omnichat' && this.filtersAreReady()) {
+      // avoid repeated call to getAllData()
+      if (loadedFromInit && firstTimeSub && !manualChange) {
+        firstTimeSub = false;
+        return;
+      }
+
+      firstTimeSub = false;
+      loadedFromInit = false;
+
+      if (selectedSection === 'omnichat' && this.filtersAreReady() && !loadedFromInit) {
         this.getAllData(manualChange);
       }
     });

--- a/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/pc-selector-wrapper/pc-selector-wrapper.component.ts
@@ -128,11 +128,30 @@ export class PcSelectorWrapperComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
+    let loadedFromInit: boolean; // first call to getAllData is from init
+    let firstTimeSub: boolean = true; // first time requestInfoSub listen a change
+
     // validate if filters are already loaded
-    this.filtersAreReady() && this.getAllData();
+    if (this.filtersAreReady()) {
+      this.getAllData();
+
+      // use loadedFromInit to avoid repeated calls to getAllData()
+      // when dashboard component is loaded for first time
+      // (e.g after page refresh or be redirected from other component that doesn't belong to to dashboard module)
+      loadedFromInit = true;
+    }
 
     this.requestInfoSub = this.requestInfoChange.subscribe(({ manualChange, selectedSection }) => {
-      if (selectedSection === 'pc-selector' && this.filtersAreReady()) {
+      // avoid repeated call to getAllData()
+      if (loadedFromInit && firstTimeSub && !manualChange) {
+        firstTimeSub = false;
+        return;
+      }
+
+      firstTimeSub = false;
+      loadedFromInit = false;
+
+      if (selectedSection === 'pc-selector' && this.filtersAreReady() && !loadedFromInit) {
         this.getAllData(manualChange);
       }
     });

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -202,6 +202,9 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
+    let loadedFromInit: boolean; // first call to getAllData is from init
+    let firstTimeSub: boolean = true; // first time requestInfoSub listen a change
+
     if (this.filtersStateService.countries &&
       this.filtersStateService.retailers &&
       this.filtersStateService.period &&
@@ -211,10 +214,24 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
       this.filtersStateService.restoreFilters();
       this.getAllData();
+
+      // use loadedFromInit to avoid repeated calls to getAllData()
+      // when dashboard component is loaded for first time
+      // (e.g after page refresh or be redirected from other component that doesn't belong to to dashboard module)
+      loadedFromInit = true
     }
 
-    this.filtersSub = this.filtersStateService.filtersChange$.subscribe(() => {
-      this.appStateService.selectedPage === 'overview' && this.getAllData();
+    this.filtersSub = this.filtersStateService.filtersChange$.subscribe((manualChange) => {
+      // avoid repeated call to getAllData()
+      if (loadedFromInit && firstTimeSub && !manualChange) {
+        firstTimeSub = false;
+        return;
+      }
+
+      firstTimeSub = false;
+      loadedFromInit = false;
+
+      (this.appStateService.selectedPage === 'overview' && !loadedFromInit) && this.getAllData();
     });
   }
 


### PR DESCRIPTION
# Problem Description
- For dashboard components which make multiple requests to te API (overview, indexed, omnichat and pc-selector) when dashboard component is loaded for first time two groups of (repeated) requests are made, one of them is when component is initialized and the other is when general-filters component emit a change in loaded/selected filters.
So, is necessary to avoid making repeated requests using some validators.

   Note: dashboard component is loaded for first time after page refresh or when the user is redirected from other component that doesn't belong to to dashboard module

# Features
- Add validators to the following components in ngOnInt method and subscription that listens changes in general filters component:
- overview-latam
- overview-wrapper
- indexed-wrapper
- omnichat-wrapper
- pc-selector wrapper

# Bug Fixes
- Add null validators in general-filters component

# Where this change will be used
- When dashboard component will be initialized at `/dashboard/*` path

# More details
- Before: Two groups of requests are made
![image](https://user-images.githubusercontent.com/38545126/125837377-c5783389-242c-48ee-a07e-8bf6a953af85.png)

- After: Only one group or requests are made
![image](https://user-images.githubusercontent.com/38545126/125837501-31ed780b-f670-4f5b-a7d9-55c4edc83e4e.png)