### PR TITLE
add i18n to acquisition-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.html
@@ -4,12 +4,14 @@
         <div class="pills-container">
             <ul class="nav nav-pills nav-fill">
                 <li class="nav-item">
-                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}"
-                        (click)="getUsers('sectors')">Usuarios por Sector</a>
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 1}" (click)="getUsers('sectors')">
+                        {{ 'acquisition.chart1CardTitle1' | translate }}
+                    </a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}"
-                        (click)="getUsers('sources')">Usuarios por Fuente</a>
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 2}" (click)="getUsers('sources')">
+                        {{ 'acquisition.chart1CardTitle2' | translate }}
+                    </a>
                 </li>
             </ul>
         </div>
@@ -17,10 +19,12 @@
     <div class="col-12 mt-4">
         <div class="card">
             <div class="card-header">
-                <span class="h4">Usuarios por {{ selectedTab1 === 1 ? 'Sector' : 'Fuente '}}</span>
+                <span *ngIf="selectedTab1 === 1" class="h4">{{ 'acquisition.chart1CardTitle1' | translate }}</span>
+                <span *ngIf="selectedTab1 === 2" class="h4">{{ 'acquisition.chart1CardTitle2' | translate }}</span>
             </div>
             <div class="card-body">
-                <app-chart-line-series name="acq-users-sector" [series]="users" yTitle="Usuarios" [status]="usersReqStatus">
+                <app-chart-line-series name="acq-users-sector" [series]="users" [yTitle]="'general.users' | translate"
+                    [status]="usersReqStatus">
                 </app-chart-line-series>
             </div>
         </div>

--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import { strTimeFormat } from 'src/app/tools/functions/time-format';
 import { CampaignInRetailService } from '../../services/campaign-in-retail.service';
