### PR TITLE
add i18n to audiences-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -11,19 +11,19 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="getDomographicsByMetric('traffic')">{{ 'general.traffic' | translate }}</a>
+                            (click)="getDemographicsByMetric('traffic')">{{ 'general.traffic' | translate }}</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="getDomographicsByMetric('conversions')">{{ 'general.conversions' | translate }}</a>
+                            (click)="getDemographicsByMetric('conversions')">{{ 'general.conversions' | translate }}</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
-                            (click)="getDomographicsByMetric('aup')">AUP</a>
+                            (click)="getDemographicsByMetric('aup')">AUP</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 4}"
-                            (click)="getDomographicsByMetric('bouncerate')">BR</a>
+                            (click)="getDemographicsByMetric('bouncerate')">BR</a>
                     </li>
                 </ul>
             </div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -3,7 +3,7 @@
     <div class="row mt-4">
         <div class="col-12">
             <div class="mb-3">
-                <span class="h3">Análisis por Tráfico, Conversiones, AUP y BR</span>
+                <span class="h3">{{ 'audiences.section1Title' | translate }}</span>
             </div>
         </div>
         <div class="col-12">
@@ -11,11 +11,11 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                            (click)="getDomographicsByMetric('traffic')">Tráfico</a>
+                            (click)="getDomographicsByMetric('traffic')">{{ 'general.traffic' | translate }}</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                            (click)="getDomographicsByMetric('conversions')">Conversiones</a>
+                            (click)="getDomographicsByMetric('conversions')">{{ 'general.conversions' | translate }}</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
@@ -36,12 +36,16 @@
             <!-- devices -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card height-fluid">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por dispositivos</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por dispositivos</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por dispositivos</span>
-                        <span *ngSwitchCase="4" class="h4">BR por dispositivos</span>
+                    <div class="card-header h4">
+                        <ng-container [ngSwitch]="selectedTab1">
+                            <span *ngSwitchCase="1">{{ 'general.traffic' | translate }}</span>
+                            <span *ngSwitchCase="2">{{ 'general.conversions' | translate }}</span>
+                            <span *ngSwitchCase="3">AUP</span>
+                            <span *ngSwitchCase="4">BR</span>
+                        </ng-container>
+                        <span>{{ 'charts.byDevice' | translate }}</span>
                     </div>
+
                     <div class="card-body">
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
@@ -78,12 +82,16 @@
             <!-- gender -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card height-fluid">
-                    <div class="card-header" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">Tráfico por Género</span>
-                        <span *ngSwitchCase="2" class="h4">Conversiones por Género</span>
-                        <span *ngSwitchCase="3" class="h4">AUP por Género</span>
-                        <span *ngSwitchCase="4" class="h4">BR por Género</span>
+                    <div class="card-header h4">
+                        <ng-container [ngSwitch]="selectedTab1">
+                            <span *ngSwitchCase="1">{{ 'general.traffic' | translate }}</span>
+                            <span *ngSwitchCase="2">{{ 'general.conversions' | translate }}</span>
+                            <span *ngSwitchCase="3">AUP</span>
+                            <span *ngSwitchCase="4">BR</span>
+                        </ng-container>
+                        <span>{{ 'charts.byGender' | translate }}</span>
                     </div>
+
                     <div class="card-body">
                         <div class="row">
                             <div class="col-12 col-xl-6 mt-5 mt-xl-0">
@@ -99,7 +107,7 @@
                                 <app-chart-pictorial [data]="demographics?.men" name="aud-gender-man"
                                     [uniqueDimensionConf]="{color: '#67B6DC'}" category="name" iconType="man"
                                     [status]="demoReqStatus[1].reqStatus"
