### PR TITLE
update columns of tables in conversion-wrapper and indexed-wrapper components

### DIFF
--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { KpiCard } from 'src/app/models/kpi';
+import { AppStateService } from 'src/app/services/app-state.service';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { TableItem } from '../generic-table/generic-table.component';
@@ -12,6 +13,7 @@ import { TableItem } from '../generic-table/generic-table.component';
 })
 export class ConversionWrapperComponent implements OnInit {
 
+  retailerID;
   // kpis
   kpis: KpiCard[] = [
     {
@@ -107,10 +109,21 @@ export class ConversionWrapperComponent implements OnInit {
 
   constructor(
     private filtersStateService: FiltersStateService,
-    private campInRetailService: CampaignInRetailService
+    private campInRetailService: CampaignInRetailService,
+    private appStateService: AppStateService,
   ) { }
 
   ngOnInit(): void {
+    this.retailerID = this.appStateService.selectedRetailer?.id;
+    // add source column for México - Liverpool retailer
+    if (this.retailerID === 26) {
+      const newTableColumn = {
+        name: 'source',
+        title: 'Origen',
+        textAlign: 'center'
+      };
+      this.productsTableColumns.splice(2, 0, newTableColumn);
+    }
     this.getAllData();
 
     this.generalFiltersSub = this.filtersStateService.filtersChange$.subscribe(() => {
@@ -158,7 +171,12 @@ export class ConversionWrapperComponent implements OnInit {
       (products: any[]) => {
         // provisional until data exists
         this.products.data = products.map(item => {
-          return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-' };
+          if (this.retailerID !== 26) {
+            return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-' };
+          }
+
+          // add source property for México - Liverpool retailer
+          return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-', source: item.source ? item.source : '-' };
         });
 
         this.products.reqStatus = 2;

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -118,7 +118,7 @@ export class ConversionWrapperComponent implements OnInit {
     // add source column for México - Liverpool retailer
     if (this.retailerID === 26) {
       const newTableColumn = {
-        name: 'source',
+        name: 'origin',
         title: 'Origen',
         textAlign: 'center'
       };
@@ -176,7 +176,7 @@ export class ConversionWrapperComponent implements OnInit {
           }
 
           // add source property for México - Liverpool retailer
-          return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-', source: item.source ? item.source : '-' };
+          return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-', origin: item.origin ? item.origin : '-' };
         });
 
         this.products.reqStatus = 2;

--- a/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/conversion-wrapper/conversion-wrapper.component.ts
@@ -115,7 +115,7 @@ export class ConversionWrapperComponent implements OnInit {
 
   ngOnInit(): void {
     this.retailerID = this.appStateService.selectedRetailer?.id;
-    // add source column for México - Liverpool retailer
+    // add origin column for México - Liverpool retailer
     if (this.retailerID === 26) {
       const newTableColumn = {
         name: 'origin',
@@ -175,7 +175,7 @@ export class ConversionWrapperComponent implements OnInit {
             return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-' };
           }
 
-          // add source property for México - Liverpool retailer
+          // add origin property for México - Liverpool retailer
           return { ...item, yoy_amount: '-', yoy_product_revenue: '-', yoy_aup: '-', origin: item.origin ? item.origin : '-' };
         });
 

--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -127,6 +127,12 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
           title: 'Usuarios',
           textAlign: 'center',
           formatValue: 'integer',
+        },
+        {
+          name: 'pdf_downloads',
+          title: '# de Descargas PDF',
+          textAlign: 'center',
+          formatValue: 'integer',
         }
       ],
       data: [],


### PR DESCRIPTION
# Problem Description
- In campaign in retail is necessary to add _origin_ column to products table for a specific RetailerID (26)
- In indexed is necessary to add _pdf_downloads_ columns to most visited categories table

# Features
- Add _origin_ column to table for a specific retailerID in conversion-wrapper component
- Add _pdf_downloads_ column to categories table in indexed-wrapper component

# Where this change will be used
- In Retailer > COOP Program > Campaign in retail > Conversion section > Products table for retailerID 26
- In LATAM/Country/Retailer > OIther tools > Indexed > Most visited categories table

# More details
- Campaign in retail > Conversión > Products table (retailerID 26)
![image](https://user-images.githubusercontent.com/38545126/128228659-57a53641-4842-4fb9-867e-ecafbe21a6e7.png)

- Other tools > Indexed > Most visited categories table
![image](https://user-images.githubusercontent.com/38545126/128228563-b7a651af-5889-4fd2-a128-734c1728093e.png)
