### PR TITLE
add investment table to overview-wrapper component template

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -24,6 +24,7 @@
                 </ul>
             </div>
         </div>
+
         <div class="col-12 mt-4">
             <div class="card">
                 <div class="card-header">
@@ -52,6 +53,26 @@
                         height="250px" [showTooltipValue]="false" [showGridBorders]="true" [showHeatLegend]="false"
                         [status]="categoriesReqStatus" [minValue]="0" [maxValue]="1" initialColor="#e9e9e9">
                     </app-chart-heat-map>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-12 mt-4">
+            <div class="card">
+                <div class="card-header">
+                    <ng-container *ngIf="selectedType === 'country'" [ngSwitch]="selectedTab1">
+                        <span *ngSwitchCase="1" class="h4">{{ 'overviewWrapper.chart1CardTitle1' | translate }}</span>
+                        <span *ngSwitchCase="2" class="h4">{{ 'overviewWrapper.chart1CardTitle2' | translate }}</span>
+                        <span *ngSwitchCase="3" class="h4">{{ 'overviewWrapper.chart1CardTitle3' | translate }}</span>
+                    </ng-container>
+
+                    <span *ngIf="selectedType === 'retailer'" class="h4">{{ 'overviewWrapper.chart1CardTitle4' |
+                        translate }}</span>
+                </div>
+                <div class="card-body">
+                    <app-generic-table [displayedColumns]="investmentBySectorColumns"
+                        [tableData]="investmentBySectorTable" [tableDataChange]="investmentBySectorTable.data">
+                    </app-generic-table>
                 </div>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -8,6 +8,7 @@ import { SOURCES } from 'src/app/tools/constants/filters';
 import { disaggregatePictorialData } from 'src/app/tools/functions/chart-data';
 import { FiltersStateService } from '../../services/filters-state.service';
 import { OverviewService } from '../../services/overview.service';
+import { TableItem } from '../generic-table/generic-table.component';
 
 @Component({
   selector: 'app-overview-wrapper',
@@ -15,7 +16,7 @@ import { OverviewService } from '../../services/overview.service';
   styleUrls: ['./overview-wrapper.component.scss']
 })
 export class OverviewWrapperComponent implements OnInit, OnDestroy {
-  @Input() selectedType: string; // country or retailer
+  @Input() selectedType: 'country' | 'retailer';
   @Input() requestInfoChange: Observable<boolean>;
   @Input() showTrafficAndSalesSection: boolean = true;
 
@@ -111,6 +112,17 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
   ];
 
   categoriesBySector: any[] = [];
+
+  investmentBySectorColumns: TableItem[] = [
+    { name: 'name', title: 'País' },
+    { name: 'ps', title: 'PS', textAlign: 'center', formatValue: 'currency' },
+    { name: 'hw_print', title: 'HW Print', textAlign: 'center', formatValue: 'currency' },
+    { name: 'supplies', title: 'Supplies', textAlign: 'center', formatValue: 'currency' },
+  ];
+  investmentBySectorTable = {
+    data: [],
+    reqStatus: 0
+  };
 
   trafficOrSales = {};
 
@@ -291,7 +303,10 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
   getCategoriesBySector(selectedSector: any) {
     this.categoriesReqStatus = 1;
+    this.investmentBySectorTable.reqStatus = 1;
+
     this.selectedSectorTabHM = selectedSector;
+
     this.overviewService.getCategoriesBySector(selectedSector?.name).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
@@ -301,6 +316,21 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         const errorMsg = error?.error?.message ? error.error.message : error?.message;
         console.error(`[overview-wrapper.component]: ${errorMsg}`);
         this.categoriesReqStatus = 3;
+      });
+
+    this.investmentBySectorColumns[0].title = this.selectedType === 'country' ? 'Retailer' : 'Sector';
+
+    this.overviewService.getInvestmentBySector(selectedSector?.name).subscribe(
+      (resp: any[]) => {
+        this.investmentBySectorTable.data = resp;
+        this.investmentBySectorTable.reqStatus = 2;
+      },
+      error => {
+        const errorMsg = error?.error?.message ? error.error.message : error?.message;
+        console.error(`[overview-wrapper.component]: ${errorMsg}`);
+
+        this.investmentBySectorTable.data = [];
+        this.investmentBySectorTable.reqStatus = 3;
       });
 
     // Tabs are only used for country view

--- a/src/app/modules/dashboard/services/overview.service.ts
+++ b/src/app/modules/dashboard/services/overview.service.ts
@@ -148,6 +148,18 @@ export class OverviewService {
     }
   }
 
+  getInvestmentBySector(sector?: string) {
+    if (this.retailerID) {
+      let queryParams = this.concatedQueryParams();
+      return this.http.get(`${this.baseUrl}/retailers/${this.retailerID}/sectors/investment?${queryParams}`);
+    } else if (this.countryID) {
+      let queryParams = this.concatedQueryParams(null, null, null, null, true);
+      return this.http.get(`${this.baseUrl}/countries/${this.countryID}/retailers/investment?sector=${sector}&${queryParams}`);
+    } else {
+      return throwError('[overview.service]: not retailerID or countryID provided');
+    }
+  }
+
   // *** traffic or sales + submetric ***
   getTrafficOrSales(metricType: string, subMetricType: string) {
     if (!metricType) {


### PR DESCRIPTION
# Problem Description
- Is necessary show the following tables in overview-wrapper component
   - Investment by retailer and category for Country view
   - Investment by sector and category for Retailer view

# Features
- Update overview service to add these endpoints GET requests
- Update overview-wrapper component to add requests in load the table in template

# Where this change will be used
- In Country overview at `/dashboard/country` path
- In Retailer overview at `/dashboard/retailer` path

# More details
- Country view
![image](https://user-images.githubusercontent.com/38545126/129118075-9dd50c27-b9c5-4444-9f8d-9e8c6a4bf980.png)

- Retailer view
![image](https://user-images.githubusercontent.com/38545126/129118057-ab8c092a-10ac-4f06-b20b-120708b4432f.png)
