### PR TITLE
hide conversion rate elements in omnichat-wrapper component

### DIFF
--- a/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.ts
+++ b/src/app/modules/dashboard/components/charts/chart-bar-group/chart-bar-group.component.ts
@@ -111,27 +111,29 @@ export class ChartBarGroupComponent implements OnInit, AfterViewInit, OnDestroy 
     hoverState.properties.fillOpacity = 1;
 
     // second value axis for valueLine1
-    let valueAxis2 = chart.yAxes.push(new am4charts.ValueAxis());
-    valueAxis2.renderer.opposite = true;
-    valueAxis2.syncWithAxis = valueAxis;
-    valueAxis2.tooltip.disabled = true;
-    valueAxis2.renderer.labels.template.fontSize = 12;
-    valueAxis2.renderer.labels.template.adapter.add('text', (text) => {
-      return `${text}${this.valueFormatLine1 ? this.valueFormatLine1 : ''}`;
-    });
+    if (this.valueLine1) {
+      let valueAxis2 = chart.yAxes.push(new am4charts.ValueAxis());
+      valueAxis2.renderer.opposite = true;
+      valueAxis2.syncWithAxis = valueAxis;
+      valueAxis2.tooltip.disabled = true;
+      valueAxis2.renderer.labels.template.fontSize = 12;
+      valueAxis2.renderer.labels.template.adapter.add('text', (text) => {
+        return `${text}${this.valueFormatLine1 ? this.valueFormatLine1 : ''}`;
+      });
 
-    // valueLine1 line series
-    let lineSeries = chart.series.push(new am4charts.LineSeries());
-    lineSeries.tooltipText = `{valueY}${this.valueFormatLine1 ? this.valueFormatLine1 : ''}`;
-    lineSeries.dataFields.categoryX = 'category';
-    lineSeries.dataFields.valueY = this.valueLine1;
-    lineSeries.yAxis = valueAxis2;
-    lineSeries.bullets.push(new am4charts.CircleBullet());
-    lineSeries.stroke = am4core.color('#FCD713');
-    lineSeries.strokeOpacity = 0.8;
-    lineSeries.fill = lineSeries.stroke;
-    lineSeries.strokeWidth = 2;
-    lineSeries.snapTooltip = true;
+      // valueLine1 line series
+      let lineSeries = chart.series.push(new am4charts.LineSeries());
+      lineSeries.tooltipText = `{valueY}${this.valueFormatLine1 ? this.valueFormatLine1 : ''}`;
+      lineSeries.dataFields.categoryX = 'category';
+      lineSeries.dataFields.valueY = this.valueLine1;
+      lineSeries.yAxis = valueAxis2;
+      lineSeries.bullets.push(new am4charts.CircleBullet());
+      lineSeries.stroke = am4core.color('#FCD713');
+      lineSeries.strokeOpacity = 0.8;
+      lineSeries.fill = lineSeries.stroke;
+      lineSeries.strokeWidth = 2;
+      lineSeries.snapTooltip = true;
+    }
 
     // fill adapter, here we save color value to colors object so that each time the item has the same name, the same color is used
     columnSeries.columns.template.adapter.add('fill', ((fill, target) => {
@@ -192,13 +194,15 @@ export class ChartBarGroupComponent implements OnInit, AfterViewInit, OnDestroy 
       }
 
       // add quantity and count to middle data item (line series uses it)
-      let lineSeriesDataIndex = Math.floor(count / 2);
-      tempArray[lineSeriesDataIndex][this.valueLine1] = serieData[this.valueLine1];
-      tempArray[lineSeriesDataIndex].count = count;
-      // push to the final data
-      am4core.array.each(tempArray, function (item) {
-        chartData.push(item);
-      })
+      if (this.valueLine1) {
+        let lineSeriesDataIndex = Math.floor(count / 2);
+        tempArray[lineSeriesDataIndex][this.valueLine1] = serieData[this.valueLine1];
+        tempArray[lineSeriesDataIndex].count = count;
+        // push to the final data
+        am4core.array.each(tempArray, function (item) {
+          chartData.push(item);
+        })
+      }
 
       // create range (the additional label at the bottom)
       let range = categoryAxis.axisRanges.create();

--- a/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.scss
+++ b/src/app/modules/dashboard/components/charts/chart-bar-horizontal/chart-bar-horizontal.component.scss
@@ -1,3 +1,0 @@
-.chart {
-    overflow: visible;
-}

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.html
@@ -29,10 +29,10 @@
                         {{ 'general.revenueVsAup' | translate }}
                     </a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item" [hidden]="true">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 3}"
                         (click)="selectedTab1 = 3; !usersAndConv && getUsersOrRevenuePromise('conversions-vs-users')">
-                        Conversion Rate
+                        {{ 'general.conversionRate' |translate }}
                     </a>
                 </li>
             </ul>
@@ -45,7 +45,7 @@
                 <ng-container [ngSwitch]="selectedTab1">
                     <span class="h4" *ngSwitchCase="1">{{ 'general.usersVsSales' | translate }}</span>
                     <span class="h4" *ngSwitchCase="2">{{ 'general.revenueVsAup' |translate }}</span>
-                    <span class="h4" *ngSwitchCase="3">Conversion Rate</span>
+                    <span class="h4" *ngSwitchCase="3">{{ 'general.conversionRate' |translate }}</span>
                 </ng-container>
             </div>
             <div class="card-body">
@@ -71,8 +71,8 @@
 <div class="row mt-5">
     <div class="col-12">
         <div class="mb-3">
-            <span class="h3" *ngIf="!levelPage.retailer">{{ 'omnichat.section1Title1' | translate }}</span>
-            <span class="h3" *ngIf="levelPage.retailer">{{ 'omnichat.section1Title2' | translate }}</span>
+            <span class="h3" *ngIf="!levelPage.retailer">{{ 'omnichat.section1Title1Prov' | translate }}</span>
+            <span class="h3" *ngIf="levelPage.retailer">{{ 'omnichat.section1Title2Prov' | translate }}</span>
         </div>
     </div>
 
@@ -91,7 +91,7 @@
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 3}"
                         (click)="getDataByLevel('sales')">{{ 'general.conversions' | translate }}</a>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item" [hidden]="true">
                     <a class="nav-link p-2" [ngClass]="{'active': selectedTab2 === 4}"
                         (click)="getDataByLevel('conversion-rate')">{{ 'general.conversionRate' | translate }}</a>
                 </li>
@@ -150,7 +150,7 @@
 
     <!-- categories -->
     <div *ngIf="selectedTab2 > 2 || levelPage.retailer" class="col-12 col-lg-4 mt-4"
-        [ngClass]="{ 'col-lg-6' : !levelPage.latam }">
+        [ngClass]="{ 'col-lg-6' : !levelPage.latam, 'col-lg-12': levelPage.retailer}">
         <div class="card height-fluid">
             <div class="card-header h4">
                 <ng-container *ngIf="!levelPage.retailer">
@@ -176,7 +176,7 @@
             </div>
         </div>
     </div>
-    <div *ngIf="levelPage.retailer" class="col-12 col-lg-6 mt-4">
+    <div *ngIf="levelPage.retailer" class="col-12 col-lg-6 mt-4" [hidden]="true">
         <div class="card height-fluid">
             <div class="card-header">
                 <span class="h4">
@@ -231,7 +231,7 @@
             <div class="col-12 mt-4">
                 <div class="card height-fluid">
                     <div class="card-header">
-                        <span class="h4">{{ 'omnichat.chart7CardTitle1' | translate }}</span>
+                        <span class="h4">{{ 'omnichat.chart7CardTitle1Prov' | translate }}</span>
                     </div>
                     <div class="card-body">
                         <div class="chart-legend mt-0 mb-2">
@@ -243,16 +243,17 @@
                                 <div class="legend-square color-2"></div>
                                 <div class="legend-label">{{ 'general.conversions' | translate }}</div>
                             </div>
-                            <div class="legend-container ml-3">
+                            <div class="legend-container ml-3" [hidden]="true">
                                 <div class="legend-square color-3"></div>
                                 <div class="legend-label">{{ 'general.conversionRate' | translate }}</div>
                             </div>
                         </div>
                         <app-chart-bar-group [data]="usersSalesAndCR" name="omnichat-users-transactions-rate"
-                            height="325px" valueBar1="users" valueBar2="transactions" valueLine1="conversion_rate"
+                            height="325px" valueBar1="users" valueBar2="transactions"
                             [valueNameBar1]="'general.users' | translate"
                             [valueNameBar2]="'general.conversions' | translate" valueFormatLine1="%"
                             [status]="usersSalesAndCRReqStatus">
+                            <!-- valueLine1="conversion_rate" -->
                         </app-chart-bar-group>
                     </div>
                 </div>

--- a/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/omnichat-wrapper/omnichat-wrapper.component.ts
@@ -103,14 +103,14 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
       icon: 'fas fa-shopping-basket',
       iconBg: '#a77dcc'
     },
