### PR TITLE
update dashboard component to show dynamic content

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -153,7 +153,7 @@ export class SidebarComponent implements OnInit, OnDestroy {
     // Other routes
     const menuItem1 = {
       title: this.translate.instant('dashboard.campaignComparator'),
-      path: '/campaign-comparator',
+      path: '/dashboard/campaign-comparator',
     }
     this.menuItems.push(menuItem1);
 

--- a/src/app/modules/dashboard/dashboard.component.html
+++ b/src/app/modules/dashboard/dashboard.component.html
@@ -2,7 +2,7 @@
     <div class="container-fluid-lg" [hidden]="!title">
         <p class="h2 text-xl">{{ title }}</p>
     </div>
-    <div class="filters-container container-fluid-lg">
+    <div class="filters-container container-fluid-lg" [hidden]="!showFilters">
         <app-general-filters></app-general-filters>
         <hr class="mt-3 mb-5">
     </div>

--- a/src/app/modules/dashboard/dashboard.component.ts
+++ b/src/app/modules/dashboard/dashboard.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { NavigationStart, Router, Event } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
-import { AppStateService } from 'src/app/services/app-state.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -12,6 +11,8 @@ import { AppStateService } from 'src/app/services/app-state.service';
 export class DashboardComponent implements OnInit, OnDestroy {
 
   title: string;
+  showFilters: boolean;
+
   routeSub: Subscription;
   translateSub: Subscription;
 
@@ -21,30 +22,46 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ) {
     this.routeSub = this.router.events.subscribe((event: Event) => {
       if (event instanceof NavigationStart) {
-        this.loadTitle(event.url);
+        this.loadContent(event.url);
       }
     })
 
     this.translateSub = translate.stream('dashboard').subscribe(() => {
-      this.loadTitle(this.router.url);
+      this.loadContent(this.router.url);
     });
   }
 
   ngOnInit(): void { }
 
-  loadTitle(route: string) {
-    if (route.includes('/dashboard/main-region')) {
-      this.title = this.translate.instant('dashboard.overview');
-    } else if (route.includes('/dashboard/country')) {
-      this.title = this.translate.instant('dashboard.overviewCountry');
-    } else if (route.includes('/dashboard/retailer')) {
-      this.title = this.translate.instant('dashboard.overviewRetailer');
-    } else if (route.includes('/dashboard/tools')) {
-      this.title = this.translate.instant('dashboard.otherTools');
-    } else if (route.includes('/dashboard/omnichat')) {
-      this.title = this.translate.instant('dashboard.feelingsAnalysis');
-    } else {
-      delete this.title;
+  loadContent(route: string) {
+    this.showFilters = true;
+
+    const path = route.replace('/dashboard/', '').split('?')[0];
+    switch (path) {
+      case 'main-region':
+        this.title = this.translate.instant('dashboard.overview');
+        break;
+
+      case 'country':
+        this.title = this.translate.instant('dashboard.overviewCountry');
+        break;
+
+      case 'retailer':
+        this.title = this.translate.instant('dashboard.overviewRetailer');
+        break;
+
+      case 'tools':
+        this.title = this.translate.instant('dashboard.otherTools');
+        break;
+
+      case 'omnichat':
+        this.title = this.translate.instant('dashboard.feelingsAnalysis');
+        break;
+
+      default:
+        delete this.title;
+        this.showFilters = false;
+        break;
     }
   }
 


### PR DESCRIPTION
# Problem Description
- In order to hide general-filters components form some pages components (routes) in dashboard component is necessary use a _hidden_ directive in dashboard template

# Features
- Update dynamic content in dashboard component
- Update campaign-comparator path in sidebar component

# Bug Fixes
- Replace loadTitle method by loadContent method
- Refator loadContent method to use swich instead multiple if conditionals

# Where this change will be used
- In dashboard module at `/dashboard/* path`

# More details
- E.g. Even the path is /dashboard general filters are hidden in this page:
![image](https://user-images.githubusercontent.com/38545126/127219648-71e181ad-01b8-42c1-a56a-772ff2abc95f.png)

