### PR TITLE
include 'on site' as sector in heatmap buttons in overview-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -12,30 +12,38 @@
     </div>
 
     <div class="row mt-5">
-        <div class="col-12" *ngIf="selectedType === 'country'">
+        <div class="col-12 mb-4" *ngIf="selectedType === 'country'">
             <div class="pills-container">
-                <ul class="nav nav-pills nav-fill" *ngIf="selectedSectors?.length > 1">
+                <ul class="nav nav-pills nav-fill">
                     <li class="nav-item mb-2" *ngFor="let sector of selectedSectors; let i = index">
                         <a class="nav-link p-2" [ngClass]="{'active': sector.id === selectedTab1}"
                             (click)="getCategoriesBySector(sector)">
                             {{ sector.name }}
                         </a>
                     </li>
+                    <li class="nav-item mb-2">
+                        <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 4}"
+                            (click)="getCategoriesBySector({id: 4, name: 'onsite'})">
+                            On Site
+                        </a>
+                    </li>
                 </ul>
             </div>
         </div>
 
-        <div class="col-12 mt-4">
+        <div class="col-12">
             <div class="card">
-                <div class="card-header">
+                <div class="card-header h4">
                     <ng-container *ngIf="selectedType === 'country'" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">{{ 'overviewWrapper.chart1CardTitle1' | translate }}</span>
-                        <span *ngSwitchCase="2" class="h4">{{ 'overviewWrapper.chart1CardTitle2' | translate }}</span>
-                        <span *ngSwitchCase="3" class="h4">{{ 'overviewWrapper.chart1CardTitle3' | translate }}</span>
+                        <span *ngSwitchCase="1">{{ 'overviewWrapper.chart1CardTitle1' | translate }}</span>
+                        <span *ngSwitchCase="2">{{ 'overviewWrapper.chart1CardTitle2' | translate }}</span>
+                        <span *ngSwitchCase="3">{{ 'overviewWrapper.chart1CardTitle3' | translate }}</span>
+                        <span *ngSwitchCase="4">{{ 'overviewWrapper.chart1CardTitle4' | translate }}</span>
                     </ng-container>
 
-                    <span *ngIf="selectedType === 'retailer'" class="h4">{{ 'overviewWrapper.chart1CardTitle4' |
-                        translate }}</span>
+                    <span *ngIf="selectedType === 'retailer'">
+                        {{ 'overviewWrapper.chart1CardTitle5' | translate }}
+                    </span>
                 </div>
                 <div class="card-body">
                     <div class="chart-legend mt-0 mb-2">
@@ -57,17 +65,18 @@
             </div>
         </div>
 
-        <div class="col-12 mt-4">
+        <div class="col-12 mt-4" *ngIf="selectedTab1 !== 4">
             <div class="card">
-                <div class="card-header">
+                <div class="card-header h4">
                     <ng-container *ngIf="selectedType === 'country'" [ngSwitch]="selectedTab1">
-                        <span *ngSwitchCase="1" class="h4">{{ 'overviewWrapper.chart1CardTitle1' | translate }}</span>
-                        <span *ngSwitchCase="2" class="h4">{{ 'overviewWrapper.chart1CardTitle2' | translate }}</span>
-                        <span *ngSwitchCase="3" class="h4">{{ 'overviewWrapper.chart1CardTitle3' | translate }}</span>
+                        <span *ngSwitchCase="1">{{ 'overviewWrapper.chart1CardTitle1' | translate }}</span>
+                        <span *ngSwitchCase="2">{{ 'overviewWrapper.chart1CardTitle2' | translate }}</span>
+                        <span *ngSwitchCase="3">{{ 'overviewWrapper.chart1CardTitle3' | translate }}</span>
                     </ng-container>
 
-                    <span *ngIf="selectedType === 'retailer'" class="h4">{{ 'overviewWrapper.chart1CardTitle4' |
-                        translate }}</span>
+                    <span *ngIf="selectedType === 'retailer'">
+                        {{ 'overviewWrapper.chart1CardTitle5' | translate }}
+                    </span>
                 </div>
                 <div class="card-body">
                     <app-generic-table [displayedColumns]="investmentBySectorColumns"

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -230,8 +230,13 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       // PRESERVE PREVIOUS SELECTION (TABS)
 
       // sectors heatmap
