### PR TITLE
add i18n to campaign-comparator components

### DIFF
--- a/src/app/modules/dashboard/components/campaign-comparator-filters/campaign-comparator-filters.component.html
+++ b/src/app/modules/dashboard/components/campaign-comparator-filters/campaign-comparator-filters.component.html
@@ -3,9 +3,9 @@
 
         <!-- RETAILER -->
         <div class="col-12 col-sm-6 mb-4">
-            <mat-select formControlName="retailer" placeholder="Selecciona un Retailer" [(value)]="selectedRetailer"
-                (selectionChange)="retailerChange()" (openedChange)="openedChange('retailer', $event)"
-                disableOptionCentering>
+            <mat-select formControlName="retailer" [placeholder]="'filters.retailerPh' | translate"
+                [(value)]="selectedRetailer" (selectionChange)="retailerChange()"
+                (openedChange)="openedChange('retailer', $event)" disableOptionCentering>
 
                 <!-- search -->
                 <div class="input-group input-group-alternative mb-1">
@@ -39,9 +39,9 @@
 
         <!-- CAMPAIGN -->
         <div class="col-12 col-sm-6 mb-4">
-            <mat-select formControlName="campaign" placeholder="Selecciona un Campaña" [(value)]="selectedCampaign"
-                (selectionChange)="campaignChange()" (openedChange)="openedChange('campaign', $event)"
-                disableOptionCentering>
+            <mat-select formControlName="campaign" [placeholder]="'filters.campaignPh' | translate"
+                [(value)]="selectedCampaign" (selectionChange)="campaignChange()"
+                (openedChange)="openedChange('campaign', $event)" disableOptionCentering>
 
                 <!-- search -->
                 <div class="input-group input-group-alternative mb-1">

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.html
@@ -2,7 +2,9 @@
     <div class="row">
         <!-- first campaign -->
         <div class="col-12 col-lg-6">
-            <span class="h4 mb-2">Primer campaña</span>
+            <span class="h4 mb-2">
+                {{ 'campaignComparator.firstCampaign' | translate }}
+            </span>
             <app-campaign-comparator-filters (selectedFiltersChange)="filtersChange(1, $event)"
                 (validFiltersChange)="validFiltersChange(1, $event)">
             </app-campaign-comparator-filters>
@@ -10,7 +12,9 @@
 
         <!-- second campaign -->
         <div class="col-12 col-lg-6">
-            <span class="h4 mb-2">Segunda campaña</span>
+            <span class="h4 mb-2">
+                {{ 'campaignComparator.secondCampaign' | translate }}
+            </span>
             <app-campaign-comparator-filters (selectedFiltersChange)="filtersChange(2, $event)"
                 (validFiltersChange)="validFiltersChange(2, $event)">
             </app-campaign-comparator-filters>
@@ -18,7 +22,9 @@
 
         <div class="col-12 text-right">
             <button class="btn btn-primary" [disabled]="!validFilters.firstSelection || !validFilters.secondSelection"
-                (click)="compareCampaigns()">Comparar</button>
+                (click)="compareCampaigns()">
+                {{ 'campaignComparator.compare' | translate }}
+            </button>
         </div>
     </div>
 
@@ -26,7 +32,9 @@
         <div class="row mt-4">
             <!-- first campaign -->
             <div class="col-12 col-md-6">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none">Primer campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none">
+                    {{ 'campaignComparator.firstCampaign' | translate }}
+                </span>
                 <div class="row">
                     <div *ngFor="let kpi of kpisCamps.camp1.kpis"
                         class="col-12 col-sm-6 col-md-12 col-lg-6 col-xl-4 mb-xl-4">
@@ -36,7 +44,7 @@
                     </div>
                     <div class="col-12 mt--3 mt-xl-2" [hidden]="kpisCamps.camp1.reqStatus !== 3">
                         <p class="text-center text-muted mb-0">
-                            Error al consultar datos
+                            {{ 'general.errorData' | translate }}
                         </p>
                     </div>
                 </div>
@@ -44,7 +52,9 @@
 
             <!-- second campaign -->
             <div class="col-12 col-md-6">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4 mt-md-0">Segunda campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4 mt-md-0">
+                    {{ 'campaignComparator.secondCampaign' | translate }}
+                </span>
                 <div class="row">
                     <div *ngFor="let kpi of kpisCamps.camp2.kpis"
                         class="col-12 col-sm-6 col-md-12 col-lg-6 col-xl-4 mb-xl-4">
@@ -54,7 +64,7 @@
                     </div>
                     <div class="col-12 mt--3 mt-xl-2" [hidden]="kpisCamps.camp2.reqStatus !== 3">
                         <p class="text-center text-muted mb-0">
