### PR TITLE
add i18n to campaign-towards-retail-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.html
@@ -4,12 +4,12 @@
             <ul class="nav nav-pills nav-fill">
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}" (click)="selectedTab1 = 1">
-                        Inversión - Conversiones
+                        {{ ('general.investment' | translate) + ' - ' + ('general.conversions' | translate) }}
                     </a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}" (click)="selectedTab1 = 2">
-                        Impresiones - Clicks
+                        {{ ('general.impressions' | translate) + ' - ' + ('general.clicks' | translate) }}
                     </a>
                 </li>
             </ul>
@@ -20,16 +20,18 @@
         <div class="card">
             <div class="card-header">
                 <ng-container [ngSwitch]="selectedTab1">
-                    <span class="h4" *ngSwitchCase="1">Inversión - Conversiones</span>
-                    <span class="h4" *ngSwitchCase="2">Impresiones - Clicks</span>
+                    <span class="h4" *ngSwitchCase="1">{{ ('general.investment' | translate) + ' - ' +
+                        ('general.conversions' | translate) }}</span>
+                    <span class="h4" *ngSwitchCase="2"> {{ ('general.impressions' | translate) + ' - ' +
+                        ('general.clicks' | translate) }}</span>
                 </ng-container>
             </div>
             <div class="card-body">
                 <app-chart-multiple-axes [data]="selectedTab1 === 1 ?  conversionsVsInvestment : impresionsVsClicks"
                     [value1]="selectedTab1 === 1 ? 'conversions' : 'clicks'"
                     [value2]="selectedTab1 === 1 ? 'investment' : 'impressions'"
-                    [valueName1]="selectedTab1 === 1 ? 'Conversiones' : 'Clicks'"
-                    [valueName2]="selectedTab1 === 1 ? 'Inversión' : 'Impresiones'"
+                    [valueName1]="selectedTab1 === 1 ? ('general.conversions' | translate) : ('general.clicks' | translate)"
+                    [valueName2]="selectedTab1 === 1 ? ('general.investment' | translate) : ('general.impressions' | translate)"
                     [valueFormat2]="selectedTab1 === 1 && 'USD'" name="campaign-towards-retail-metrics"
                     [status]="campPerformanceReqStatus">
                 </app-chart-multiple-axes>
@@ -58,8 +60,8 @@
             </p>
         </div>
         <app-generic-table [displayedColumns]="campListDisplayedColumns" [tableData]="campaigns"
-            [tableDataChange]="campaigns.data" errorMsg="Error al consultar campañas"
-            emptyDataMsg="No se encontraron campañas">
+            [tableDataChange]="campaigns.data" [errorMsg]="'campTowardsRetail.table1Error' | translate"
+            [emptyDataMsg]="'campTowardsRetail.table1Empty' | translate">
         </app-generic-table>
     </div>
 </div>

--- a/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/campaign-towards-retail-wrapper/campaign-towards-retail-wrapper.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Observable, Subscription } from 'rxjs';
 import { CampaignTowardsRetailService } from '../../services/campaign-towards-retail.service';
 import { TableItem } from '../generic-table/generic-table.component';
@@ -93,11 +94,18 @@ export class CampaignTowardsRetailWrapperComponent implements OnInit, OnDestroy 
   conversionsVsInvestment: any[] = [];
   impresionsVsClicks: any[] = [];
 
+  translateSub: Subscription;
   requestInfoSub: Subscription;
 
   constructor(
-    private campTowardsRetailServ: CampaignTowardsRetailService
-  ) { }
+    private campTowardsRetailServ: CampaignTowardsRetailService,
+    private translate: TranslateService,
+  ) {
+
+    this.translateSub = translate.stream('campTowardsRetail').subscribe(() => {
+      this.loadI18nContent();
+    });
+  }
 
   ngOnInit(): void {
     this.getAllData();
@@ -199,6 +207,15 @@ export class CampaignTowardsRetailWrapperComponent implements OnInit, OnDestroy 
           item.reqStatus = 3;
         });
     });
