### PR TITLE
add i18n to behaviour-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
+++ b/src/app/modules/dashboard/components/behaviour-wrapper/behaviour-wrapper.component.html
@@ -3,12 +3,13 @@
     <div class="col-12 mt-4 mb-5">
         <div class="card">
             <div class="card-header">
-                <span class="h4">Porcentaje de rebote y páginas vistas </span>
+                <span class="h4">{{ 'behaviour.chart1CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
-                <app-chart-multiple-axes name="bh-general-behavior" value1="page_views" valueName1="Páginas vistas"
-                    value2="bounce_rate" valueName2="Porcentaje de rebote" valueFormat2="%"
-                    [status]="brVsPagesViewedReqStatus" [data]="brVsPagesViewed">
+                <app-chart-multiple-axes name="bh-general-behavior" value1="page_views"
+                    [valueName1]="'general.pageViews' | translate" value2="bounce_rate"
+                    [valueName2]="'general.bounceRate' | translate" valueFormat2="%" [status]="brVsPagesViewedReqStatus"
+                    [data]="brVsPagesViewed">
                 </app-chart-multiple-axes>
             </div>
         </div>
@@ -21,7 +22,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Visitantes nuevos - Visitantes recurrentes</span>
+                <span class="h4">{{ 'behaviour.chart2CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sessions-ret-visitor" [data]="behavior.newUsersVsCurrent"
@@ -35,7 +36,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Conversiones Visitantes nuevos - Visitantes recurrentes</span>
+                <span class="h4">{{ 'behaviour.chart3CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-ret-visitor" [data]="behavior.salesNewUsersVsCurrent"
@@ -49,7 +50,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Conversiones por Fuente de conversión</span>
+                <span class="h4">{{ 'behaviour.chart4CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-by-conv-sorce" [data]="behavior.salesBySource"
@@ -63,7 +64,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Conversiones por Sector</span>
+                <span class="h4">{{ 'behaviour.chart5CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sales-by-sorce" [data]="behavior.salesBySector"
@@ -84,7 +85,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Sesiones por tipo de audiencia</span>
+                <span class="h4">{{ 'behaviour.chart6CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-sessions-by-audience" [data]="behavior.sessionsByAudience"
@@ -98,7 +99,7 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Usuarios nuevos por tipo de audiencia</span>
+                <span class="h4">{{ 'behaviour.chart7CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-pie name="bh-users-by-audience" [data]="behavior.newUsersByAudience" [minLegendHeight]="150"
@@ -112,11 +113,11 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Cantidad por tipo de audiencia</span>
+                <span class="h4">{{ 'behaviour.chart8CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-bar name="bh-quantity-by-audience" [data]="behavior.quantityByAudience"
-                    [minLegendHeight]="150" legendPosition="bottom" [status]="behaviorReqStatus[6].reqStatus">
+                    legendPosition="bottom" [status]="behaviorReqStatus[6].reqStatus">
                 </app-chart-bar>
             </div>
         </div>
@@ -126,12 +127,13 @@
     <div class="col-12 col-lg-6 col-xl-3 mt-4 mb-5">
         <div class="card">
             <div class="card-header">
-                <span class="h4">Revenue y AUP por tipo de audiencia</span>
+                <span class="h4">{{ 'behaviour.chart9CardTitle' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-column-line-mix name="bh-revenue-aup-audience" [data]="behavior.revenueAupByAudience"
                     category="audience" columnValue="revenue" columnName="Revenue" lineValue="aup" lineName="AUP"
-                    valueFormat="USD" [status]="behaviorReqStatus[7].reqStatus">
+                    valueFormat="USD" [status]="behaviorReqStatus[7].reqStatus"
+                    [joinTextInTooltip]="'others.in' | translate">
                 </app-chart-column-line-mix>
             </div>
         </div>

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -145,6 +145,17 @@
         "chart1CardTitle1": "Users by Sector",
         "chart1CardTitle2": "Users by Source"
     },
+    "behaviour": {
+        "chart1CardTitle": "Bounce rate and Page views",
+        "chart2CardTitle": "New Visitors - Recurring Visitors",
+        "chart3CardTitle": "Conversions New Visitors - Returning Visitors",
+        "chart4CardTitle": "Conversions by Conversion Source",
+        "chart5CardTitle": "Conversions by Sector",
+        "chart6CardTitle": "Sessions by type of audience",
+        "chart7CardTitle": "New users by audience type",
+        "chart8CardTitle": "Amount by type of audience",
+        "chart9CardTitle": "Revenue and AUP by type of audience"
+    },
     "googleBusiness": {
         "province": "Province",
         "city": "City",
@@ -201,10 +212,13 @@
         "impressions": "Impressions",
         "clicks": "Clicks",
         "name": "Name",
+        "pageViews": "Page views",
         "pagesBySessions": "Pages per session",
         "bounceRate": "Bounce rate",
         "sessionDuration": "Average session duration",
         "productIncomes": "Product revenue",
+        "newVisitors": "New visitors",
+        "recurringVisitors": "Recurring Visitors",
         "usersVsSales": "Users - Conversions",
         "investmentVsRevenue": "Investment - Revenue",
         "revenueVsAup": "Revenue - AUP",
@@ -215,6 +229,7 @@
     },
     "others": {
         "by": "by",
+        "in": "in",
         "onDay": "on",
         "atHour": "at",
         "all": "all",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -145,6 +145,17 @@
         "chart1CardTitle1": "Usuarios por Sector",
         "chart1CardTitle2": "Usuarios por Fuente"
     },
+    "behaviour": {
+        "chart1CardTitle": "Porcentaje de rebote y páginas vistas",
+        "chart2CardTitle": "Visitantes nuevos - Visitantes recurrentes",
+        "chart3CardTitle": "Conversiones Visitantes nuevos - Visitantes recurrentes",
+        "chart4CardTitle": "Conversiones por Fuente de conversión",
+        "chart5CardTitle": "Conversiones por Sector",
+        "chart6CardTitle": "Sesiones por tipo de audiencia",
+        "chart7CardTitle": "Usuarios nuevos por tipo de audiencia",
+        "chart8CardTitle": "Cantidad por tipo de audiencia",
+        "chart9CardTitle": "Revenue y AUP por tipo de audiencia"
+    },
     "googleBusiness": {
         "province": "Provincia",
         "city": "Ciudad",
@@ -201,10 +212,13 @@
         "impressions": "Impresiones",
         "clicks": "Clicks",
         "name": "Nombre",
+        "pageViews": "Páginas vistas",
         "pagesBySessions": "Páginas por sesión",
         "bounceRate": "Porcentaje de rebote",
         "sessionDuration": "Duración media de la sesión",
         "productIncomes": "Ingresos del producto",
+        "newVisitors": "Nuevos visitantes",
+        "recurringVisitors": "Visitantes recurrentes",
         "usersVsSales": "Usuarios - Conversiones",
         "investmentVsRevenue": "Inversión - Revenue",
         "revenueVsAup": "Revenue - AUP",
@@ -215,6 +229,7 @@
     },
     "others": {
         "by": "por",
+        "in": "en",
         "onDay": "en",
         "atHour": "a las",
         "all": "todo",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -145,6 +145,17 @@
         "chart1CardTitle1": "Usuários por Setor",
         "chart1CardTitle2": "Usuários por Fonte"
     },
+    "behaviour": {
+        "chart1CardTitle": "Taxa de rejeição e visualizações de página",
+        "chart2CardTitle": "Novos usuários vs visitantes recorrentes",
+        "chart3CardTitle": "Vendas de novos visitantes vs  Visitantes recorrentes",
+        "chart4CardTitle": "Vendas por fonte de conversão",
+        "chart5CardTitle": "Vendas por setor",
+        "chart6CardTitle": "Sessões por tipo de público",
+        "chart7CardTitle": "Novos usuários por tipo de público",
+        "chart8CardTitle": "Quantidade por tipo de público",
+        "chart9CardTitle": "Revenue y AUP por tipo de público"
+    },
     "googleBusiness": {
         "province": "Província",
         "city": "Cidade",
@@ -201,10 +212,13 @@
         "impressions": "Impressões",
         "clicks": "Clicks",
         "name": "Nome",
+        "pageViews": "Número de visualizações de página",
         "pagesBySessions": "Páginas por sessão",
         "bounceRate": "Taxa de Rejeição",
         "sessionDuration": "Duração média da sessão",
         "productIncomes": "Receita do Produto",
+        "newVisitors": "Novos usuários",
+        "recurringVisitors": "Visitantes recorrentes",
         "usersVsSales": "Usuários - Conversões",
         "investmentVsRevenue": "Investimento - Revenue",
         "revenueVsAup": "Revenue - AUP",
@@ -215,6 +229,7 @@
     },
     "others": {
         "by": "por",
+        "in": "em",
         "onDay": "de",
         "atHour": "às",
         "all": "tudo",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to Campaign in retail > Behaviour section

# Features
- Update i18n files
- Add i18n references to behaviour-wrapper component

# Where this change will be used
- In Retailer > Campaign in retail > Behaviour section at `/dashboard/retailer` path