@@ -97,10 +98,18 @@ export class AcquisitionWrapperComponent implements OnInit, OnDestroy {
 
   generalFiltersSub: Subscription;
   retailFiltersSub: Subscription;
+  translateSub: Subscription;
 
   constructor(
     private filtersStateService: FiltersStateService,
-    private campInRetailService: CampaignInRetailService) { }
+    private campInRetailService: CampaignInRetailService,
+    private translate: TranslateService
+  ) {
+
+    this.translateSub = translate.stream('acquisition').subscribe(() => {
+      this.loadI18nContent();
+    });
+  }
 
   ngOnInit(): void {
     this.getAllData();
@@ -125,6 +134,7 @@ export class AcquisitionWrapperComponent implements OnInit, OnDestroy {
     this.campInRetailService.getDataByMetric('users', subMetricType).subscribe(
       (users: any[]) => {
         this.users = users;
+        this.loadi18ntoUsers();
         this.usersReqStatus = 2;
       },
       error => {
@@ -155,8 +165,32 @@ export class AcquisitionWrapperComponent implements OnInit, OnDestroy {
       });
   }
 
+  loadI18nContent() {
+    this.campaignsTableColumns[0].title = this.translate.instant('general.source');
+    this.campaignsTableColumns[1].title = this.translate.instant('general.medium');
+    this.campaignsTableColumns[2].title = this.translate.instant('general.campaign');
+    this.campaignsTableColumns[3].title = this.translate.instant('general.users');
+    this.campaignsTableColumns[4].title = this.translate.instant('general.new_users');
+    this.campaignsTableColumns[5].title = this.translate.instant('general.sessions');
+    this.campaignsTableColumns[6].title = this.translate.instant('general.pagesBySessions');
+    this.campaignsTableColumns[7].title = this.translate.instant('general.bounceRate');
+    this.campaignsTableColumns[8].title = this.translate.instant('general.sessionDuration');
+    this.campaignsTableColumns[9].title = this.translate.instant('general.amount');
+    this.campaignsTableColumns[10].title = this.translate.instant('general.productIncomes');
+
+    this.loadi18ntoUsers();
+  }
+
+  loadi18ntoUsers() {
+    if (this.users.length > 0 && this.selectedTab1 === 1) {
+      const salesItem = this.users.find(item => item.name === 'Ventas');
+      salesItem.name = this.translate.instant('general.sales');
+    }
+  }
+
   ngOnDestroy() {
     this.generalFiltersSub?.unsubscribe();
     this.retailFiltersSub?.unsubscribe();
+    this.translateSub?.unsubscribe();
   }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -140,6 +140,10 @@
         "chart11CardTitle": "Conversions and Traffic by time of day",
         "section4Title": "Audiences - Affinity and Market"
     },
+    "acquisition": {
+        "chart1CardTitle1": "Users by Sector",
+        "chart1CardTitle2": "Users by Source"
+    },
     "googleBusiness": {
         "province": "Province",
         "city": "City",
@@ -177,12 +181,15 @@
         "sector": "Sector",
         "category": "Category",
         "source": "Source",
+        "medium": "Medium",
         "campaign": "Campaign",
         "period": "Period",
         "traffic": "Traffic",
         "conversions": "Conversions",
         "sales": "Sales",
         "users": "Users",
+        "new_users": "New users",
+        "sessions": "Sessions",
         "investment": "Investment",
         "ranking": "Ranking",
         "product": "Product",
@@ -193,6 +200,10 @@
         "impressions": "Impressions",
         "clicks": "Clicks",
         "name": "Name",
+        "pagesBySessions": "Pages per session",
+        "bounceRate": "Bounce rate",
+        "sessionDuration": "Average session duration",
+        "productIncomes": "Product revenue",
         "usersVsSales": "Users - Conversions",
         "investmentVsRevenue": "Investment - Revenue",
         "revenueVsAup": "Revenue - AUP",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -140,6 +140,10 @@
         "chart11CardTitle": "Conversiones y Tráfico por hora del día",
         "section4Title": "Audiencias - Afinidad y Mercado"
     },
+    "acquisition": {
+        "chart1CardTitle1": "Usuarios por Sector",
+        "chart1CardTitle2": "Usuarios por Fuente"
+    },
     "googleBusiness": {
         "province": "Provincia",
         "city": "Ciudad",
@@ -177,12 +181,15 @@
         "sector": "Sector",
         "category": "Categoría",
         "source": "Fuente",
+        "medium": "Medio",
         "campaign": "Campaña",
         "period": "Período",
         "traffic": "Tráfico",
         "conversions": "Conversiones",
         "sales": "Ventas",
         "users": "Usuarios",
+        "new_users": "Nuevos usuarios",
+        "sessions": "Sesiones",
         "investment": "Inversión",
         "ranking": "Ranking",
         "product": "Producto",
@@ -193,6 +200,10 @@
         "impressions": "Impresiones",
         "clicks": "Clicks",
         "name": "Nombre",
+        "pagesBySessions": "Páginas por sesión",
+        "bounceRate": "Porcentaje de rebote",
+        "sessionDuration": "Duración media de la sesión",
+        "productIncomes": "Ingresos del producto",
         "usersVsSales": "Usuarios - Conversiones",
         "investmentVsRevenue": "Inversión - Revenue",
         "revenueVsAup": "Revenue - AUP",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -115,8 +115,8 @@
         "chart1Legend2": "Inativas"
     },
     "retailer": {
-        "campTowardsRetail": "Campanhas direcionadas para o varejo (retail)",
-        "campInRetail": "Campanhas no varejo (retail)"
+        "campTowardsRetail": "Campanhas direcionadas para o Retail",
+        "campInRetail": "Campanhas no Retail"
     },
     "campTowardsRetail": {
         "table1Error": "Erro ao consultar campanhas",
@@ -139,6 +139,10 @@
         "chart10CardTitle": "Conversões e Tráfego por dia",
         "chart11CardTitle": "Conversões e Tráfego por hora do dia",
         "section4Title": "Públicos - Afinidade e Mercado"
+    },
+    "acquisition": {
+        "chart1CardTitle1": "Usuários por Setor",
+        "chart1CardTitle2": "Usuários por Fonte"
     },
     "googleBusiness": {
         "province": "Província",
@@ -177,12 +181,15 @@
         "sector": "Setor",
         "category": "Categoria",
         "source": "Fonte",
-        "campaign": "Campaña",
+        "medium": "Mídia",
+        "campaign": "Campanha",
         "period": "Período",
         "traffic": "Tráfego",
         "conversions": "Conversões",
         "sales": "Vendas",
         "users": "Usuários",
+        "new_users": "Novos usuários",
+        "sessions": "Sessões",
         "investment": "Investimento",
         "ranking": "Ranking",
         "product": "Produtos",
@@ -193,6 +200,10 @@
         "impressions": "Impressões",
         "clicks": "Clicks",
         "name": "Nome",
+        "pagesBySessions": "Páginas por sessão",
+        "bounceRate": "Taxa de Rejeição",
+        "sessionDuration": "Duração média da sessão",
+        "productIncomes": "Receita do Produto",
         "usersVsSales": "Usuários - Conversões",
         "investmentVsRevenue": "Investimento - Revenue",
         "revenueVsAup": "Revenue - AUP",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to Campaign in retail > Acquisition section

# Features
- Update i18n files
- Add i18n references to acquisition-wrapper component

# Where this change will be used
- In Retailer > Campaign in retail > Acquisition section at `/dashboard/retailer` path