-                                    [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'"
+                                    [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate"
                                     height="280px">
                                 </app-chart-pictorial>
                             </div>
@@ -116,7 +124,7 @@
                                 <app-chart-pictorial [data]="demographics?.women" name="aud-gender-woman"
                                     [uniqueDimensionConf]="{color: '#6794DC'}" category="name" iconType="woman"
                                     [status]="demoReqStatus[1].reqStatus"
-                                    [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'"
+                                    [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate"
                                     height="280px">
                                 </app-chart-pictorial>
                             </div>
@@ -131,8 +139,8 @@
             <!-- devices -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header">
-                        <span class="h4">AUP por dispositivos</span>
+                    <div class="card-header h4">
+                        <span>AUP {{ 'charts.byDevice' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <app-chart-bar name="aud-devices" [data]="demographics?.device"
@@ -146,14 +154,14 @@
             <!-- gender -->
             <div class="col-12 col-md-6 mt-4">
                 <div class="card">
-                    <div class="card-header">
-                        <span class="h4">AUP por Género</span>
+                    <div class="card-header h4">
+                        <span>AUP {{ 'charts.byGender' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <app-chart-bar name="aud-gender" [data]="demographics?.gender"
                             [status]="demoReqStatus[1].reqStatus" valueFormat="USD" category="name" height="280px"
                             [legendsByCategory]="true"
-                            [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'">
+                            [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate">
                         </app-chart-bar>
                     </div>
                 </div>
@@ -163,18 +171,21 @@
         <!-- age -->
         <div class="col-12 col-md-6 mt-4">
             <div class="card">
-                <div class="card-header" [ngSwitch]="selectedTab1">
-                    <span *ngSwitchCase="1" class="h4">Tráfico por Edad</span>
-                    <span *ngSwitchCase="2" class="h4">Conversiones por Edad</span>
-                    <span *ngSwitchCase="3" class="h4">AUP por Edad</span>
-                    <span *ngSwitchCase="4" class="h4">BR por Edad</span>
+                <div class="card-header h4">
+                    <ng-container [ngSwitch]="selectedTab1">
+                        <span *ngSwitchCase="1">{{ 'general.traffic' | translate }}</span>
+                        <span *ngSwitchCase="2">{{ 'general.conversions' | translate }}</span>
+                        <span *ngSwitchCase="3">AUP</span>
+                        <span *ngSwitchCase="4">BR</span>
+                    </ng-container>
+                    <span>{{ 'charts.byAge' | translate }}</span>
                 </div>
                 <div class="card-body">
                     <app-chart-lollipop name="aud-age" [data]="demographics?.age" category="age"
                         [value]="selectedTab1 === 1 ? 'visits' : selectedTab1 === 2 ? 'sales' : selectedTab1 === 3 ? 'aup' : 'value'"
                         [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
                         height="280px" [status]="demoReqStatus[2].reqStatus"
-                        [emptyDataLegend]="retailerID === 11 && 'Sin acceso a información por decisión del Retail'">
+                        [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate">
                     </app-chart-lollipop>
                 </div>
             </div>
@@ -183,11 +194,14 @@
         <!-- age and gender -->
         <div class="col-12 col-md-6 mt-4">
             <div class="card">
-                <div class="card-header" [ngSwitch]="selectedTab1">
-                    <span *ngSwitchCase="1" class="h4">Tráfico por Género y Edad</span>
-                    <span *ngSwitchCase="2" class="h4">Conversiones por Género y Edad</span>
-                    <span *ngSwitchCase="3" class="h4">AUP por Género y Edad</span>
-                    <span *ngSwitchCase="4" class="h4">BR por Género y Edad</span>
+                <div class="card-header h4" [ngSwitch]="selectedTab1">
+                    <ng-container>
+                        <span *ngSwitchCase="1">{{ 'general.traffic' | translate }}</span>
+                        <span *ngSwitchCase="2">{{ 'general.conversions' | translate }}</span>
+                        <span *ngSwitchCase="3">AUP</span>
+                        <span *ngSwitchCase="4">BR</span>
+                    </ng-container>
+                    <span>{{ 'charts.byGenderAndAge' | translate }}</span>
                 </div>
                 <div class="card-body" style="height: 328px">
                     <!-- loader -->
@@ -209,7 +223,7 @@
                             {{ 'general.withoutData2' | translate }}
                         </p>
                         <p *ngIf="retailerID === 11">
-                            Sin acceso a información por decisión del Retail
+                            {{ 'audiences.retailErrorMsg' | translate }}
                         </p>
                     </div>
 
@@ -229,7 +243,7 @@
     <div class="row mt-5">
         <div class="col-12">
             <div class="mb-3">
-                <span class="h3">Tráfico y conversiones por hora y por día</span>
+                <span class="h3">{{ 'audiences.section2Title' | translate }}</span>
             </div>
         </div>
         <div class="col-12">
@@ -237,11 +251,12 @@
                 <ul class="nav nav-pills nav-fill">
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 1}"
-                            (click)="getWeekdaysAndHoursByMetric('traffic')">Tráfico</a>
+                            (click)="getWeekdaysAndHoursByMetric('traffic')">{{ 'general.traffic' | translate }}</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                            (click)="getWeekdaysAndHoursByMetric('conversions')">Conversiones</a>
+                            (click)="getWeekdaysAndHoursByMetric('conversions')">{{ 'general.conversions' | translate
+                            }}</a>
                     </li>
                 </ul>
             </div>
@@ -252,8 +267,10 @@
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}}
-                        por día de la semana y hora del día</span>
+                    <span class="h4">
+                        {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.conversions') | translate) +
+                        ('charts.byDayAndHour' | translate) }}
+                    </span>
                 </div>
                 <div class="card-body">
                     <app-chart-heat-map name="aud-weekday-sesions" [data]="weekDaysAndHours?.weekdayAndHour"
@@ -265,8 +282,10 @@
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}}
-                        por día de la semana</span>
+                    <span class="h4">
+                        {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.conversions') | translate) +
+                        ('charts.byWeekday' | translate) }}
+                    </span>
                 </div>
                 <div class="card-body">
                     <app-chart-bar-horizontal name="aud-traffic-day" [data]="weekDaysAndHours?.weekday"
@@ -278,8 +297,10 @@
 
             <div class="card mt-4">
                 <div class="card-header">
-                    <span class="h4">{{selectedTab2 === 1 ? 'Tráfico' : 'Conversiones'}}
-                        por hora del día</span>
+                    <span class="h4">
+                        {{ ((selectedTab2 === 1 ? 'general.traffic' : 'general.conversions') | translate) +
+                        ('charts.byHour' | translate) }}
+                    </span>
                 </div>
                 <div class="card-body">
                     <app-chart-lollipop name="aud-traffic-hour" [data]="weekDaysAndHours?.hour"
@@ -293,12 +314,12 @@
     <!-- CONVERSIONES VS TRÁFICO -->
     <div class="row mt-5">
         <div class="col-12">
-            <span class="h3">Conversiones - Tráfico</span>
+            <span class="h3">{{ 'audiences.section3Title' | translate }}</span>
         </div>
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">Conversiones y tráfico por día de la semana</span>
+                    <span class="h4">{{ 'audiences.chart10CardTitle' | translate }}</span>
                 </div>
                 <div class="card-body">
                     <!-- <app-chart-multiple-axes name="aud-conv-tra-day" category="weekday" value1="conversions" value2="visits"
@@ -308,8 +329,8 @@
 
                     <app-chart-column-line-mix name="aud-conv-tra-day" [data]="conversionsVsTraffic?.weekday"
                         [status]="conversionsVsTrafficReqStatus[0].reqStatus" category="weekdayName"
-                        columnValue="visits" lineValue="conversions" columnName="Tráfico" lineName="Conversiones"
-                        [XYCursor]="true">
+                        columnValue="visits" lineValue="conversions" [columnName]="'general.traffic' | translate"
+                        [lineName]="'general.conversions' | translate" [XYCursor]="true">
                     </app-chart-column-line-mix>
                 </div>
             </div>
@@ -317,7 +338,7 @@
         <div class="col-12 col-lg-6 mt-4">
             <div class="card">
                 <div class="card-header">
-                    <span class="h4">Conversiones y tráfico por hora del día</span>
+                    <span class="h4">{{ 'audiences.chart11CardTitle' | translate }}</span>
                 </div>
                 <div class="card-body">
                     <!-- <app-chart-multiple-axes name="aud-conv-tra-hour" category="hour" value1="conversions" value2="visits"
@@ -327,8 +348,8 @@
 
                     <app-chart-column-line-mix name="aud-conv-tra-hour" [data]="conversionsVsTraffic?.hour"
                         [status]="conversionsVsTrafficReqStatus[1].reqStatus" category="hour" columnValue="visits"
-                        lineValue="conversions" columnName="Tráfico" lineName="Conversiones" joinTextInTooltip="a las"
-                        [XYCursor]="true">
+                        lineValue="conversions" [columnName]="'general.traffic' | translate"
+                        [lineName]="'general.conversions' | translate" joinTextInTooltip="a las" [XYCursor]="true">
                     </app-chart-column-line-mix>
                 </div>
             </div>
@@ -339,22 +360,18 @@
 <!-- INTERESTS -->
 <div class="row mt-5">
     <div class="col-12">
-        <span class="h3">Audiencias - Afinidad y Mercado</span>
+        <span class="h3">{{ 'audiences.section4Title' | translate }}</span>
     </div>
     <div class="col-12 col-xl-6 mt-4">
         <div class="card height-fluid">
             <div class="card-header header-info">
-                <span class="h4 mr-2 mb-0">Categoría de afinidad</span>
+                <span class="h4 mr-2 mb-0">{{ 'charts.affinityCategory' | translate }}</span>
                 <div class="info-popover" ngbDropdown>
                     <a ngbDropdownToggle>
                         <i class="fas fa-info-circle"></i>
                     </a>
                     <div class="content" ngbDropdownMenu>
-                        <p>
-                            Las categorías de afinidad se utilizan para llegar a clientes potenciales, para que conozcan
-                            la marca o producto. Estos son usuarios que se encuentran más arriba en el embudo de compra,
-                            cerca del comienzo del proceso.
-                        </p>
+                        <p>{{ 'charts.affinityCategoryDesc' | translate }}</p>
                     </div>
                 </div>
             </div>
@@ -364,7 +381,8 @@
                 </app-chart-bar-horizontal>
 
                 <small class="text-muted mt-2 d-block d-sm-none">
-                    Para mejor visualización usar la versión de <strong>Escritorio</strong>
+                    {{ 'charts.mobileSuggestion' | translate }} <strong>{{ 'charts.mobileSuggestion2' | translate
+                        }}</strong>
                 </small>
             </div>
         </div>
@@ -372,17 +390,13 @@
     <div class="col-12 col-xl-6 mt-4">
         <div class="card height-fluid">
             <div class="card-header header-info">
-                <span class="h4 mr-2 mb-0">Segmento de mercado</span>
+                <span class="h4 mr-2 mb-0">{{ 'charts.marketSegment' | translate }}</span>
                 <div class="info-popover" ngbDropdown>
                     <a ngbDropdownToggle>
                         <i class="fas fa-info-circle"></i>
                     </a>
                     <div class="content" ngbDropdownMenu>
-                        <p>
-                            Es más probable que los usuarios de estos segmentos estén listos para comprar productos o
-                            servicios en la categoría especificada. Estos son los usuarios que se encuentran más abajo
-                            en el embudo de compra, cerca del final del proceso.
-                        </p>
+                        <p>{{ 'charts.marketSegmentDesc' | translate }}</p>
                     </div>
                 </div>
             </div>
@@ -391,7 +405,8 @@
                     [status]="interestsReqStatus[1].reqStatus" value="users" [singleColorBars]="true">
                 </app-chart-bar-horizontal>
                 <small class="text-muted mt-2 d-block d-sm-none">
-                    Para mejor visualización usar la versión de <strong>Escritorio</strong>
+                    {{ 'charts.mobileSuggestion' | translate }} <strong>{{ 'charts.mobileSuggestion2' | translate
+                        }}</strong>
                 </small>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -349,7 +349,8 @@
                     <app-chart-column-line-mix name="aud-conv-tra-hour" [data]="conversionsVsTraffic?.hour"
                         [status]="conversionsVsTrafficReqStatus[1].reqStatus" category="hour" columnValue="visits"
                         lineValue="conversions" [columnName]="'general.traffic' | translate"
-                        [lineName]="'general.conversions' | translate" joinTextInTooltip="a las" [XYCursor]="true">
+                        [lineName]="'general.conversions' | translate" [joinTextInTooltip]="'others.atHour' | translate"
+                        [XYCursor]="true">
                     </app-chart-column-line-mix>
                 </div>
             </div>

--- a/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
+++ b/src/app/modules/dashboard/components/audiences-wrapper/audiences-wrapper.component.html
@@ -145,7 +145,7 @@
                     <div class="card-body">
                         <app-chart-bar name="aud-devices" [data]="demographics?.device"
                             [status]="demoReqStatus[0].reqStatus" valueFormat="USD" category="name" height="280px"
-                            [legendsByCategory]="true">
+                            [legendsByCategory]="false">
                         </app-chart-bar>
                     </div>
                 </div>
@@ -160,7 +160,7 @@
                     <div class="card-body">
                         <app-chart-bar name="aud-gender" [data]="demographics?.gender"
                             [status]="demoReqStatus[1].reqStatus" valueFormat="USD" category="name" height="280px"
-                            [legendsByCategory]="true"
+                            [legendsByCategory]="false"
                             [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate">
                         </app-chart-bar>
                     </div>
@@ -183,8 +183,8 @@
                 <div class="card-body">
                     <app-chart-lollipop name="aud-age" [data]="demographics?.age" category="age"
                         [value]="selectedTab1 === 1 ? 'visits' : selectedTab1 === 2 ? 'sales' : selectedTab1 === 3 ? 'aup' : 'value'"
-                        [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
-                        height="280px" [status]="demoReqStatus[2].reqStatus"
+                        [valueFormat]="selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'" height="280px"
+                        [status]="demoReqStatus[2].reqStatus"
                         [emptyDataLegend]="retailerID === 11 && 'audiences.retailErrorMsg' | translate">
                     </app-chart-lollipop>
                 </div>
@@ -209,14 +209,13 @@
                     </app-chart-loader>
 
                     <!-- ready -->
-                    <app-chart-pyramid *ngIf="demographics?.genderByAge?.length > 0" name="aud-age-and-gender"
-                        [data]="demographics?.genderByAge" [status]="demoReqStatus[3].reqStatus"
-                        [valueFormat]="selectedTab1 === 2 || selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'"
-                        height="280px">
+                    <app-chart-pyramid *ngIf="demographics?.genderAndAge?.length > 0" name="aud-age-and-gender"
+                        [data]="demographics?.genderAndAge" [status]="demoReqStatus[3].reqStatus"
+                        [valueFormat]="selectedTab1 === 3 ? 'USD' :  selectedTab1 === 4 && '%'" height="280px">
                     </app-chart-pyramid>
 
                     <!-- empty data -->
-                    <div *ngIf="demoReqStatus[3].reqStatus === 2 && demographics?.genderByAge?.length === 0"
+                    <div *ngIf="demoReqStatus[3].reqStatus === 2 && demographics?.genderAndAge?.length === 0"
                         class="chart-error-container text-muted text-center">
                         <p *ngIf="retailerID !== 11">
                             {{ 'general.withoutData' | translate }} <br>

--- a/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-column-line-mix/chart-column-line-mix.component.ts
@@ -5,6 +5,7 @@ import am4themes_animated from '@amcharts/amcharts4/themes/animated';
 import { loadLanguage } from 'src/app/tools/functions/chart-lang';
 import { Subscription } from 'rxjs';
 import { AppStateService } from 'src/app/services/app-state.service';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-chart-column-line-mix',
@@ -22,7 +23,7 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit, OnDes
   @Input() height: string = '350px' // height property value valid in css
   @Input() status: number = 2; // 0) initial 1) load 2) ready 3) error
   @Input() errorLegend: string;
-  @Input() joinTextInTooltip: string = 'en';
+  @Input() joinTextInTooltip: string = this.translate.instant('others.onDay');;
   @Input() zebraBars: boolean;
   @Input() XYCursor: boolean;
 
@@ -50,12 +51,17 @@ export class ChartColumnLineMixComponent implements OnInit, AfterViewInit, OnDes
   langSub: Subscription;
 
   constructor(
-    private appStateService: AppStateService
+    private appStateService: AppStateService,
+    private translate: TranslateService
   ) { }
 
   ngOnInit(): void {
     this.langSub = this.appStateService.selectedLang$.subscribe((lang: string) => {
       this.loadChart(lang);
+
+      if (this.joinTextInTooltip === 'en') {
+        this.joinTextInTooltip = this.translate.instant('others.onDay');
+      }
     });
   }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -203,6 +203,8 @@
     },
     "others": {
         "by": "by",
+        "onDay": "on",
+        "atHour": "at",
         "all": "all",
         "allPluralM": "all",
         "allPluralF": "all",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -131,6 +131,15 @@
         "panel3Title": "Behavior",
         "panel4Title": "Conversion"
     },
+    "audiences": {
+        "section1Title": "Analysis by Traffic, Conversions, AUP and BR",
+        "retailErrorMsg": "No access to information due to Retail decision",
+        "section2Title": "Traffic and Conversions by weekday and hour",
+        "section3Title": "Conversions - Traffic",
+        "chart10CardTitle": "Conversions and Traffic by weekday",
+        "chart11CardTitle": "Conversions and Traffic by time of day",
+        "section4Title": "Audiences - Affinity and Market"
+    },
     "googleBusiness": {
         "province": "Province",
         "city": "City",
@@ -143,7 +152,15 @@
         "byGender": " by Gender",
         "byAge": " by Age",
         "byGenderAndAge": " by Gender and Age",
-        "byDayAndHour": " by day of week and time of day"
+        "byDayAndHour": " by day of week and time of day",
+        "byWeekday": " by weekday",
+        "byHour": " by time of day",
+        "affinityCategory": "Affinity category",
+        "affinityCategoryDesc": "Affinity categories are used to reach potential customers, so that they know the brand or product. These are users higher up the buying funnel, near the beginning of the process.",
+        "marketSegment": "Market segment",
+        "marketSegmentDesc": "Users in these segments are more likely to be ready to buy products or services in the specified category. These are the users further down the purchase funnel, near the end of the process.",
+        "mobileSuggestion": "For better viewing use the",
+        "mobileSuggestion2": "desktop version"
     },
     "paginator": {
         "itemsPerPage": "Items per page",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -203,6 +203,8 @@
     },
     "others": {
         "by": "por",
+        "onDay": "en",
+        "atHour": "a las",
         "all": "todo",
         "allPluralM": "todos",
         "allPluralF": "todas",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -131,6 +131,15 @@
         "panel3Title": "Comportamiento",
         "panel4Title": "Conversión"
     },
+    "audiences": {
+        "section1Title": "Análisis por Tráfico, Conversiones, AUP y BR",
+        "retailErrorMsg": "Sin acceso a información por decisión del Retail",
+        "section2Title": "Tráfico y Conversiones por hora y por día",
+        "section3Title": "Conversiones - Tráfico",
+        "chart10CardTitle": "Conversiones y Tráfico por día de la semana",
+        "chart11CardTitle": "Conversiones y Tráfico por hora del día",
+        "section4Title": "Audiencias - Afinidad y Mercado"
+    },
     "googleBusiness": {
         "province": "Provincia",
         "city": "Ciudad",
@@ -143,7 +152,15 @@
         "byGender": " por Género",
         "byAge": " por Edad",
         "byGenderAndAge": " por Género y Edad",
-        "byDayAndHour": " por día de la semana y hora del día"
+        "byDayAndHour": " por día de la semana y hora del día",
+        "byWeekday": " por día de la semana",
+        "byHour": " por hora del día",
+        "affinityCategory": "Categoría de afinidad",
+        "affinityCategoryDesc": "Las categorías de afinidad se utilizan para llegar a clientes potenciales, para que conozcan la marca o producto. Estos son usuarios que se encuentran más arriba en el embudo de compra, cerca del comienzo del proceso.",
+        "marketSegment": "Segmento de mercado",
+        "marketSegmentDesc": "Es más probable que los usuarios de estos segmentos estén listos para comprar productos o servicios en la categoría especificada. Estos son los usuarios que se encuentran más abajo en el embudo de compra, cerca del final del proceso.",
+        "mobileSuggestion": "Para mejor visualización usar la versión de",
+        "mobileSuggestion2": "Escritorio"
     },
     "paginator": {
         "itemsPerPage": "Registros por página",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -131,6 +131,15 @@
         "panel3Title": "Comportamento",
         "panel4Title": "Conversão"
     },
+    "audiences": {
+        "section1Title": "Análise por tráfego, conversões, AUP e BR",
+        "retailErrorMsg": "Sem acesso às informações devido à decisão de varejo",
+        "section2Title": "Tráfego e Conversões por hora e por dia",
+        "section3Title": "Conversões - Tráfego",
+        "chart10CardTitle": "Conversões e Tráfego por dia",
+        "chart11CardTitle": "Conversões e Tráfego por hora do dia",
+        "section4Title": "Públicos - Afinidade e Mercado"
+    },
     "googleBusiness": {
         "province": "Província",
         "city": "Cidade",
@@ -143,7 +152,15 @@
         "byGender": " por Gênero",
         "byAge": " por Idade",
         "byGenderAndAge": " por Gênero e Idade",
-        "byDayAndHour": " por dia da semana e hora do dia"
+        "byDayAndHour": " por dia da semana e hora do dia",
+        "byWeekday": " por dia da semana",
+        "byHour": " por hora do dia",
+        "affinityCategory": "Categoria de afinidade",
+        "affinityCategoryDesc": "As categorias de afinidade são usadas para alcançar clientes em potencial, para que eles conheçam a marca ou o produto. Esses são os usuários na parte superior do funil de compra, perto do início do processo.",
+        "marketSegment": "Segmento de mercado",
+        "marketSegmentDesc": "Os usuários nesses segmentos são mais propensos a estar prontos para comprar produtos ou serviços na categoria especificada. Esses são os usuários mais abaixo no funil de compra, perto do final do processo.",
+        "mobileSuggestion": "Para melhor visualização use a versão",
+        "mobileSuggestion2": "Desktop"
     },
     "paginator": {
         "itemsPerPage": "Itens por página",
@@ -194,8 +211,8 @@
         "otherPluralM": "outros",
         "otherPluralF": "outras",
         "only": "somente",
-        "men": "Masculino",
-        "women": "Feminino",
+        "men": "Homens",
+        "women": "Mulheres",
         "years": "anos",
         "multSelection": "Ctrl + click para seleção múltipla",
         "days": {

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -203,6 +203,8 @@
     },
     "others": {
         "by": "por",
+        "onDay": "de",
+        "atHour": "às",
         "all": "tudo",
         "allPluralM": "todos",
         "allPluralF": "todas",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to Campaign in retail > Audiences section

# Features
- Update i18n files
- Add i18n references to the following components:
   - audiences-wrapper
   - chart-column-line-mix component

# Bug Fixes
- Replace getSelectedMetricForDemo method by a an array and find function in audiences-wrapper component

# Where this change will be used
- In Retailer > Campaign in retail > Audiences section at `/dashboard/retailer` path
