### PR TITLE
add conversion rate chart in omnichat-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/acquisition-wrapper/acquisition-wrapper.component.ts
@@ -182,7 +182,6 @@ export class AcquisitionWrapperComponent implements OnInit, OnDestroy {
   }
 
   loadi18ntoUsers() {
-    console.log('users', this.users)
     if (this.users.length > 0) {
 
       this.users = this.users.map(item => {

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -29,6 +29,12 @@
                         {{ 'general.revenueVsAup' | translate }}
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
+                        (click)="selectedTab1 = 3; !usersAndConv && getUsersOrRevenuePromise('conversions-vs-users')">
+                        Conversion Rate
+                    </a>
+                </li>
             </ul>
         </div>
     </div>
@@ -39,10 +45,11 @@
                 <ng-container [ngSwitch]="selectedTab1">
                     <span class="h4" *ngSwitchCase="1">{{ 'general.usersVsSales' | translate }}</span>
                     <span class="h4" *ngSwitchCase="2">{{ 'general.revenueVsAup' |translate }}</span>
+                    <span class="h4" *ngSwitchCase="3">Conversion Rate</span>
                 </ng-container>
             </div>
             <div class="card-body">
-                <app-chart-multiple-axes [data]="usersOrRevenue"
+                <app-chart-multiple-axes *ngIf="selectedTab1 !== 3" [data]="usersOrRevenue"
                     [value1]="selectedTab1 === 1 ? 'transactions' : 'revenue'"
                     [value2]="selectedTab1 === 1 ? 'users' : 'aup'"
                     [valueName1]="selectedTab1 === 1 ? ('general.conversions' | translate) : 'Revenue'"
@@ -50,6 +57,10 @@
                     [valueFormat1]="selectedTab1 === 2 && 'USD'" [valueFormat2]="selectedTab1 === 2 && 'USD'"
                     name="omnichat-traffic-vs-conversions" [status]="usersOrRevenueReqStatus">
                 </app-chart-multiple-axes>
+
+                <app-chart-line *ngIf="selectedTab1 === 3" [data]="cr" value="cr" valueFormat="%"
+                    yTitle="Conversion Rate %" name="omnichat-cr" [status]="usersOrRevenueReqStatus">
+                </app-chart-line>
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Problem Description
- Add a new button and chart to display conversion rate data using data provided by 'conversions vs users' request

# Features
- Update chart-line component
- Adapt component to display conversion rate chart in omnichat-wrapper component

# Bug Fixes
-  Remove unused log from acquisition-wrapper component

# Where this change will be used
- In LATAM/Country/Retailer > Omnichat section

# More details
![image](https://user-images.githubusercontent.com/38545126/129959397-40711f2f-0d26-40c4-a67c-22ba8953ff06.png)