-                            Error al consultar datos
+                            {{ 'general.errorData' | translate }}
                         </p>
                     </div>
                 </div>
@@ -63,14 +73,16 @@
 
         <div class="row mt-4">
             <div class="col-12">
-                <p class="h2">Adquisición</p>
+                <p class="h2">{{ 'general.acquisition' | translate }}</p>
             </div>
         </div>
 
         <div class="row mt-3">
             <!-- first campaign -->
             <div class="col-12 col-lg-6 mb-4">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none">Primer campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none">
+                    {{ 'campaignComparator.firstCampaign' | translate }}
+                </span>
                 <app-generic-table [displayedColumns]="acqCampTableColumns" [tableData]="acqCamps.camp1"
                     [tableDataChange]="acqCamps.camp1.data" [reducedPadding]="true">
                 </app-generic-table>
@@ -78,7 +90,9 @@
 
             <!-- second campaign -->
             <div class="col-12 col-lg-6 mb-4">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4">Segunda campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4">
+                    {{ 'campaignComparator.secondCampaign' | translate }}
+                </span>
                 <app-generic-table [displayedColumns]="acqCampTableColumns" [tableData]="acqCamps.camp2"
                     [tableDataChange]="acqCamps.camp2.data" [reducedPadding]="true">
                 </app-generic-table>
@@ -88,13 +102,15 @@
 
         <div class="row mt-4">
             <div class="col-12">
-                <p class="h2">Conversión</p>
+                <p class="h2">{{ 'general.conversion' | translate }}</p>
             </div>
         </div>
         <div class="row mt-3">
             <!-- first campaign -->
             <div class="col-12 col-lg-6 mb-4">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none">Primer campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none">
+                    {{ 'campaignComparator.firstCampaign' | translate }}
+                </span>
                 <app-generic-table [displayedColumns]="convCampTableColumns" [tableData]="convCamps.camp1"
                     [tableDataChange]="convCamps.camp1.data" [reducedPadding]="true">
                 </app-generic-table>
@@ -102,7 +118,9 @@
 
             <!-- second campaign -->
             <div class="col-12 col-lg-6 mb-4">
-                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4">Segunda campaña</span>
+                <span class="h4 mb-2 d-block d-lg-none d-xl-none mt-4">
+                    {{ 'campaignComparator.secondCampaign' | translate }}
+                </span>
                 <app-generic-table [displayedColumns]="convCampTableColumns" [tableData]="convCamps.camp2"
                     [tableDataChange]="convCamps.camp2.data" [reducedPadding]="true">
                 </app-generic-table>

--- a/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.ts
+++ b/src/app/modules/dashboard/pages/campaign-comparator/campaign-comparator.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { Subscription } from 'rxjs';
 import { KpiCard } from 'src/app/models/kpi';
 import { strTimeFormat } from 'src/app/tools/functions/time-format';
 import { TableItem } from '../../components/generic-table/generic-table.component';
@@ -9,7 +11,7 @@ import { CampaignComparatorService } from '../../services/campaign-comparator.se
   templateUrl: './campaign-comparator.component.html',
   styleUrls: ['./campaign-comparator.component.scss']
 })
-export class CampaignComparatorComponent implements OnInit {
+export class CampaignComparatorComponent implements OnInit, OnDestroy {
 
   firstSelection: { retailer: any, campaign: any };
   secondSelection: { retailer: any, campaign: any };
@@ -246,9 +248,17 @@ export class CampaignComparatorComponent implements OnInit {
   selections: { retailer: any, campaign: any, selection: string }[];
   showComparison: boolean;
 
+  translateSub: Subscription;
+
   constructor(
-    private campaignCompService: CampaignComparatorService
-  ) { }
+    private campaignCompService: CampaignComparatorService,
+    private translate: TranslateService,
+  ) {
+
+    this.translateSub = translate.stream('campaignComparator').subscribe(() => {
+      this.loadI18nContent();
+    });
+  }
 
   ngOnInit(): void {
   }
@@ -315,6 +325,7 @@ export class CampaignComparatorComponent implements OnInit {
           }
 
           this.kpisCamps[item.selection].kpis = campaignKpis;
+          this.loadI18nKpis(this.kpisCamps[item.selection]);
           this.kpisCamps[item.selection].reqStatus = 2;
 
         },
@@ -387,5 +398,33 @@ export class CampaignComparatorComponent implements OnInit {
     }
   }
 