+  }
+
+  loadI18nContent() {
+    this.campList[0].name = this.translate.instant('campTowardsRetail.campList1');
+
+    this.campListDisplayedColumns[0].title = this.translate.instant('general.name');
+    this.campListDisplayedColumns[1].title = this.translate.instant('general.investment');
+    this.campListDisplayedColumns[2].title = this.translate.instant('general.impressions');
+    this.campListDisplayedColumns[3].title = this.translate.instant('general.clicks');
   }
 
   ngOnDestroy() {

--- a/src/app/modules/dashboard/components/generic-table/generic-table.component.ts
+++ b/src/app/modules/dashboard/components/generic-table/generic-table.component.ts
@@ -12,8 +12,8 @@ import { MatSort } from '@angular/material/sort';
 })
 export class GenericTableComponent implements OnInit, AfterViewInit, OnDestroy {
 
-  @Input() errorMsg = 'Error al consultar datos';
-  @Input() emptyDataMsg = 'No se encontraron datos';
+  @Input() errorMsg;
+  @Input() emptyDataMsg;
   @Input() reducedPadding: boolean;
 
   private _displayedColumns: TableItem[];
@@ -57,8 +57,14 @@ export class GenericTableComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngOnInit(): void {
     this.langSub = this.translate.stream('general').subscribe(() => {
-      this.errorMsg = this.translate.instant('general.errorData');
-      this.emptyDataMsg = this.translate.instant('general.withoutData3');
+      if (!this.errorMsg) {
+        this.errorMsg = this.translate.instant('general.errorData');
+      }
+
+      if (!this.emptyDataMsg) {
+        this.emptyDataMsg = this.translate.instant('general.withoutData3');
+      }
+
       this.loadPaginator();
     });
   }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -84,6 +84,11 @@
         "chart1Legend1": "Active",
         "chart1Legend2": "Inactive"
     },
+    "campTowardsRetail": {
+        "table1Error": "Error when consulting campaigns",
+        "table1Empty": "No found campaigns",
+        "campList1": "Google Search and MDF"
+    },
     "charts": {
         "byCountry": " by Country",
         "byDevice": " by Devices",
@@ -120,6 +125,9 @@
         "fund": "Fund",
         "institutional": "Institutional",
         "others": "Others",
+        "impressions": "Impressions",
+        "clicks": "Clicks",
+        "name": "Name",
         "usersVsSales": "Users - Conversions",
         "investmentVsRevenue": "Investment - Revenue",
         "revenueVsAup": "Revenue - AUP",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -84,6 +84,11 @@
         "chart1Legend1": "Activas",
         "chart1Legend2": "Inactivas"
     },
+    "campTowardsRetail": {
+        "table1Error": "Error al consultar campañas",
+        "table1Empty": "No se encontraron campañas",
+        "campList1": "Google Search y MDF"
+    },
     "charts": {
         "byCountry": " por País",
         "byDevice": " por Dispositivos",
@@ -120,6 +125,9 @@
         "fund": "Fondo",
         "institutional": "Institucional",
         "others": "Otros",
+        "impressions": "Impresiones",
+        "clicks": "Clicks",
+        "name": "Nombre",
         "usersVsSales": "Usuarios - Conversiones",
         "investmentVsRevenue": "Inversión - Revenue",
         "revenueVsAup": "Revenue - AUP",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -84,6 +84,11 @@
         "chart1Legend1": "Ativas",
         "chart1Legend2": "Inativas"
     },
+    "campTowardsRetail": {
+        "table1Error": "Erro ao consultar campanhas",
+        "table1Empty": "Nenhum campanha encontrada",
+        "campList1": "Google Search e MDF"
+    },
     "charts": {
         "byCountry": " por País",
         "byDevices": " por Dispositivos",
@@ -120,6 +125,9 @@
         "fund": "Fundo",
         "institutional": "Institucional",
         "others": "Outros",
+        "impressions": "Impressões",
+        "clicks": "Clicks",
+        "name": "Nome",
         "usersVsSales": "Usuários - Conversões",
         "investmentVsRevenue": "Investimento - Revenue",
         "revenueVsAup": "Revenue - AUP",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files for 'campaign-towards-retail-wrapper' component

# Features
- Update i18n files
- Update campaign-towards-retail component

# Bug Fixes
- Update instant translations in generic-table component

# Where this change will be used
- In Retailer > Campaign towards retail section at `/dashboard/retailer` path
