### PR TITLE
align card headers, charts and legends of behaviour-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
@@ -25,7 +25,7 @@
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sessions-ret-visitor" [data]="behavior.newUsersVsCurrent"
-                    [status]="behaviorReqStatus[0].reqStatus" legendPosition="bottom">
+                    [status]="behaviorReqStatus[0].reqStatus" [minLegendHeight]="150" legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -39,7 +39,7 @@
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-ret-visitor" [data]="behavior.salesNewUsersVsCurrent"
-                    [status]="behaviorReqStatus[1].reqStatus" legendPosition="bottom">
+                    [status]="behaviorReqStatus[1].reqStatus" [minLegendHeight]="150" legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -53,7 +53,7 @@
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-by-conv-sorce" [data]="behavior.salesBySource"
-                    [status]="behaviorReqStatus[2].reqStatus" legendPosition="bottom">
+                    [status]="behaviorReqStatus[2].reqStatus" [minLegendHeight]="150" legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -67,7 +67,7 @@
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-by-sorce" [data]="behavior.salesBySector"
-                    [status]="behaviorReqStatus[3].reqStatus" legendPosition="bottom">
+                    [status]="behaviorReqStatus[3].reqStatus" [minLegendHeight]="150" legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -88,7 +88,7 @@
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sessions-by-audience" [data]="behavior.sessionsByAudience"
-                    [status]="behaviorReqStatus[4].reqStatus" legendPosition="bottom">
+                    [status]="behaviorReqStatus[4].reqStatus" [minLegendHeight]="150" legendPosition="bottom">
                 </app-chart-pie>
             </div>
         </div>
@@ -101,8 +101,8 @@
                 <span class="h4">Usuarios nuevos por tipo de audiencia</span>
             </div>
             <div class="card-body">
-                <app-chart-pie name="bh-users-by-audience" [data]="behavior.newUsersByAudience" legendPosition="bottom"
-                    [status]="behaviorReqStatus[5].reqStatus">
+                <app-chart-pie name="bh-users-by-audience" [data]="behavior.newUsersByAudience" [minLegendHeight]="150"
+                    legendPosition="bottom" [status]="behaviorReqStatus[5].reqStatus">
                 </app-chart-pie>
             </div>
         </div>
@@ -116,7 +116,7 @@
             </div>
             <div class="card-body">
                 <app-chart-bar name="bh-quantity-by-audience" [data]="behavior.quantityByAudience"
-                    legendPosition="bottom" [status]="behaviorReqStatus[6].reqStatus">
+                    [minLegendHeight]="150" legendPosition="bottom" [status]="behaviorReqStatus[6].reqStatus">
                 </app-chart-bar>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
@@ -1,0 +1,25 @@
+
+.card .card-header {
+    display: flex;
+    align-items: center;
+    min-height: 53px;
+
+    span {
+        display: block;
+        line-height: 16px;
+        margin-bottom: 0;
+        margin-top: 4px;
+    }
+}
+
+@media screen and (max-width: 1433px) and (min-width: 1207px){
+    .card .card-header {
+        min-height: 69px;
+    }
+}
+
+@media screen and (max-width: 1207px) and (min-width: 1200px){
+    .card .card-header {
+        min-height: 85px;
+    }
+}

--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.scss
@@ -1,7 +1,7 @@
 
 .card .card-header {
-    display: flex;
     align-items: center;
+    display: flex;
     min-height: 53px;
 
     span {

--- a/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-pie/chart-pie.component.ts
@@ -21,6 +21,7 @@ export class ChartPieComponent implements OnInit, AfterViewInit, OnDestroy {
   @Input() height: string = '350px'; // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
+  @Input() minLegendHeight: number;
 
   private _name: string;
   get name() {
@@ -77,9 +78,12 @@ export class ChartPieComponent implements OnInit, AfterViewInit, OnDestroy {
   */
   loadChart(lang?: string) {
     this.browserOnly(() => {
+
       // Chart code goes in here
       am4core.useTheme(am4themes_animated);
       let chart = am4core.create(this.chartID, am4charts.PieChart);
+
+
 
       this.loadChartData(chart);
       loadLanguage(chart, lang);
@@ -109,6 +113,8 @@ export class ChartPieComponent implements OnInit, AfterViewInit, OnDestroy {
       pieSeries.ticks.template.disabled = true;
       pieSeries.slices.template.fillOpacity = 0.8;
 
+      pieSeries.slicesContainer.maxHeight = 2;
+
       // Create a base filter effect (as if it's not there) for the hover to return to
       let shadow = pieSeries.slices.template.filters.push(new am4core.DropShadowFilter);
       shadow.opacity = 0;
@@ -126,7 +132,15 @@ export class ChartPieComponent implements OnInit, AfterViewInit, OnDestroy {
       chart.legend.position = this.legendPosition;
       chart.legend.fontSize = 12;
       chart.legend.useDefaultMarker = true;
-      chart.legend.maxHeight = 150;
+
+      if (!this.minLegendHeight) {
+        chart.legend.maxHeight = 150;
+      } else {
+        // 0.1 is a min difference of minLegendHeight in order to align charts where there're multiple charts in a row
+        chart.legend.minHeight = this.minLegendHeight - 0.1;
+        chart.legend.maxHeight = this.minLegendHeight;
+      }
+
       chart.legend.scrollable = true;
 
       let marker = chart.legend.markers.template.children.getIndex(0);


### PR DESCRIPTION
# Problem Description
- In order to improve UX is necessary align card headers and charts shown in behaviour-wrapper component

# Features
- Add minLegendHeight input to chart-pie component
- Add minLegendHeight property of chart-bar component instances in behaviour-wrapper component

# Where this change will be used
- In Retailer > Campaign in retail > Behaviour section at `/dashboard/retailer` path

# More details
-  Before changes:
![image](https://user-images.githubusercontent.com/38545126/126700815-9b75e8ed-e99a-4f64-8d09-7296c8fe1db5.png)
![image](https://user-images.githubusercontent.com/38545126/126700839-11e6263a-2e70-45b5-80b4-271bd9a2ed4e.png)

- After changes:
![image](https://user-images.githubusercontent.com/38545126/126700962-c15fb376-0bc9-49d1-b3f9-b1611cfe08f0.png)
![image](https://user-images.githubusercontent.com/38545126/126701003-40b8e747-1683-4f7d-bb67-b4b16a4e5b7c.png)


