### PR TITLE
add i18n to omnichat-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -7,7 +7,7 @@
             </app-card-stat>
         </div>
         <p class="text-center text-muted mt-3 mb-0" [hidden]="kpisReqStatus !== 3">
-            Error al consultar datos
+            {{ 'general.errorData' | translate }}
         </p>
     </div>
 </div>
@@ -45,10 +45,10 @@
                 <app-chart-multiple-axes [data]="usersOrRevenue"
                     [value1]="selectedTab1 === 1 ? 'transactions' : 'revenue'"
                     [value2]="selectedTab1 === 1 ? 'users' : 'aup'"
-                    [valueName1]="selectedTab1 === 1 ? 'Conversiones' : 'Revenue'"
-                    [valueName2]="selectedTab1 === 1 ? 'Usuarios' : 'AUP'" [valueFormat1]="selectedTab1 === 2 && 'USD'"
-                    [valueFormat2]="selectedTab1 === 2 && 'USD'" name="omnichat-traffic-vs-conversions"
-                    [status]="usersOrRevenueReqStatus">
+                    [valueName1]="selectedTab1 === 1 ? ('general.conversions' | translate) : 'Revenue'"
+                    [valueName2]="selectedTab1 === 1 ? ('general.users' | translate ): 'AUP'"
+                    [valueFormat1]="selectedTab1 === 2 && 'USD'" [valueFormat2]="selectedTab1 === 2 && 'USD'"
+                    name="omnichat-traffic-vs-conversions" [status]="usersOrRevenueReqStatus">
                 </app-chart-multiple-axes>
             </div>
         </div>
@@ -60,8 +60,8 @@
 <div class="row mt-5">
     <div class="col-12">
         <div class="mb-3">
-            <span class="h3" *ngIf="!levelPage.retailer">Chats, Usuarios, Conversiones y Tasa de conversión</span>
-            <span class="h3" *ngIf="levelPage.retailer">Conversiones y Tasa de conversión</span>
+            <span class="h3" *ngIf="!levelPage.retailer">{{ 'omnichat.section1Title1' | translate }}</span>
+            <span class="h3" *ngIf="levelPage.retailer">{{ 'omnichat.section1Title2' | translate }}</span>
         </div>
     </div>
 
@@ -74,15 +74,15 @@
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 2}"
-                        (click)="getDataByLevel('traffic')">Usuarios</a>
+                        (click)="getDataByLevel('traffic')">{{ 'general.users' | translate }}</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 3}"
-                        (click)="getDataByLevel('sales')">Conversiones</a>
+                        (click)="getDataByLevel('sales')">{{ 'general.conversions' | translate }}</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 4}"
-                        (click)="getDataByLevel('conversion-rate')">Tasa de conversión</a>
+                        (click)="getDataByLevel('conversion-rate')">{{ 'general.conversionRate' | translate }}</a>
                 </li>
             </ul>
         </div>
@@ -91,13 +91,14 @@
     <!-- countries -->
     <div *ngIf="levelPage.latam" class="col-12 col-lg-4 mt-4" [ngClass]="{'col-lg-6': selectedTab2 < 3}">
         <div class="card height-fluid">
-            <div class="card-header">
+            <div class="card-header h4">
                 <ng-container [ngSwitch]="selectedTab2">
-                    <span *ngSwitchCase="1" class="h4">Chats por País</span>
-                    <span *ngSwitchCase="2" class="h4">Usuarios por País</span>
-                    <span *ngSwitchCase="3" class="h4">Conversiones por País</span>
-                    <span *ngSwitchCase="4" class="h4">Tasa de conversión por País</span>
+                    <span *ngSwitchCase="1">Chats</span>
+                    <span *ngSwitchCase="2">{{ 'general.users' | translate }}</span>
+                    <span *ngSwitchCase="3">{{ 'general.conversions' | translate }}</span>
+                    <span *ngSwitchCase="4">{{ 'general.conversionRate' | translate }}</span>
                 </ng-container>
+                <span>{{ 'charts.byCountry' | translate }}</span>
             </div>
             <div class="card-body">
                 <app-chart-bar-horizontal [data]="dataByLevel.countries" name="omnichat-chats-by-country"