-    {
-      title: 'tasa de conversión',
-      name: 'conversion_rate',
-      value: 0,
-      format: 'percentage',
-      icon: 'fas fa-percentage',
-      iconBg: '#fbc001'
-    },
+    // {
+    //   title: 'tasa de conversión',
+    //   name: 'conversion_rate',
+    //   value: 0,
+    //   format: 'percentage',
+    //   icon: 'fas fa-percentage',
+    //   iconBg: '#fbc001'
+    // },
     {
       title: 'revenue',
       name: 'revenue',
@@ -450,7 +450,8 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
           const dateStrFormat = `${this.translationsServ.convertMonthToString(date[1])} ${date[0]}`;
 
           const obj = months[item];
-          newMonthsObj[dateStrFormat] = obj;
+          // newMonthsObj[dateStrFormat] = obj;
+          newMonthsObj[dateStrFormat] = { users: obj.users, transactions: obj.transactions };
         }
 
         this.usersSalesAndCR = newMonthsObj;
@@ -589,7 +590,7 @@ export class OmnichatWrapperComponent implements OnInit, OnDestroy {
     this.kpis[5].title = this.translate.instant('omnichat.chatScore');
     this.kpis[6].title = this.translate.instant('general.users');
     this.kpis[7].title = this.translate.instant('general.conversions');
-    this.kpis[8].title = this.translate.instant('general.conversionRate');
+    // this.kpis[8].title = this.translate.instant('general.conversionRate');
 
     this.kpis[5].subKpis[0].title = this.translate.instant('omnichat.chatResult');
 

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -175,10 +175,13 @@
     },
     "omnichat": {
         "section1Title1": "Chats, Users, Conversions and Conversion rate",
+        "section1Title1Prov": "Chats, Users and Conversions",
         "section1Title2": "Conversions and Conversion rate",
+        "section1TitleProv": "Conversions",
         "section2Title1": "Conversion analysis by category",
         "chart6CardTitle1": "Conversions by product",
         "chart7CardTitle1": "Users, Conversions and Conversion rate by date",
+        "chart7CardTitle1Prov": "Users, Conversions by date",
         "totalChats": "total chats",
         "avgChatsPerDay": "average chats per day",
         "dedicatedCustomer": "% dedicated to the customer",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -175,10 +175,13 @@
     },
     "omnichat": {
         "section1Title1": "Chats, Usuarios, Conversiones y Tasa de conversión",
+        "section1Title1Prov": "Chats, Usuarios y Conversiones",
         "section1Title2": "Conversiones y Tasa de conversión",
+        "section1Title2Prov": "Conversiones",
         "section2Title1": "Análisis de conversión por categoría",
         "chart6CardTitle1": "Conversiones por producto",
         "chart7CardTitle1": "Usuarios, Conversiones y Tasa de conversión por fecha",
+        "chart7CardTitle1Prov": "Usuarios y Conversiones por fecha",
         "totalChats": "total chats",
         "avgChatsPerDay": "promedio de chats por día",
         "dedicatedCustomer": "% dedicado al cliente",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -175,10 +175,13 @@
     },
     "omnichat": {
         "section1Title1": "Chats, Usuários, Conversões e Conversion rate",
+        "section1Title1Prov": "Chats, Usuários e Conversões",
         "section1Title2": "Conversões and Conversion rate",
+        "section1Title2Prov": "Conversões",
         "section2Title1": "Análise de conversão por categoria",
         "chart6CardTitle1": "Conversões por produto",
         "chart7CardTitle1": "Usuários, Conversões e Taxa de conversão por período",
+        "chart7CardTitle1Prov": "Usuários, Conversões por período",
         "totalChats": "total chats",
         "avgChatsPerDay": "média de chats por dia",
         "dedicatedCustomer": "% dedicado ao cliente",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -407,5 +407,10 @@ a:active{
 
 .chart {
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
+
+  @media print {
+    overflow: hidden;
+  }
 }
+


### PR DESCRIPTION
# Problem Description
- Temporarily hide all elements which refer conversion rate metric in Omnichat component

# Features
- Hide conversion rate references in omnichat-wrapper component
- Other omplications:
   - Update i18n files
   - Generate chart without line in chart-bar-group component
   - Update styles of chart-bar-horizontal component
   - Update chart class in styles.scss file

# Where this change will be used
- In LATAM/Country/Retailer > Omnichat section

# More details
![image](https://user-images.githubusercontent.com/38545126/130154248-ea5907d6-4dec-4f65-8f5f-274151b04810.png)
![image](https://user-images.githubusercontent.com/38545126/130154260-dc52c0f4-a604-4969-8045-5468d403cb03.png)
![image](https://user-images.githubusercontent.com/38545126/130154273-8060704c-2a71-4c73-8e11-8a86b1d3b3e1.png)

