### PR TITLE
add custom empty message to charts used for demographics data

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -342,7 +342,6 @@ export class SidebarComponent implements OnInit, OnDestroy {
         break;
     }
 
-    console.log('page', page)
     return page;
   }
 

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -98,7 +98,9 @@
                                 </div>
                                 <app-chart-pictorial [data]="demographics?.men" name="aud-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
-                                    [status]="demoReqStatus[1].reqStatus" height="280px">
+                                    [status]="demoReqStatus[1].reqStatus"
+                                    [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'"
+                                    height="280px">
                                 </app-chart-pictorial>
                             </div>
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
@@ -113,7 +115,9 @@
                                 </div>
                                 <app-chart-pictorial [data]="demographics?.women" name="aud-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
-                                    height="280px" [status]="demoReqStatus[1].reqStatus">
+                                    [status]="demoReqStatus[1].reqStatus"
+                                    [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'"
+                                    height="280px">
                                 </app-chart-pictorial>
                             </div>
                         </div>
@@ -148,7 +152,8 @@
                     <div class="card-body">
                         <app-chart-bar name="aud-gender" [data]="demographics?.gender"
                             [status]="demoReqStatus[1].reqStatus" valueFormat="USD" category="name" height="280px"
-                            [legendsByCategory]="true">
+                            [legendsByCategory]="true"
+                            [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'">
                         </app-chart-bar>
                     </div>
                 </div>
@@ -168,7 +173,8 @@
                     <app-chart-lollipop name="aud-age" [data]="demographics?.age" category="age"
                         [value]="selectedTab1 === 1 ? 'visits' : selectedTab1 === 2 ? 'sales' : selectedTab1 === 3 ? 'aup' : 'value'"
                         [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
-                        height="280px" [status]="demoReqStatus[2].reqStatus">
+                        height="280px" [status]="demoReqStatus[2].reqStatus"
+                        [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -197,10 +203,13 @@
 
                     <!-- empty data -->
                     <div *ngIf="demoReqStatus[3].reqStatus === 2 && demographics?.genderByAge?.length === 0"
-                        class="chart-error-container text-muted">
-                        <p class="text-center">
+                        class="chart-error-container text-muted text-center">
+                        <p *ngIf="retailerID !== 11">
                             {{ 'general.withoutData' | translate }} <br>
                             {{ 'general.withoutData2' | translate }}
+                        </p>
+                        <p *ngIf="retailerID === 11">
+                            Sin acceso a información por decisión del Retail
                         </p>
                     </div>
 

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
+import { AppStateService } from 'src/app/services/app-state.service';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { convertWeekdayToString } from 'src/app/tools/functions/data-convert';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
@@ -12,6 +13,8 @@ import { FiltersStateService } from '../../services/filters-state.service';
   styleUrls: ['./audiences-wrapper.component.scss']
 })
 export class AudiencesWrapperComponent implements OnInit, OnDestroy {
+
+  retailerID: number;
 
   demographics = {}; // for devices, gender, age and age-gender data
   demoReqStatus = [
@@ -44,16 +47,20 @@ export class AudiencesWrapperComponent implements OnInit, OnDestroy {
   selectedTab2: any = 1;
 
   chartsInitLoad: boolean = true;
+
   generalFiltersSub: Subscription;
   retailFiltersSub: Subscription;
 
   constructor(
     private filtersStateService: FiltersStateService,
     private campInRetailService: CampaignInRetailService,
+    private appStateService: AppStateService,
     private translate: TranslateService
   ) { }
 
   ngOnInit(): void {
+    this.retailerID = this.appStateService.selectedRetailer?.id;
+
     this.getAllData();
 
     this.generalFiltersSub = this.filtersStateService.filtersChange$.subscribe(() => {

--- a/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.html
@@ -6,10 +6,13 @@
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
 
     <!-- empty data -->
-    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted text-center">
+        <p *ngIf="!emptyDataLegend">
             {{ 'general.withoutData' | translate }} <br>
             {{ 'general.withoutData2' | translate }}
+        </p>
+        <p *ngIf="emptyDataLegend">
+            {{ emptyDataLegend }}
         </p>
     </div>
 

--- a/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar/chart-bar.component.ts
@@ -20,6 +20,7 @@ export class ChartBarComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() legendsByCategory: boolean; // show a legend (category + value + value format) per category only recommended for a small number of categories
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() emptyDataLegend: string;
 
   chartID;
 

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.html
@@ -6,10 +6,13 @@
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
 
     <!-- empty data -->
-    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted text-center">
+        <p *ngIf="!emptyDataLegend">
             {{ 'general.withoutData' | translate }} <br>
             {{ 'general.withoutData2' | translate }}
+        </p>
+        <p *ngIf="emptyDataLegend">
+            {{ emptyDataLegend }}
         </p>
     </div>
 

--- a/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-lollipop/chart-lollipop.component.ts
@@ -17,6 +17,7 @@ export class ChartLollipopComponent implements OnInit, AfterViewInit, OnDestroy 
   @Input() height: string = '350px'; // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() emptyDataLegend: string;
 
   chartID;
 

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.html
@@ -6,10 +6,13 @@
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
 
     <!-- empty data -->
-    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted text-center">
+        <p *ngIf="!emptyDataLegend">
             {{ 'general.withoutData' | translate }} <br>
             {{ 'general.withoutData2' | translate }}
+        </p>
+        <p *ngIf="emptyDataLegend">
+            {{ emptyDataLegend }}
         </p>
     </div>
 

--- a/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pictorial/chart-pictorial.component.ts
@@ -24,6 +24,7 @@ export class ChartPictorialComponent implements OnInit, AfterViewInit, OnDestroy
   @Input() uniqueDimensionConf: OneDimensionPictorial;
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() emptyDataLegend: string;
   @Input() position: am4charts.LegendPosition = 'left';
   @Input() valing: am4core.VerticalAlign = 'bottom';
   @Input() legendSquareSize: number;

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.html
@@ -6,10 +6,13 @@
     <div [hidden]="status !== 2 || data?.length < 1" [id]="chartID" style="height: 100%"></div>
 
     <!-- empty data -->
-    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted">
-        <p class="text-center">
+    <div [hidden]="status !== 2 || data?.length > 0" class="chart-error-container text-muted text-center">
+        <p *ngIf="!emptyDataLegend">
             {{ 'general.withoutData' | translate }} <br>
             {{ 'general.withoutData2' | translate }}
+        </p>
+        <p *ngIf="emptyDataLegend">
+            {{ emptyDataLegend }}
         </p>
     </div>
 

--- a/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pyramid/chart-pyramid.component.ts
@@ -22,6 +22,7 @@ export class ChartPyramidComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() height: string = '350px'; // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() emptyDataLegend: string;
 
   private _name: string;
   get name() {

--- a/src/app/tools/functions/chart-data.ts
+++ b/src/app/tools/functions/chart-data.ts
@@ -22,8 +22,8 @@ export function disaggregatePictorialData(metricName1: string, metricName2: stri
         value1 = percValues.perc1;
         value2 = percValues.perc2;
     } else {
-        value1 = metric1.value.toFixed(2);
-        value2 = metric2.value.toFixed(2);
+        value1 = metric1?.value.toFixed(2);
+        value2 = metric2?.value.toFixed(2);
     }
 
     if (metric1) {


### PR DESCRIPTION
# Problem Description
- For retailer Ripley in Chile is necessary show custom messages in charts because there aren't demographic data.
- Replace default message _"Sin datos disponibles. Muestra insuficiente"_ by _"Sin acceso a información por decisión del Retail"_

# Features
- Add emptyDataLegend input to charts components used for demographics data
- Add dynamic content based on retailerID in audicences-wrapper component

# Bug Fixes
- add validator to disaggregatePictorialData function
- Remove comment line in sidebar component

# Where this change will be used
- Where the following comoponents willl be used in dashboard module at `/dashboard/*` path:
   - chart-pictorial
   - chart-lollipop
   - chart-pyramid
   -  chart-bar

# More details
- Custom message for Ripley in Chile:
![image](https://user-images.githubusercontent.com/38545126/126000293-29d13149-c773-4992-845b-56c5fe4934fa.png)

- Default message for other Retailers:
![image](https://user-images.githubusercontent.com/38545126/126000416-1b290f1f-3f2e-4af3-9965-f6904642dbde.png)
