### PR TITLE
add patch to avoid adding access to other tools section from some retailers

### DIFF
--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -482,12 +482,20 @@ export class SidebarComponent implements OnInit, OnDestroy {
           ];
 
           if (item.indexed || item.omnichat || item.pc_selector) {
-            submenu.push({
-              title: this.translate.instant('dashboard.otherTools'),
-              path: '/dashboard/tools',
-              paramName: 'retailer',
-              param: item.name.toLowerCase().replaceAll(' ', '-')
-            });
+
+            // Patch to avoid adding the access to other tools from the following retailers
+            // AR - Garbarino (id 1)
+            // AR - Walmart (id 2)
+            // AR - Compumundo (id 4)
+            // CL - Alkosto (id 14)
+            if (item.id !== 1 && item.id !== 2 && item.id !== 4 && item.id !== 14) {
+              submenu.push({
+                title: this.translate.instant('dashboard.otherTools'),
+                path: '/dashboard/tools',
+                paramName: 'retailer',
+                param: item.name.toLowerCase().replaceAll(' ', '-')
+              });
+            }
           }
           return {
             id: item.id,


### PR DESCRIPTION
# Problem Description
- For some retailers is necessary to add patch to avoid adding access to other tools section

# Features
- Add patch to avoid adding access to other tools section from some retailers in sidebar component

# Where this change will be used
- In retailers options displayed in sidebar

# More details
![image](https://user-images.githubusercontent.com/38545126/129229662-fc8fac74-ffcd-4f6e-81a2-bb5dce13ed78.png)
![image](https://user-images.githubusercontent.com/38545126/129229708-08a0fb97-4472-4629-8977-f7b12aff3c93.png)
