### PR TITLE
add metric by country table in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -46,12 +46,35 @@
                         </span>
                     </div>
                     <div class="card-body">
-                        <app-chart-heat-map [data]="categoriesBySector" name="latam-categories-by-sector'"
+                        <app-chart-heat-map [data]="metricByCountry" name="latam-categories-by-sector'"
                             categoryX="country"
                             [categoryY]="selectedTab1 === 1 ? 'sector' : selectedTab1 === 2 ? 'category' : 'fund'"
                             height="250px" [showGridBorders]="true" [showHeatLegend]="false"
-                            [status]="categoriesReqStatus" formatValue="USD" gridBordersColor="#f7f7f7">
+                            [status]="metricByCountryReqStatus" formatValue="USD" gridBordersColor="#f7f7f7">
                         </app-chart-heat-map>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-12 mt-4">
+                <div class="card">
+                    <div class="card-header">
+                        <span class="h4">
+                            {{
+                            ('overviewLatam.chart1CardTitle1' | translate) +
+                            (( selectedTab1 === 1 ? 'overviewLatam.chart1CardTitle2' : selectedTab1 === 2 ?
+                            'overviewLatam.chart1CardTitle3' : 'Fondos')
+                            | translate) +
+                            ('overviewLatam.chart1CardTitle4' | translate)
+                            }}
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        <app-generic-table
+                            [displayedColumns]="selectedTab1 === 1 ? metricByCountryColumns.sector : selectedTab1 === 2  ? metricByCountryColumns.category : metricByCountryColumns.found"
+                            [tableData]="metricByCountryTable" [tableDataChange]="metricByCountryTable.data"
+                            errorData="Error al consultar países" emptyDataMsg="No se encontraron países">
+                        </app-generic-table>
                     </div>
                 </div>
             </div>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -111,7 +111,35 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     }
   ];
 
-  categoriesBySector: any[] = [];
+  metricByCountry: any[] = [];
+  metricByCountryColumns = {
+    sector: [
+      { name: 'country', title: 'País' },
+      { name: 'search', title: 'Search', textAlign: 'center', formatValue: 'currency' },
+      { name: 'marketing', title: 'Marketing', textAlign: 'center', formatValue: 'currency' },
+      { name: 'ventas', title: 'Ventas', textAlign: 'center', formatValue: 'currency' },
+    ],
+    category: [
+      { name: 'country', title: 'País' },
+      { name: 'ps', title: 'PS', textAlign: 'center', formatValue: 'currency' },
+      { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
+      { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
+    ],
+    found: [
+      { name: 'country', title: 'País' },
+      { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
+      { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
+      { name: 'intel_premium', title: 'Intel Premium', textAlign: 'center', formatValue: 'currency' },
+      { name: 'intel_gaming', title: 'Intel Gaming', textAlign: 'center', formatValue: 'currency' },
+      { name: 'ms_jma_premium', title: 'MS JMA Premium', textAlign: 'center', formatValue: 'currency' },
+      { name: 'ms_jma_gaming', title: 'MS JMA Gaming', textAlign: 'center', formatValue: 'currency' },
+    ]
+  };
+
+  metricByCountryTable = {
+    data: [],
+    reqStatus: 0
+  }
 
   trafficOrSales = {};
 
@@ -120,22 +148,9 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   // top products
   topProductsColumns: TableItem[] = [
-    {
-      name: 'rank',
-      title: 'Posición',
-      tooltip: true,
-    },
-    {
-      name: 'product',
-      title: 'Producto',
-      tooltip: true,
-    },
-    {
-      name: 'amount',
-      title: 'Cantidad',
-      textAlign: 'center',
-      formatValue: 'integer'
-    }
+    { name: 'rank', title: 'Posición', tooltip: true },
+    { name: 'product', title: 'Producto', tooltip: true },
+    { name: 'amount', title: 'Cantidad', textAlign: 'center', formatValue: 'integer' }
   ];
   topProducts = {
     data: [],
@@ -144,7 +159,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
 
   // requests status
   kpisReqStatus: number = 0;
-  categoriesReqStatus: number = 0;
+  metricByCountryReqStatus: number = 0;
   usersInvOrAupReqStatus: number = 0;
   invVsRevenueReqStatus: number = 0;
   trafficOrSalesReqStatus = [
@@ -319,16 +334,52 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   getSectorsAndCategories(metricType: string) {
-    this.categoriesReqStatus = 1;
+    this.metricByCountryReqStatus = 1;
+    this.metricByCountryTable.reqStatus = 1;
     this.overviewService.getSectorsAndCategoriesLatam(metricType).subscribe(
       (resp: any[]) => {
-        this.categoriesBySector = resp;
-        this.categoriesReqStatus = 2;
+        this.metricByCountry = resp;
+        this.metricByCountryReqStatus = 2;
+
+        this.metricByCountryTable.data = [];
+
+        let countries: any[] = [];
+        for (let item of resp) {
+          let baseObj = countries.find(c => c.country === item.country);
+
+          let propName;
+          switch (metricType) {
+            case 'sectors':
+              propName = item.sector.toLowerCase().replaceAll(' ', '_');
+              break;
+
+            case 'categories':
+              propName = item.category.toLowerCase().replaceAll(' ', '_');
+              break;
+
+            case 'funds':
+              propName = item.fund.toLowerCase().replaceAll(' ', '_');
+              break;
+
+            default:
+              break;
+          }
+
+          if (!baseObj) {
+            countries.push({ country: item.country, [propName]: item.value });
+          } else {
+            baseObj[propName] = item.value;
+          }
+        }
+
+        this.metricByCountryTable.data = countries;
+        this.metricByCountryTable.reqStatus = 2;
       },
       error => {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-latam.component]: ${errorMsg}`);
-        this.categoriesReqStatus = 3;
+        this.metricByCountryReqStatus = 3;
+        this.metricByCountryTable.reqStatus = 3;
       });
 
     this.selectedTab1 = metricType === 'sectors' ? 1 : metricType === 'categories' ? 2 : 3;


### PR DESCRIPTION
# Problem Description
- For LATAM overview use the same data of dynamic heat map chart and show it in a table with dynamic colums based on selected metric (sector, category or found)

# Features
- Add metric by country table in overview-latam component

# Where this change will be used
- In LATAM overview at `/dashboard/main-region?main-region=latam` path

# More details
- Sectors
![image](https://user-images.githubusercontent.com/38545126/126253922-52a9fb6a-2f5e-4e73-aabd-dad20d067406.png)

- Categories
![image](https://user-images.githubusercontent.com/38545126/126253963-03123550-8de3-482b-a901-48163f6ecde8.png)

- Founds
![image](https://user-images.githubusercontent.com/38545126/126254009-e1c24e7a-4229-4a33-b6e3-ba7b5bad56e3.png)