@@ -113,13 +114,14 @@
     <div *ngIf="levelPage.latam || levelPage.country" class="col-12 col-lg-4 mt-4"
         [ngClass]="{'col-lg-6' : selectedTab2 < 3 || (levelPage.country && selectedTab2 > 2), 'col-lg-12' : levelPage.country && selectedTab2 <= 2}">
         <div class="card height-fluid superimposed">
-            <div class="card-header">
+            <div class="card-header h4">
                 <ng-container [ngSwitch]="selectedTab2">
-                    <span *ngSwitchCase="1" class="h4">Chats por Retailer</span>
-                    <span *ngSwitchCase="2" class="h4">Usuarios por Retailer</span>
-                    <span *ngSwitchCase="3" class="h4">Conversiones por Retailer</span>
-                    <span *ngSwitchCase="4" class="h4">Tasa de conversión por Retailer</span>
+                    <span *ngSwitchCase="1">Chats</span>
+                    <span *ngSwitchCase="2">{{ 'general.users' | translate }}</span>
+                    <span *ngSwitchCase="3">{{ 'general.conversions' | translate }}</span>
+                    <span *ngSwitchCase="4">{{ 'general.conversionRate' | translate }}</span>
                 </ng-container>
+                <span>{{ 'charts.byRetailer' | translate }}</span>
             </div>
             <div class="card-body" [ngClass]="{'overfow-container': dataByLevel?.retailers?.length > 10}">
                 <div class="superimposed">
@@ -139,15 +141,21 @@
     <div *ngIf="selectedTab2 > 2 || levelPage.retailer" class="col-12 col-lg-4 mt-4"
         [ngClass]="{ 'col-lg-6' : !levelPage.latam }">
         <div class="card height-fluid">
-            <div class="card-header">
+            <div class="card-header h4">
                 <ng-container *ngIf="!levelPage.retailer">
                     <ng-container [ngSwitch]="selectedTab2">
-                        <span *ngSwitchCase="3" class="h4">Conversiones por Categoría</span>
-                        <span *ngSwitchCase="4" class="h4">Tasa de conversión por Categoría</span>
+                        <span *ngSwitchCase="3">
+                            {{ ('general.conversions' | translate) + ('charts.byCategory' | translate) }}
+                        </span>
+                        <span *ngSwitchCase="4">
+                            {{ ('general.conversionRate' | translate) + ('charts.byCategory' | translate) }}
+                        </span>
                     </ng-container>
                 </ng-container>
 
-                <span *ngIf="levelPage.retailer" class="h4">Conversiones por Categoría</span>
+                <span *ngIf="levelPage.retailer">
+                    {{ ('general.conversions' | translate) + ('charts.byCategory' | translate) }}
+                </span>
             </div>
             <div class="card-body">
                 <app-chart-bar-horizontal [data]="dataByLevel.category1" name="omnichat-chats-by-category-1"
@@ -160,7 +168,9 @@
     <div *ngIf="levelPage.retailer" class="col-12 col-lg-6 mt-4">
         <div class="card height-fluid">
             <div class="card-header">
-                <span class="h4">Tasa de conversión por Categoría</span>
+                <span class="h4">
+                    {{ ('general.conversionRate' | translate) + ('charts.byCategory' | translate) }}
+                </span>
             </div>
             <div class="card-body">
                 <app-chart-bar-horizontal [data]="dataByLevel.category2" name="omnichat-chats-by-category-2"
@@ -176,7 +186,7 @@
 <!-- CONVERSIONES - TASAS DE CONVERSION -->
 <div class="row mt-5">
     <div class="col-12">
-        <span class="h3">Análisis de conversión por categoría</span>
+        <span class="h3">{{ 'omnichat.section2Title1' | translate }}</span>
     </div>
     <div class="col-12 mt-3">
         <div class="pills-container" *ngIf="selectedCategories?.length > 1">
@@ -193,7 +203,7 @@
             <div class="col-12 mt-4">
                 <div class="card height-fluid superimposed">
                     <div class="card-header">
