### PR TITLE
update most visited categories table in indexed-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/indexed-wrapper/indexed-wrapper.component.ts
@@ -130,9 +130,8 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
         },
         {
           name: 'pdf_downloads',
-          title: '# de Descargas PDF',
-          textAlign: 'center',
-          formatValue: 'integer',
+          title: 'Descargas PDF',
+          textAlign: 'center'
         }
       ],
       data: [],
@@ -348,7 +347,21 @@ export class IndexedWrapperComponent implements OnInit, OnDestroy {
       this.topMostVisited[metric.name].reqStatus = 1;
       this.indexedService.getDataByMetric(this.levelPage.latam, metric.metricType).subscribe(
         (resp: any[]) => {
-          this.topMostVisited[metric.name]['data'] = resp;
+          if (metric.name === 'top-products') {
+            this.topMostVisited[metric.name]['data'] = resp;
+          } else {
+            this.topMostVisited[metric.name]['data'] = resp.map(item => {
+
+              if (item.name !== 'Supplies') {
+                return { ...item, pdf_downloads: '-' };
+              }
+
+              const pdf_downloads = item.pdf_downloads ? item.pdf_downloads : Math.round(Math.random() * (20 - 1));
+
+              return { ...item, pdf_downloads };
+            });
+          }
+
           this.topMostVisited[metric.name].reqStatus = 2;
         },
         error => {


### PR DESCRIPTION
# Problem Description
- Is necessary to make te following changes:
   - Update PDF downloads column name in most visited categories table
   - Load a random number between 0 and 20 for Supplies category
   - Use `-` character for PS and HW Print categories

# Features
- Update most visited categories table in indexed-wrapper component

# Where this change will be used
- In LATAM/Countries/Retailer > Indexed > Most visited categories table

# More details
![image](https://user-images.githubusercontent.com/38545126/128395418-24ea9835-ae22-4bf9-91d1-5cf0d1c6eaac.png)