+  loadI18nContent() {
+    this.acqCampTableColumns[0].title = this.translate.instant('general.source');
+    this.acqCampTableColumns[1].title = this.translate.instant('general.medium');
+    this.acqCampTableColumns[2].title = this.translate.instant('general.users');
+    this.acqCampTableColumns[3].title = this.translate.instant('general.newUsers');
+    this.acqCampTableColumns[4].title = this.translate.instant('general.sessions');
+    this.acqCampTableColumns[5].title = this.translate.instant('general.pagesBySessions');
+    this.acqCampTableColumns[6].title = this.translate.instant('general.bounceRate');
+    this.acqCampTableColumns[7].title = this.translate.instant('general.sessionDuration');
+    this.acqCampTableColumns[8].title = this.translate.instant('general.amount');
+    this.acqCampTableColumns[9].title = this.translate.instant('general.productIncomes');
 
+    this.convCampTableColumns[0].title = this.translate.instant('general.category');
+    this.convCampTableColumns[1].title = this.translate.instant('general.product');
+    this.convCampTableColumns[2].title = this.translate.instant('general.amount');
+    this.convCampTableColumns[4].title = this.translate.instant('general.productIncomes');
+  }
+
+  loadI18nKpis(campaign: any) {
+    if (campaign.kpis.length > 0) {
+      campaign.kpis[0].title = this.translate.instant('general.investment');
+      campaign.kpis[1].title = this.translate.instant('general.users');
+      campaign.kpis[4].title = this.translate.instant('general.conversions');
+    }
+  }
+
+  ngOnDestroy() {
+    this.translateSub?.unsubscribe();
+  }
 }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -217,6 +217,11 @@
         "question": "Question",
         "finish": "Ends the process"
     },
+    "campaignComparator": {
+        "firstCampaign": "First campaign",
+        "secondCampaign": "Second campaign",
+        "compare": "Compare"
+    },
     "charts": {
         "byCountry": " by Country",
         "byRetailer": " by Retailer",
@@ -256,6 +261,7 @@
         "campaign": "Campaign",
         "period": "Period",
         "traffic": "Traffic",
+        "conversion": "Conversion",
         "conversions": "Conversions",
         "sales": "Sales",
         "users": "Users",
@@ -273,6 +279,7 @@
         "name": "Name",
         "origin": "Origin",
         "audience": "Audience",
+        "acquisition": "Acquisition",
         "pageViews": "Page views",
         "pageViewsNumber": "Number of page views",
         "pagesBySessions": "Pages per session",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -217,6 +217,11 @@
         "question": "Pregunta",
         "finish": "Termina el proceso"
     },
+    "campaignComparator": {
+        "firstCampaign": "Primera campaña",
+        "secondCampaign": "Segunda campaña",
+        "compare": "Comparar"
+    },
     "charts": {
         "byCountry": " por País",
         "byRetailer": " por Retailer",
@@ -256,6 +261,7 @@
         "campaign": "Campaña",
         "period": "Período",
         "traffic": "Tráfico",
+        "conversion": "Conversión",
         "conversions": "Conversiones",
         "sales": "Ventas",
         "users": "Usuarios",
@@ -273,6 +279,7 @@
         "name": "Nombre",
         "origin": "Origen",
         "audience": "Audiencia",
+        "acquisition": "Adquisición",
         "pageViews": "Páginas vistas",
         "pageViewsNumber": "Número de páginas vistas",
         "pagesBySessions": "Páginas por sesión",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -217,6 +217,11 @@
         "question": "Questão",
         "finish": "Termina o processo"
     },
+    "campaignComparator": {
+        "firstCampaign": "Primeira campanha",
+        "secondCampaign": "Segunda campanha",
+        "compare": "Comparar"
+    },
     "charts": {
         "byCountry": " por País",
         "byRetailer": " por Retailer",
@@ -256,6 +261,7 @@
         "campaign": "Campanha",
         "period": "Período",
         "traffic": "Tráfego",
+        "conversion": "Conversão",
         "conversions": "Conversões",
         "sales": "Vendas",
         "users": "Usuários",
@@ -273,6 +279,7 @@
         "name": "Nome",
         "origin": "Fonte",
         "audience": "Público",
+        "acquisition": "Aquisição",
         "pageViews": "Número de visualizações de página",
         "pageViewsNumber": "Visualizações de página",
         "pagesBySessions": "Páginas por sessão",


### PR DESCRIPTION
# Problem Description
- Add spanish, english and portuguese content using i18n files to campaign-comparator components

# Features
- Update i18n files
- Add i18n references to campaign-comparator component
- Update i18n references to campaign-comparator-filters component

# Where this change will be used
- In campaign comparator section at `/dashboard/campaign-comparator` path