-      const previousSectorHM = this.selectedSectors.find(sector => sector.id === this.selectedSectorTabHM.id);
-      selectedSectorHM = previousSectorHM ? previousSectorHM : this.selectedSectors[0];
+      if (this.selectedTab1 !== 4) {
+        const previousSectorHM = this.selectedSectors.find(sector => sector.id === this.selectedSectorTabHM.id);
+        selectedSectorHM = previousSectorHM ? previousSectorHM : this.selectedSectors[0];
+      } else {
+        // onsite option is diplayed (and previous selected) apart of selected categories in filters
+        selectedSectorHM = { id: 4, name: 'onsite' };
+      }
 
       // demograhics
       demographicMetric = this.selectedTab2 === 1 ? 'traffic' : 'sales';
@@ -307,6 +312,9 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
     this.selectedSectorTabHM = selectedSector;
 
+    // Tabs are only used for country view
+    this.selectedTab1 = selectedSector.id;
+
     this.overviewService.getCategoriesBySector(selectedSector?.name).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
@@ -320,6 +328,10 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
 
     this.investmentBySectorColumns[0].title = this.selectedType === 'country' ? 'Retailer' : 'Sector';
 
+    if (selectedSector?.name === 'onsite') {
+      return;
+    }
+
     this.overviewService.getInvestmentBySector(selectedSector?.name).subscribe(
       (resp: any[]) => {
         this.investmentBySectorTable.data = resp;
@@ -332,9 +344,6 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         this.investmentBySectorTable.data = [];
         this.investmentBySectorTable.reqStatus = 3;
       });
-
-    // Tabs are only used for country view
-    this.selectedTab1 = selectedSector.id;
   }
 
   getTrafficOrSales(metricType: string) {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -110,7 +110,8 @@
         "chart1CardTitle1": "Categories by Retailer - Search",
         "chart1CardTitle2": "Categories by Retailer - Marketing",
         "chart1CardTitle3": "Categories by Retailer - Sales",
-        "chart1CardTitle4": "Categories by Sector",
+        "chart1CardTitle4": "Categories by Retailer - On Site",
+        "chart1CardTitle5": "Categories by Sector",
         "chart1Legend1": "Active",
         "chart1Legend2": "Inactive"
     },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -110,7 +110,8 @@
         "chart1CardTitle1": "Categorías por Retailer - Search",
         "chart1CardTitle2": "Categorías por Retailer - Marketing",
         "chart1CardTitle3": "Categorías por Retailer - Ventas",
-        "chart1CardTitle4": "Categorías por Sector",
+        "chart1CardTitle4": "Categorías por Retailer - On Site",
+        "chart1CardTitle5": "Categorías por Sector",
         "chart1Legend1": "Activas",
         "chart1Legend2": "Inactivas"
     },

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -110,7 +110,8 @@
         "chart1CardTitle1": "Categorias por Retailer - Search",
         "chart1CardTitle2": "Categorias por Retailer - Marketing",
         "chart1CardTitle3": "Categorias por Retailer - Vendas",
-        "chart1CardTitle4": "Categorias por Setor",
+        "chart1CardTitle4": "Categorias por Retailer - On Site",
+        "chart1CardTitle5": "Categorias por Setor",
         "chart1Legend1": "Ativas",
         "chart1Legend2": "Inativas"
     },


### PR DESCRIPTION
# Problem Description
- Is necessary update overview component template to show 'On site' button as an option in heatmap
- Hide investment table when 'On site' button is selected

# Features
- Update i18n files
- Update overview-wrapper component

# Where this change will be used
- In Country overview at `/dashboard/country` path

# More details
![image](https://user-images.githubusercontent.com/38545126/129410730-f2ac456d-5bcc-45a6-9ac5-43dbbf307ff6.png)
