### PR TITLE
update funds references in overview-latam component

### DIFF
--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.html
@@ -71,7 +71,7 @@
                     </div>
                     <div class="card-body">
                         <app-generic-table
-                            [displayedColumns]="selectedTab1 === 1 ? metricByCountryColumns.sector : selectedTab1 === 2  ? metricByCountryColumns.category : metricByCountryColumns.found"
+                            [displayedColumns]="selectedTab1 === 1 ? metricByCountryColumns.sector : selectedTab1 === 2  ? metricByCountryColumns.category : metricByCountryColumns.fund"
                             [tableData]="metricByCountryTable" [tableDataChange]="metricByCountryTable.data"
                             errorData="Error al consultar países" emptyDataMsg="No se encontraron países">
                         </app-generic-table>

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -125,14 +125,17 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
       { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
       { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
     ],
-    found: [
+    fund: [
       { name: 'country', title: 'País' },
-      { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
-      { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
-      { name: 'intel_premium', title: 'Intel Premium', textAlign: 'center', formatValue: 'currency' },
-      { name: 'intel_gaming', title: 'Intel Gaming', textAlign: 'center', formatValue: 'currency' },
-      { name: 'ms_jma_premium', title: 'MS JMA Premium', textAlign: 'center', formatValue: 'currency' },
+      { name: 'mdf', title: 'MDF', textAlign: 'center', formatValue: 'currency' },
+      { name: 'amd', title: 'AMD', textAlign: 'center', formatValue: 'currency' },
+      { name: 'ms_jma', title: 'MS JMA', textAlign: 'center', formatValue: 'currency' },
+      { name: 'intel_mdf_gaming', title: 'Intel MDF Gaming', textAlign: 'center', formatValue: 'currency' },
+      { name: 'intel_mdf_premium', title: 'Intel MDF Premium', textAlign: 'center', formatValue: 'currency' },
       { name: 'ms_jma_gaming', title: 'MS JMA Gaming', textAlign: 'center', formatValue: 'currency' },
+      { name: 'ms_jma_premium', title: 'MS JMA Premium', textAlign: 'center', formatValue: 'currency' },
+      { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
+      { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
     ]
   };
 
@@ -358,7 +361,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
               break;
 
             case 'funds':
-              propName = item.fund.toLowerCase().replaceAll(' ', '_');
+              propName = item.fund.toLowerCase().replaceAll(' - ', '_').replaceAll(' ', '_');
               break;
 
             default:


### PR DESCRIPTION
# Problem Description
- After changes in the API endpoint response at GET `/api/v1/latam/countries/funds/segments` is necessary update funds references to load title and values in the table correctly

# Features
- Update funds names used in metricByCountryColumns variable of overview-latam component

# Bug Fixes
- Fix variable name found by fund

# Where this change will be used
- In LATAM overview countries table at `/dashboard/main-region` path

# More details
![image](https://user-images.githubusercontent.com/38545126/127022473-14b1a9ad-4a36-451b-9460-7bef7a7dfc84.png)
