### PR TITLE
add i18n to heatmaps used in overviews components

### DIFF
--- a/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
+++ b/src/app/modules/dashboard/components/overview-wrapper/overview-wrapper.component.ts
@@ -318,6 +318,7 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     this.overviewService.getCategoriesBySector(selectedSector?.name_id).subscribe(
       (resp: any[]) => {
         this.categoriesBySector = resp;
+        this.selectedType === 'retailer' && this.loadi18nHeatmap();
         this.categoriesReqStatus = 2;
       },
       error => {
@@ -500,6 +501,17 @@ export class OverviewWrapperComponent implements OnInit, OnDestroy {
     this.trafficOrSales['weekdayAndHour'] = this.trafficOrSales['weekdayAndHour']?.map(item => {
       return { ...item, weekdayName: this.translationsServ.convertWeekdayToString(item.weekday) }
     });
+
+    this.loadi18nHeatmap();
+  }
+
+
+  loadi18nHeatmap() {
+    if (this.selectedTab1 === 1) {
+      this.categoriesBySector = this.categoriesBySector.map(item => {
+        return { ...item, sector: item.sector === 'Ventas' ? this.translate.instant('general.sales') : item.sector }
+      });
+    }
   }
 
 

--- a/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
+++ b/src/app/modules/dashboard/pages/overview-latam/overview-latam.component.ts
@@ -320,8 +320,11 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
   }
 
   getSectorsAndCategories(metricType: string) {
+    this.selectedTab1 = metricType === 'sectors' ? 1 : metricType === 'categories' ? 2 : 3;
+
     this.metricByCountryReqStatus = 1;
     this.metricByCountryTable.reqStatus = 1;
+
     this.overviewService.getSectorsAndCategoriesLatam(metricType).subscribe(
       (resp: any[]) => {
         this.metricByCountry = resp;
@@ -359,6 +362,7 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         }
 
         this.metricByCountryTable.data = countries;
+        this.loadi18nHeatmap();
         this.metricByCountryTable.reqStatus = 2;
       },
       error => {
@@ -367,8 +371,6 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
         this.metricByCountryReqStatus = 3;
         this.metricByCountryTable.reqStatus = 3;
       });
-
-    this.selectedTab1 = metricType === 'sectors' ? 1 : metricType === 'categories' ? 2 : 3;
   }
 
   getTrafficOrSales(metricType: string) {
@@ -532,6 +534,16 @@ export class OverviewLatamComponent implements OnInit, OnDestroy {
     this.trafficOrSales['weekdayAndHour'] = this.trafficOrSales['weekdayAndHour']?.map(item => {
       return { ...item, weekdayName: this.translationsServ.convertWeekdayToString(item.weekday) }
     });
+
+    this.loadi18nHeatmap();
+  }
+
+  loadi18nHeatmap() {
+    if (this.selectedTab1 === 1) {
+      this.metricByCountry = this.metricByCountry.map(item => {
+        return { ...item, sector: item.sector === 'Ventas' ? this.translate.instant('general.sales') : item.sector }
+      });
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to heatmaps in overview when these display data by sectors

# Features
- Add i18n to sales sector of heatmap displayed in overview-latam component
- Add i18n to sales sector of heatmap displayed in overview-wrapper component

# Where this change will be used
- In heatmaps displayed in overview components of dashboard module at `/dashboard/* `path