-                        <span class="h4">Conversiones por producto</span>
+                        <span class="h4">{{ 'omnichat.chart6CardTitle1' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <app-chart-bar-horizontal [data]="salesByProduct" name="omnichat-transactions-by-product"
@@ -201,7 +211,8 @@
                             [status]="salesByProductReqStatus">
                         </app-chart-bar-horizontal>
                         <small class="text-muted mt-2 d-block d-sm-none">
-                            Para mejor visualización usar la versión de <strong>Escritorio</strong>
+                            {{ 'charts.mobileSuggestion' | translate }}
+                            <strong>{{ 'charts.mobileSuggestion2' | translate }}</strong>
                         </small>
                     </div>
                 </div>
@@ -209,26 +220,27 @@
             <div class="col-12 mt-4">
                 <div class="card height-fluid">
                     <div class="card-header">
-                        <span class="h4">Usuarios, Conversiones y Tasa de conversión por fecha</span>
+                        <span class="h4">{{ 'omnichat.chart7CardTitle1' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <div class="chart-legend mt-0 mb-2">
                             <div class="legend-container legend-right">
                                 <div class="legend-square color-1"></div>
-                                <div class="legend-label">Usuarios</div>
+                                <div class="legend-label">{{ 'general.users' | translate }}</div>
                             </div>
                             <div class="legend-container ml-3">
                                 <div class="legend-square color-2"></div>
-                                <div class="legend-label">Conversiones</div>
+                                <div class="legend-label">{{ 'general.conversions' | translate }}</div>
                             </div>
                             <div class="legend-container ml-3">
                                 <div class="legend-square color-3"></div>
-                                <div class="legend-label">Tasa de conversión</div>
+                                <div class="legend-label">{{ 'general.conversionRate' | translate }}</div>
                             </div>
                         </div>
                         <app-chart-bar-group [data]="usersSalesAndCR" name="omnichat-users-transactions-rate"
                             height="325px" valueBar1="users" valueBar2="transactions" valueLine1="conversion_rate"
-                            valueNameBar1="Usuarios" valueNameBar2="Conversiones" valueFormatLine1="%"
+                            [valueNameBar1]="'general.users' | translate"
+                            [valueNameBar2]="'general.conversions' | translate" valueFormatLine1="%"
                             [status]="usersSalesAndCRReqStatus">
                         </app-chart-bar-group>
                     </div>
@@ -238,8 +250,7 @@
             <!-- PERFOMANCE BY CATEGORY -->
             <div class="col-12 mt-4">
                 <app-generic-table [displayedColumns]="performanceByCategoryColumns" [tableData]="performanceByCategory"
-                    [tableDataChange]="performanceByCategory.data" errorMsg="Error al consultar datos"
-                    emptyDataMsg="No se encontraron datos">
+                    [tableDataChange]="performanceByCategory.data">
                 </app-generic-table>
             </div>
         </div>
@@ -250,7 +261,7 @@
 <!-- TRAFFICO Y CONVERSIONES (7 GRAFICOS) -->
 <div class="row mt-5">
     <div class="col-12">
-        <span class="h3">Audiencia</span>
+        <span class="h3">{{ 'general.audience' | translate }}</span>
     </div>
     <div class="col-12 mt-3">
         <div class="row">
@@ -259,11 +270,15 @@
                     <ul class="nav nav-pills nav-fill">
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 1}"
-                                (click)="getAudienceByMetric('traffic'); chartsInitLoad = chartsInitLoad && false;">Tráfico</a>
+                                (click)="getAudienceByMetric('traffic'); chartsInitLoad = chartsInitLoad && false">
+                                {{ 'general.traffic' | translate }}
+                            </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link p-2" [ngClass]="{'active': selectedTab4 === 2}"
-                                (click)="getAudienceByMetric('sales'); chartsInitLoad = chartsInitLoad && false;">Conversiones</a>
+                                (click)="getAudienceByMetric('sales'); chartsInitLoad = chartsInitLoad && false">
+                                {{ 'general.conversions' | translate }}
+                            </a>
                         </li>
                     </ul>
                 </div>
@@ -274,7 +289,8 @@
                 <div class="card height-fluid">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por dispositivos
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byDevice' | translate }}
                         </span>
                     </div>
                     <div class="card-body">
@@ -313,7 +329,8 @@
                 <div class="card height-fluid">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por Género
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byGender' | translate }}
                         </span>
                     </div>
                     <div class="card-body">
@@ -322,7 +339,9 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container" *ngIf="audience?.men?.length > 0">
                                         <div class="legend-square on color-4"></div>
-                                        <div class="legend-label">Hombres {{ audience.men[1].value }}%</div>
+                                        <div class="legend-label">
+                                            {{ 'others.men' | translate }} {{ audience.men[1].value }}%
+                                        </div>
                                     </div>
                                 </div>
                                 <app-chart-pictorial [data]="audience?.men" name="omnichat-gender-man"
@@ -335,7 +354,9 @@
                                 <div class="chart-legend legend-center mt-0">
                                     <div class="legend-container" *ngIf="audience?.women?.length > 0">
                                         <div class="legend-square on color-5"></div>
-                                        <div class="legend-label">Mujeres {{ audience.women[1].value }}%</div>
+                                        <div class="legend-label">
+                                            {{ 'others.women' | translate }} {{ audience.women[1].value }}%
+                                        </div>
                                     </div>
                                 </div>
                                 <app-chart-pictorial [data]="audience?.women" name="omnichat-gender-woman"
@@ -353,7 +374,8 @@
                 <div class="card height-fluid">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por Edad
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byAge' | translate }}
                         </span>
                     </div>
                     <div class="card-body">
@@ -370,7 +392,8 @@
                 <div class="card height-fluid">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por Género y Edad
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byGenderAndAge' | translate }}
                         </span>
                     </div>
                     <div class="card-body" style="height: 328px">
@@ -387,15 +410,15 @@
                         <div *ngIf="audienceReqStatus[3].reqStatus === 2 && audience?.genderAndAge?.length === 0"
                             class="chart-error-container text-muted">
                             <p class="text-center">
-                                Sin datos disponibles <br>
-                                Muestra insuficiente
+                                {{ 'general.withoutData' | translate }} <br>
+                                {{ 'general.withoutData2' | translate }}
                             </p>
                         </div>
 
                         <!-- error -->
                         <div *ngIf="chartsInitLoad && audienceReqStatus[3].reqStatus === 3"
                             class="chart-error-container text-muted">
-                            <span>Error al consultar datos</span>
+                            <span> {{ 'general.errorData' | translate }}</span>
                         </div>
                     </div>
                 </div>
@@ -406,7 +429,8 @@
                 <div class="card height-fluid">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por día de la semana y hora del día
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byDayAndHour' | translate }}
                         </span>
                     </div>
                     <div class="card-body">
@@ -422,7 +446,8 @@
                 <div class="card">
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por día de la semana
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byWeekday' | translate }}
                         </span>
                     </div>
                     <div class="card-body">
@@ -437,7 +462,8 @@
                     <!-- hour -->
                     <div class="card-header">
                         <span class="h4">
-                            {{selectedTab4 === 1 ? 'Tráfico' : 'Conversiones'}} por hora del día
+                            {{ (selectedTab4 === 1 ? 'general.traffic' : 'general.conversions' ) | translate }}
+                            {{ 'charts.byHour' | translate }}
                         </span>
                     </div>
                     <div class="card-body">

--- a/src/app/services/translations.service.ts
+++ b/src/app/services/translations.service.ts
@@ -41,40 +41,40 @@ export class TranslationsService {
     let monthName;
     switch (month) {
       case '01':
-        monthName = this.translate.instant('others.days.jan');
+        monthName = this.translate.instant('others.months.jan');
         break;
       case '02':
-        monthName = this.translate.instant('others.days.feb');
+        monthName = this.translate.instant('others.months.feb');
         break;
       case '03':
-        monthName = this.translate.instant('others.days.mar');
+        monthName = this.translate.instant('others.months.mar');
         break;
       case '04':
-        monthName = this.translate.instant('others.days.apr');
+        monthName = this.translate.instant('others.months.apr');
         break;
       case '05':
-        monthName = this.translate.instant('others.days.may');
+        monthName = this.translate.instant('others.months.may');
         break;
       case '06':
-        monthName = this.translate.instant('others.days.jun');
+        monthName = this.translate.instant('others.months.jun');
         break;
       case '07':
-        monthName = this.translate.instant('others.days.jul');
+        monthName = this.translate.instant('others.months.jul');
         break;
       case '08':
-        monthName = this.translate.instant('others.days.aug');
+        monthName = this.translate.instant('others.months.aug');
         break;
       case '09':
-        monthName = this.translate.instant('others.days.sep');
+        monthName = this.translate.instant('others.months.sep');
         break;
       case '10':
-        monthName = this.translate.instant('others.days.oct');
+        monthName = this.translate.instant('others.months.oct');
         break;
       case '11':
-        monthName = this.translate.instant('others.days.nov');
+        monthName = this.translate.instant('others.months.nov');
         break;
       case '12':
-        monthName = this.translate.instant('others.days.dec');
+        monthName = this.translate.instant('others.months.dec');
         break;
     }
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -156,6 +156,12 @@
         "chart8CardTitle": "Amount by type of audience",
         "chart9CardTitle": "Revenue and AUP by type of audience"
     },
+    "googleBusiness": {
+        "province": "Province",
+        "city": "City",
+        "store": "Store",
+        "visits": "Visits"
+    },
     "indexed": {
         "chart10CardTitle": "Exit rate, bounce rate and page views",
         "table1CardTitle": "Most visited models",
@@ -167,16 +173,24 @@
         "section1Title": "Audiences - Affinity and Market",
         "pdfDownloads": "PDF downloads"
     },
-    "googleBusiness": {
-        "province": "Province",
-        "city": "City",
-        "store": "Store",
-        "visits": "Visits"
+    "omnichat": {
+        "section1Title1": "Chats, Users, Conversions and Conversion rate",
+        "section1Title2": "Conversions and Conversion rate",
+        "section2Title1": "Conversion analysis by category",
+        "chart6CardTitle1": "Conversions by product",
+        "chart7CardTitle1": "Users, Conversions and Conversion rate by date",
+        "totalChats": "total chats",
+        "avgChatsPerDay": "average chats per day",
+        "dedicatedCustomer": "% dedicated to the customer",
+        "chatScore": "chat score",
+        "chatResult": "result"
     },
     "charts": {
         "byCountry": " by Country",
+        "byRetailer": " by Retailer",
         "byCountries": " by Countries",
         "byRetailers": " by Retailers",
+        "byCategory": " por Category",
         "byDevice": " by Devices",
         "byGender": " by Gender",
         "byAge": " by Age",
@@ -226,11 +240,13 @@
         "clicks": "Clicks",
         "name": "Name",
         "origin": "Origin",
+        "audience": "Audience",
         "pageViews": "Page views",
         "pageViewsNumber": "Number of page views",
         "pagesBySessions": "Pages per session",
         "exiteRate": "Exit rate",
         "bounceRate": "Bounce rate",
+        "conversionRate": "Conversion rate",
         "sessionDuration": "Average session duration",
         "productIncomes": "Product revenue",
         "newVisitors": "New visitors",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -156,6 +156,12 @@
         "chart8CardTitle": "Cantidad por tipo de audiencia",
         "chart9CardTitle": "Revenue y AUP por tipo de audiencia"
     },
+    "googleBusiness": {
+        "province": "Provincia",
+        "city": "Ciudad",
+        "store": "Tienda",
+        "visits": "Visitas"
+    },
     "indexed": {
         "chart10CardTitle": "Porcentaje de salidas, rebote y páginas vistas",
         "table1CardTitle": "Modelos más visitados",
@@ -167,16 +173,24 @@
         "section1Title": "Audiencias - Afinidad y Mercado",
         "pdfDownloads": "Descargas PDF"
     },
-    "googleBusiness": {
-        "province": "Provincia",
-        "city": "Ciudad",
-        "store": "Tienda",
-        "visits": "Visitas"
+    "omnichat": {
+        "section1Title1": "Chats, Usuarios, Conversiones y Tasa de conversión",
+        "section1Title2": "Conversiones y Tasa de conversión",
+        "section2Title1": "Análisis de conversión por categoría",
+        "chart6CardTitle1": "Conversiones por producto",
+        "chart7CardTitle1": "Usuarios, Conversiones y Tasa de conversión por fecha",
+        "totalChats": "total chats",
+        "avgChatsPerDay": "promedio de chats por día",
+        "dedicatedCustomer": "% dedicado al cliente",
+        "chatScore": "calificación del chat",
+        "chatResult": "resultado"
     },
     "charts": {
         "byCountry": " por País",
+        "byRetailer": " por Retailer",
         "byCountries": " por Países",
         "byRetailers": " por Retailers",
+        "byCategory": " por Categoría",
         "byDevice": " por Dispositivos",
         "byGender": " por Género",
         "byAge": " por Edad",
@@ -226,11 +240,13 @@
         "clicks": "Clicks",
         "name": "Nombre",
         "origin": "Origen",
+        "audience": "Audiencia",
         "pageViews": "Páginas vistas",
         "pageViewsNumber": "Número de páginas vistas",
         "pagesBySessions": "Páginas por sesión",
         "exiteRate": "Porcentaje de salidas",
         "bounceRate": "Porcentaje de rebote",
+        "conversionRate": "Tasa de conversión",
         "sessionDuration": "Duración media de la sesión",
         "productIncomes": "Ingresos del producto",
         "newVisitors": "Nuevos visitantes",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -156,6 +156,12 @@
         "chart8CardTitle": "Quantidade por tipo de público",
         "chart9CardTitle": "Revenue y AUP por tipo de público"
     },
+    "googleBusiness": {
+        "province": "Província",
+        "city": "Cidade",
+        "store": "Armazenar",
+        "visits": "Visitas"
+    },
     "indexed": {
         "chart10CardTitle": "Porcentagem de saídas, rejeição e visualizações de página",
         "table1CardTitle": "Modelos mais visitados",
@@ -167,16 +173,24 @@
         "section1Title": "Públicos - Afinidade e Mercado",
         "pdfDownloads": "Downloads de PDF"
     },
-    "googleBusiness": {
-        "province": "Província",
-        "city": "Cidade",
-        "store": "Armazenar",
-        "visits": "Visitas"
+    "omnichat": {
+        "section1Title1": "Chats, Usuários, Conversões e Conversion rate",
+        "section1Title2": "Conversões and Conversion rate",
+        "section2Title1": "Análise de conversão por categoria",
+        "chart6CardTitle1": "Conversões por produto",
+        "chart7CardTitle1": "Usuários, Conversões e Taxa de conversão por período",
+        "totalChats": "total chats",
+        "avgChatsPerDay": "média de chats por dia",
+        "dedicatedCustomer": "% dedicado ao cliente",
+        "chatScore": "qualificação do chat",
+        "chatResult": "resultado"
     },
     "charts": {
         "byCountry": " por País",
+        "byRetailer": " por Retailer",
         "byCountries": " por Países",
         "byRetailers": " por Retailers",
+        "byCategory": " por Categoria",
         "byDevices": " por Dispositivos",
         "byGender": " por Gênero",
         "byAge": " por Idade",
@@ -226,11 +240,13 @@
         "clicks": "Clicks",
         "name": "Nome",
         "origin": "Fonte",
+        "audience": "Público",
         "pageViews": "Número de visualizações de página",
         "pageViewsNumber": "Visualizações de página",
         "pagesBySessions": "Páginas por sessão",
         "exiteRate": "Porcentagem de saídas",
         "bounceRate": "Taxa de Rejeição",
+        "conversionRate": "Conversion rate",
         "sessionDuration": "Duração média da sessão",
         "productIncomes": "Revenue de Produto",
         "newVisitors": "Novos visitantes",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to LATAM/Country/Retailer > Omnichat section

# Features
- Update i18n files
- Update omnichat-wrapper component

# Bug Fixes
- Fix i18n references in translation service

# Where this change will be used
- In LATAM > Indexed at `/dashboard/tools?main-region=latam` path
- In Country > Indexed at `/dashboard/tools?country={country_name}` path
- In Retailer > Indexed at` /dashboard/tools?country={country_name}&retailer={retailer_name} `path