### PR TITLE
add i18n to options of selects displayed on filters components

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.html
@@ -23,7 +23,7 @@
                     </li>
                     <li class="nav-item mb-2">
                         <a class="nav-link p-2" [ngClass]="{'active': selectedTab1 === 4}"
-                            (click)="getCategoriesBySector({id: 4, name: 'onsite'})">
+                            (click)="getCategoriesBySector({id: 4, name: 'onsite', name_id: 'onsite'})">
                             On Site
                         </a>
                     </li>

--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -235,7 +235,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
         selectedSectorHM = previousSectorHM ? previousSectorHM : this.selectedSectors[0];
       } else {
         // onsite option is diplayed (and previous selected) apart of selected categories in filters
-        selectedSectorHM = { id: 4, name: 'onsite' };
+        selectedSectorHM = { id: 4, name: 'onsite', name_id: 'onsite' };
       }
 
       // demograhics
@@ -315,7 +315,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     // Tabs are only used for country view
     this.selectedTab1 = selectedSector.id;
 
-    this.overviewService.getCategoriesBySector(selectedSector?.name).subscribe(
+    this.overviewService.getCategoriesBySector(selectedSector?.name_id).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
         this.categoriesReqStatus = 2;
@@ -332,7 +332,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.overviewService.getInvestmentBySector(selectedSector?.name).subscribe(
+    this.overviewService.getInvestmentBySector(selectedSector?.name_id).subscribe(
       (resp: any[]) => {
         this.investmentBySectorTable.data = resp;
         this.investmentBySectorTable.reqStatus = 2;

--- a/src/app/modules/dashboard/components/retail-filters/retail-filters.component.ts
+++ b/src/app/modules/dashboard/components/retail-filters/retail-filters.component.ts
@@ -1,6 +1,8 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { AbstractControl, FormBuilder, FormControl, FormGroup } from '@angular/forms';
 import { MatOption } from '@angular/material/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
 import { AUDIENCES, MEDIUMS, SOURCES } from 'src/app/tools/constants/filters';
 import { FiltersStateService } from '../../services/filters-state.service';
 
@@ -9,7 +11,7 @@ import { FiltersStateService } from '../../services/filters-state.service';
   templateUrl: './retail-filters.component.html',
   styleUrls: ['./retail-filters.component.scss']
 })
-export class RetailFiltersComponent implements OnInit {
+export class RetailFiltersComponent implements OnInit, OnDestroy {
 
   sourceList: any[] = SOURCES.filter(item => item.id !== 'banner' && item.id !== 'institucional');
   mediumList: any[] = MEDIUMS;
@@ -36,14 +38,22 @@ export class RetailFiltersComponent implements OnInit {
   mediums: AbstractControl;
   audiences: AbstractControl;
 
+  translateSub: Subscription;
+
   @ViewChild('allSelectedSources') private allSelectedSources: MatOption;
   @ViewChild('allSelectedMediums') private allSelectedMediums: MatOption;
   @ViewChild('allSelectedAudiences') private allSelectedAudiences: MatOption;
 
   constructor(
     private fb: FormBuilder,
-    private filtersStateService: FiltersStateService
-  ) { }
+    private filtersStateService: FiltersStateService,
+    private translate: TranslateService
+  ) {
+
+    this.translateSub = translate.stream('filters').subscribe(() => {
+      this.loadI18nContent();
+    });
+  }
 
   async ngOnInit() {
     this.form = this.fb.group({
@@ -207,6 +217,18 @@ export class RetailFiltersComponent implements OnInit {
 
 
     this.filtersStateService.retailFiltersChange();
+  }
+
+  loadI18nContent() {
+    this.mediumList = this.mediumList.map(item => {
+      item.id === 'institucional' && (item.name = this.translate.instant('general.institutional').toLowerCase());
+      item.id === 'others' && (item.name = this.translate.instant('general.others').toLowerCase());
+      return item;
+    });
+  }
+
+  ngOnDestroy() {
+    this.translateSub?.unsubscribe();
   }
 
 }


### PR DESCRIPTION
# Problem Description
-  Add spanish, english and portuguese content using i18n files to options of selects displayed on filters components

# Features
- Add i18n references to general-filters component
- Add i18n references to retail-filters component
- Other implications:
   - Update overview-wrapper component to use name_id property for sectors instead name (translated copy) property

# Where this change will be used
- In dashboard module components at `/dashboard/*` path where filters are displayed

# More details
- "Sales" copy in sector options (also is used to show tabs in a chart)
![image](https://user-images.githubusercontent.com/38545126/130298908-2840bb5b-d16f-4039-876b-e0bdfa99b40b.png)
![image](https://user-images.githubusercontent.com/38545126/130299038-52972cd9-1c47-40d2-8050-5be4ba7919cf.png)

- "Institutional" and "Others" copies for  source options
![image](https://user-images.githubusercontent.com/38545126/130298964-58c7bbfb-5c7b-4873-91d9-31bd9900488b.png)
![image](https://user-images.githubusercontent.com/38545126/130299060-cdac0432-5bad-4c1d-84db-26edcee6cb8b.png)
![image](https://user-images.githubusercontent.com/38545126/130299109-0d478ffa-cec2-4c12-86e2-6c4ac5a4a5c2.png)

- "Institucional" and "Others" copies for mediums options
![image](https://user-images.githubusercontent.com/38545126/130299146-506ac80a-f4f0-494d-b561-2af03215d7d8.png)
